### PR TITLE
[Core] Remove embedded entity reference methods

### DIFF
--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -330,7 +330,6 @@ class Manager(Debuggable):
     @note This call does not verify the entity exits, just that the format of
     the string is recognised.
 
-    @see containsEntityReference
     @see entityExists
     @see resolveEntityReference
 
@@ -343,39 +342,6 @@ class Manager(Debuggable):
     # or regex, if supplied, instead of calling the manager, this is less
     # relevant in python though, more in C, but the note is here to remind us.
     return self.__impl.isEntityReference(token, context, self.__hostSession)
-
-
-  @debugApiCall
-  @auditApiCall("Manager methods")
-  def containsEntityReference(self, string, context=None):
-    """
-
-    Determines if the string contains a @ref entity_reference.
-
-    There may be occasion to operate on a more complex input string, that
-    combines one or more @ref entity_reference and free-form text. It is not
-    possible as a Host to isolate these references as the format is not known.
-    For example, the following strings should cause isEntityReference()
-    to return false, but this function to return true:
-
-    @li `{fnasset://job?t=scriptsDir}/fileInDirectory.nk`
-    @li `source fnasset://myScript?v=1 fnasset://myOtherScript?v=2`
-
-    Positive matches here indicate that the string may need to
-    be resolved using resolveEntityReferences() prior to use.
-
-    @param str The input to parse for @ref entity_reference occurrences
-
-    @return bool, True if one or more @ref entity_reference is found within the
-    string, otherwise False.
-
-    @note This call does not verify that any of the referenced entities exit,
-    just that the string contains one or more @ref entity_reference. Often
-
-    @see resolveEntityReferences()
-
-    """
-    return self.__impl.containsEntityReference(string, context, self.__hostSession)
 
 
   @debugApiCall
@@ -907,32 +873,6 @@ class Manager(Debuggable):
     """
     return self.__impl.resolveEntityReferences(refrences, context, self.__hostSession)
 
-
-  @debugApiCall
-  @auditApiCall("Manager methods")
-  def resolveInlineEntityReferences(self, string, context):
-    """
-
-    Returns a copy of the input string will all references resolved in-place.
-    The same rules of resolution apply for each @ref entity_reference in the
-    input string as noted in resolveEntityReference().
-
-    If no entity references are present, the input string will be returned.
-
-    @return str
-
-    @exception FnAssetAPI.exceptions.InvalidEntityReference If any supplied
-    @ref entity_reference is not recognised by the asset management system.
-
-    @exception FnAssetAPI.exceptions.EntityResolutionError If any supplied @ref
-    entity_reference does not have a meaningful string representation, or any
-    supplied reference points to a non-existent entity.
-
-    @see resolveEntityReference()
-    @see containsEntityReference()
-
-    """
-    return self.__impl.resolveInlineEntityReferences(string, context, self.__hostSession)
 
   ## @}
 

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -231,7 +231,7 @@ class ManagerInterface(object):
     neither of these fields are set, then isEntityReference will always be used
     to determine if a string is an entityReference or not. Note, not all hosts
     support this optimisation, so @ref isEntityReference should be implemented
-    regardless. @ref containsEntityReferences will always be called regardless.
+    regardless.
 
       @li FnAssetAPI.constants.kField_EntityReferencesMatchPrefix
       @li FnAssetAPI.constants.kField_EntityReferencesMatchRegex
@@ -407,42 +407,6 @@ class ManagerInterface(object):
 
 
   @abc.abstractmethod
-  def containsEntityReference(self, string, context, hostSession):
-    """
-
-    Determines if the string contains a @ref entity_reference.
-
-    There may be occasion to operate on a more complex input string, that
-    combines one or more @ref entity_reference and free-form text.
-    For example, the following strings should cause isEntityReference()
-    to return false, but this function to return true:
-
-    @li `{fnasset://job?t=scriptsDir}/fileInDirectory.nk`
-    @li `source fnasset://myScript?v=1 fnasset://myOtherScript?v=2`
-
-    Positive matches here inform the Host that the string may need to
-    be resolved using resolveEntityReferences() prior to use.
-
-    @param str The input to parse for @ref entity_reference occurrences
-
-    @return bool, True if one or more @ref entitry_reference is found within the
-    string, otherwise False.
-
-    @param context, The calling context, this may be None.
-
-    @warning The result of this call should not depend on the context Locale,
-    as these results may be cached by access pattern.
-
-    @note This call does not verify that any of the referenced entities exit,
-    just that the string contains one or more @ref entity_reference.
-
-    @see resolveEntityReferences()
-
-    """
-    raise NotImplementedError
-
-
-  @abc.abstractmethod
   def entityExists(self, entityRef, context, hostSession):
     """
 
@@ -554,31 +518,6 @@ class ManagerInterface(object):
     for r in references:
       resolved.append(self.resolveEntityReference(r, context, hostSession))
     return resolved
-
-
-  @abc.abstractmethod
-  def resolveInlineEntityReferences(self, string, context, hostSession):
-    """
-
-    Returns a copy of the input string will all references resolved in-place.
-    The same rules of resolution apply for each @ref entity_reference in the
-    input string as noted in resolveEntityReference().
-
-    If no entity references are present, the input string should be returned.
-
-    @return str
-
-    @exception FnAssetAPI.exceptions.InvalidEntityReference If any supplied
-    @ref entity_reference is not recognised by the asset management system.
-    @exception FnAssetAPI.exceptions.EntityResolutionError If any supplied @ref
-    entity_reference does not have a meaningful string representation, or any
-    supplied reference points to a non-existent entity.
-
-    @see resolveEntityReference()
-    @see containsEntityReference()
-
-    """
-    raise NotImplementedError
 
 
   def getDefaultEntityReference(self, specification, context, hostSession):

--- a/tests/openassetio/hostAPI/test_manager.py
+++ b/tests/openassetio/hostAPI/test_manager.py
@@ -117,8 +117,6 @@ class TestManager():
 		assert manager.isEntityReference(a_ref, a_context) == method.return_value
 		method.assert_called_once_with(a_ref, a_context, host_session)
 
-	# Not testing containsEntityReference as it will be removed
-
 	def test_entityExists(self, manager, mock_manager_interface, host_session, a_ref, a_context):
 		method = mock_manager_interface.entityExists
 		assert manager.entityExists(a_ref, a_context) == method.return_value
@@ -256,8 +254,6 @@ class TestManager():
 		method = mock_manager_interface.resolveEntityReferences
 		assert manager.resolveEntityReferences(some_refs, a_context) == method.return_value
 		method.assert_called_once_with(some_refs, a_context, host_session)
-
-	# Not testing resolveInlineEntityReferences as they will be removed
 
 	def test_managementPolicy(self, manager, mock_manager_interface, host_session, an_entity_spec, a_context, a_ref):
 


### PR DESCRIPTION
Closes #2.

These methods pass on the responsibility of parsing, tokenising and expanding references in arbitrary strings to the manager with no context of the formatting of the string. Understanding the myriad of character escaping/quoting possibilities in these strings is far out-of-scope for a manager.