### PR TITLE
[Docs] Add GitHub Pages link to API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ The API builds upon the production-tested [Katana Asset API](https://learn.found
 addressing several common integration challenges and adding support
 for a wider range of asset types and publishing workflows.
 
+## API documentation
+
+The documentation for OpenAssetIO can be found here: [https://thefoundryvisionmongers.github.io/OpenAssetIO](https://thefoundryvisionmongers.github.io/OpenAssetIO/).
+
 ## Project status
 
 > **Important:** The project is currently in early beta stage and is


### PR DESCRIPTION
This link will be active once we migrate a docs build over to docs repo, and activate pages. Currently, this is limited to public visibility, so we'll do this once we flick the switch here too.