### PR TITLE
Remove references to UTF-8 from docs

### DIFF
--- a/doc/src/Glossary.dox
+++ b/doc/src/Glossary.dox
@@ -103,13 +103,13 @@
  * thought of as being analogous to a primary key in a database of
  * entities, for various reasons detailed below.
  *
- * An entity reference can be any UTF-8 encoded ASCII compatible string,
- * and there are no constraints on the content of the reference other
- * than that of a std::string. It's worth noting however, that if no
- * custom UI widgets are supplied by a manager, a @ref host will simply
- * display it as a standard string. It is up to the design of the @ref
- * manager to decide on the format for it's entity references, and
- * whether they are in a human readable form.
+ * An entity reference can be any string, and there are no constraints
+ * on the content of the reference other than that of a std::string.
+ * It's worth noting however, that if no custom UI widgets are supplied
+ * by a manager, a @ref host will simply display it as a standard
+ * string. It is up to the design of the @ref manager to decide on the
+ * format for it's entity references, and whether they are in a human
+ * readable form.
  *
  * > Note: We strongly recommend using a human-readable form that
  * > follows <a href=https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#cite_ref-FOOTNOTERFC_3986,_section_32005_23-0" target="_blank">RFC_3986</a>.
@@ -294,7 +294,6 @@
  * names internally, as long as the mapping is reversed for queries.
  *
  * Metadata is limited to **string** keys, and **plain old data** typed values.
- * String data should be UTF-8 encoded.
  *
  * > Note: The length of a value is yet to be defined, but ideally it
  * > will be something suitably large - this will only be restricted if

--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -148,8 +148,8 @@ class Manager(Debuggable):
           @li openassetio.constants.kField_EntityRefrencesMatchPrefix
           @li openassetio.constants.kField_EntityRefrencesMatchRegex
 
-        Keys will always be UTF8 strings, and Values will be int, bool,
-        float or str.
+        Keys will always be str, and Values will be int, bool, float or
+        str.
         """
         return self.__impl.getInfo()
 
@@ -324,7 +324,7 @@ class Manager(Debuggable):
         If False, this manager should no longer be involved in actions
         relating to the token.
 
-        @param token The UTF-8 encoded string to be inspected.
+        @param token The string to be inspected.
 
         @return bool, True if the supplied token should be considered as
         an @ref entity_reference, False if the pattern is not
@@ -438,8 +438,8 @@ class Manager(Debuggable):
          @li `"Cuttlefish v1"` - for a versioned asset
          @li `"seq003"` - for a sequence in a hierarchy
 
-        @return str, An UTF-8 encoded string containing any valid
-        characters for the manager's implementation.
+        @return str, A string containing any valid characters for the
+        manager's implementation.
         """
         return self.__impl.getEntityName(reference, context, self.__hostSession)
 
@@ -460,9 +460,8 @@ class Manager(Debuggable):
          @li `"Sequence 003 [ Dive / Episode 1 ]"` - for a sequence in
          an hierarchy as a window title.
 
-        @return str, a UTF-8 encoded string containing any valid
-        characters for the @ref asset_management_system's
-        implementation.
+        @return str, a string containing any valid characters for the
+        @ref asset_management_system's implementation.
         """
         return self.__impl.getEntityDisplayName(reference, context, self.__hostSession)
 
@@ -494,7 +493,7 @@ class Manager(Debuggable):
 
         @return Dict[str,primitive], with the entity's metadata. Values
         will be singular plain-old-data types (ie. string, int, float,
-        bool), keys will be UTF-8 encoded strings.
+        bool), keys will be strings.
         """
         return self.__impl.getEntityMetadata(reference, context, self.__hostSession)
 
@@ -571,8 +570,8 @@ class Manager(Debuggable):
         Retrieves the name of the version pointed to by the supplied
         @ref entity_reference.
 
-        @return str, A UTF-8 encoded string representing the version or
-        an empty string if the entity was not versioned.
+        @return str, A string representing the version or an empty
+        string if the entity was not versioned.
 
         @note It is not necessarily a requirement that the entity
         exists, if, for example, the version name can be determined from
@@ -600,12 +599,11 @@ class Manager(Debuggable):
         versions will be returned. If a value of -1 is used, then all
         results will be returned.
 
-        @return dict, Where the keys are UTF8 encoded ASCII string
-        versions, and the values are an @ref entity_reference that
-        points to its entity. Additionally the
-        openassetio.constants.kVersionDict_OrderKey can be set to a list
-        of the version names (ie: dict keys) in their natural ascending
-        order, that may be used by UI elements, etc...
+        @return dict, Where the keys are string versions, and the values
+        are an @ref entity_reference that points to its entity.
+        Additionally the openassetio.constants.kVersionDict_OrderKey can
+        be set to a list of the version names (ie: dict keys) in their
+        natural ascending order, that may be used by UI elements, etc...
 
         @see getEntityVersionName()
         @see getFinalizedEntityVersion()
@@ -816,8 +814,7 @@ class Manager(Debuggable):
         represent file sequences should use the 'format' syntax,
         compatible with sprintf, etc... (eg.  %04d").
 
-        @return str, The UTF-8 encoded string that that is represented
-        by the entity.
+        @return str, The string that that is represented by the entity.
 
         @exception openassetio.exceptions.EntityResolutionError If the
         @ref entity_reference does not have a meaningful string

--- a/python/openassetio/hostAPI/localization.py
+++ b/python/openassetio/hostAPI/localization.py
@@ -91,7 +91,7 @@ class Localizer:
         @important Escaping brace literals with `{{` is not currently
         supported.
 
-        @param sourceStr a UTF-8 ASCII string to localize.
+        @param sourceStr a string to localize.
 
         @return str The input string with all applicable terms
         localized, any remaining braces ({}) will be removed.

--- a/python/openassetio/logging.py
+++ b/python/openassetio/logging.py
@@ -68,10 +68,10 @@ class LoggerInterface(object):
         1, if set to a value less than 0 it should be considered
         cancelled, if greater than one, complete.
 
-        @param message str, A UTF-8 ASCII string message to display with
-        the progress. If None is supplied, assume that there is no
-        message and any previous message may remain. Set to an empty
-        string if it is desired to always clear any previous message.
+        @param message str, A message to display with the progress. If
+        None is supplied, assume that there is no message and any
+        previous message may remain. Set to an empty string if it is
+        desired to always clear any previous message.
         """
         msg = "%3d%% %s" % (int(100 * decimalProgress), message if message is not None else "")
         self.log(msg, self.kProgress)

--- a/python/openassetio/managerAPI/HostSession.py
+++ b/python/openassetio/managerAPI/HostSession.py
@@ -89,9 +89,9 @@ class HostSession(object):
         1, if set to a value less than 0 it will be considered
         cancelled, if greater than one, complete.
 
-        @param message str, A UTF-8 ASCII string message to display with
-        the progress. If None is supplied, it is assumed that there is
-        no message and the previous message may remain. Set to an empty
+        @param message str, A string message to display with the
+        progress. If None is supplied, it is assumed that there is no
+        message and the previous message may remain. Set to an empty
         string if it is desired to always clear the previous message.
         """
         self.__logger.progress(decimalProgress, message=message)

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -237,8 +237,8 @@ class ManagerInterface(object):
           @li openassetio.constants.kField_EntityReferencesMatchPrefix
           @li openassetio.constants.kField_EntityReferencesMatchRegex
 
-        @note Keys should always be UTF-8 encoded strings, and values
-        must be plain-old-data types (ie: str, int, float, bool).
+        @note Keys should always be strings, and values must be
+        plain-old-data types (ie: str, int, float, bool).
         """
         return {}
 
@@ -389,7 +389,7 @@ class ManagerInterface(object):
         @warning The result of this call should not depend on the
         context Locale.
 
-        @param token The UTF-8 encoded string to be inspected.
+        @param token The string to be inspected.
 
         @param context openassetio.Context, The calling context.
 
@@ -477,8 +477,8 @@ class ManagerInterface(object):
         this function to ensure any @ref meta_version "meta-versions"
         are resolved prior to resolution.
 
-        @return str, The UTF-8 encoded string that that is represented
-        by the reference.
+        @return str, The string that that is represented by the
+        reference.
 
         @exception openassetio.exceptions.EntityResolutionError If the
         supplied @ref entity_reference does not have a meaningful string
@@ -562,8 +562,8 @@ class ManagerInterface(object):
          @li `"Cuttlefish v1"` - for a version of an asset
          @li `"seq003"` - for a sequence in a hierarchy
 
-        @return str, A UTF-8 encoded string containing any valid
-        characters for the manager's implementation.
+        @return str, A string containing any valid characters for the
+        manager's implementation.
         """
         raise NotImplementedError
 
@@ -583,9 +583,8 @@ class ManagerInterface(object):
          @li `"Sequence 003 [ Dive / Episode 1 ]"` - for a sequence in
          an hierarchy as a window title.
 
-        @return str, A UTF-8 encoded string containing any valid
-        characters for the @ref asset_management_system's
-        implementation.
+        @return str, A string containing any valid characters for the
+        @ref asset_management_system's implementation.
 
         @exception openassetio.exceptions.InvalidEntityReference If any
         supplied reference is not recognised by the asset management
@@ -611,7 +610,7 @@ class ManagerInterface(object):
 
         @return Dict[str,primitive], with the entity's metadata. Values
         must be singular plain-old-data types (ie. string, int, float,
-        bool), keys must be UTF-8 encoded strings.
+        bool), keys must be strings.
         """
         raise NotImplementedError
 
@@ -688,8 +687,8 @@ class ManagerInterface(object):
         Retrieves the name of the version pointed to by the supplied
         @ref entity_reference.
 
-        @return str, A UTF-8 encoded string representing the version or
-        an empty string if the entity was not versioned.
+        @return str, A string representing the version or an empty
+        string if the entity was not versioned.
 
         @note It is not necessarily a requirement that the entity
         exists, if, for example, the version name can be determined from
@@ -717,9 +716,9 @@ class ManagerInterface(object):
         versions should be returned. If a value of -1 is used, then all
         results should be returned.
 
-        @return Dict[str,str], Where the keys are UTF-8 encoded string
-        versions, and the values are an @ref entity_reference that
-        points to that versions entity.  Additionally the
+        @return Dict[str,str], Where the keys are string versions, and
+        the values are an @ref entity_reference that points to that
+        versions entity. Additionally the
         openassetio.constants.kVersionDict_OrderKey can be set to a list
         of the version names (ie: dict keys) in their natural ascending
         order, that may be used by UI elements, etc...
@@ -1411,8 +1410,7 @@ class ManagerInterface(object):
         openassetio.exceptions.StateError if made without first thawing
         the stack.
 
-        @return A UTF-8 encoded string that can be used to restore the
-        stack.
+        @return A string that can be used to restore the stack.
 
         @see thawState()
         @see The @ref transactions page.


### PR DESCRIPTION
Closes #47 .

As discussed in issue #47, explicitly specifying UTF-8 encoding doesn't make sense for Python 3, where UTF-8 is implied.

Encoding is still something we must address, but will be handled in a dedicated issue #61.