### PR TITLE
Remove Python 3 type hints

### DIFF
--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -49,7 +49,7 @@ class Manager(Debuggable):
     threads concurrently.
     """
 
-    def __init__(self, interfaceInstance, hostSession: HostSession):
+    def __init__(self, interfaceInstance, hostSession):
         """
         @private
 

--- a/python/openassetio/hostAPI/ManagerFactoryInterface.py
+++ b/python/openassetio/hostAPI/ManagerFactoryInterface.py
@@ -35,7 +35,7 @@ class ManagerFactoryInterface(object):
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, logger: LoggerInterface):
+    def __init__(self, logger):
         super(ManagerFactoryInterface, self).__init__()
         self._logger = logger
 

--- a/python/openassetio/managerAPI/HostSession.py
+++ b/python/openassetio/managerAPI/HostSession.py
@@ -49,7 +49,7 @@ class HostSession(object):
     kError = LoggerInterface.kError
     kCritical = LoggerInterface.kCritical
 
-    def __init__(self, host: Host, logger: LoggerInterface):
+    def __init__(self, host, logger):
         """
         The HostSession should not be directly constructed. They will be
         automatically managed by the API middleware.

--- a/python/openassetio/pluginSystem/PluginSystem.py
+++ b/python/openassetio/pluginSystem/PluginSystem.py
@@ -30,7 +30,7 @@ class PluginSystem(object):
     with that id will be skipped.
     """
 
-    def __init__(self, logger: LoggerInterface):
+    def __init__(self, logger):
         self.__map = {}
         self.__paths = {}
         self.__logger = logger

--- a/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
+++ b/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
@@ -41,7 +41,7 @@ class PluginSystemManagerFactory(ManagerFactoryInterface):
     ## The Environment Variable to read the plug-in search path from
     kPluginEnvVar = "FOUNDRY_ASSET_PLUGIN_PATH"
 
-    def __init__(self, logger: LoggerInterface, paths=None):
+    def __init__(self, logger, paths=None):
 
         super(PluginSystemManagerFactory, self).__init__(logger)
 


### PR DESCRIPTION
Closes #40. We had been adding these to new code in the interests of
best practice. However this breaks the Doxygen build. As we're porting
all of this core API to c++ in the end anyway, there isn't any long-term
detriment here.

In addition, Python 2 support has not entirely been ruled out yet(!).