### PR TITLE
[Core] Rename `Manager.relatedEntities` -> `getRelatedReferences`

### DIFF
--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -688,7 +688,7 @@ class Manager(Debuggable):
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def relatedReferences(self, references, relationshipSpecOrSpecs, context, resultSpec=None):
+    def getRelatedReferences(self, references, relationshipSpecOrSpecs, context, resultSpec=None):
         """
         Returns related entity references, based on a relationship
         specification.
@@ -706,15 +706,15 @@ class Manager(Debuggable):
 
         In all cases, the return value is a list of lists, for example:
 
-            a)  relatedReferences([ r1 ], [ s1, s2, s3 ])
+            a)  getRelatedReferences([ r1 ], [ s1, s2, s3 ])
 
             > [ [ r1s1... ], [ r1s2... ], [ r1s3... ] ]
 
-            b)  relatedReferences([ r1, r2, r3 ], [ s1 ])
+            b)  getRelatedReferences([ r1, r2, r3 ], [ s1 ])
 
             > [ [ r1s1... ], [ r2s1... ], [ r3s1... ] ]
 
-            c)  relatedReferences([ r1, r2, r3 ], [ s1, s2, s3 ])
+            c)  getRelatedReferences([ r1, r2, r3 ], [ s1, s2, s3 ])
 
             > [ [ r1s1... ], [ r2s2... ], [ r3s3... ] ]
 
@@ -753,7 +753,7 @@ class Manager(Debuggable):
         length, ie: not a 1:1 mapping of entities to specs.
 
         @see openassetio.specifications
-        @see setRelatedReferences()
+        @todo Implement missing setRelatedReferences()
         """
         if not isinstance(references, (list, tuple)):
             references = [references, ]

--- a/tests/openassetio/hostAPI/test_manager.py
+++ b/tests/openassetio/hostAPI/test_manager.py
@@ -228,7 +228,7 @@ class TestManager():
         method.assert_called_once_with(
             a_ref, a_context, host_session, overrideVersionName=a_version_name)
 
-    def test_relatedReferences(
+    def test_getRelatedReferences(
             self, manager, mock_manager_interface, host_session, a_ref, an_entity_spec, a_context):
 
         method = mock_manager_interface.getRelatedReferences
@@ -247,7 +247,7 @@ class TestManager():
                 (three_refs, two_specs)
         ):
             with pytest.raises(ValueError):
-                manager.relatedReferences(refs_arg, specs_arg, a_context)
+                manager.getRelatedReferences(refs_arg, specs_arg, a_context)
             method.assert_not_called()
             method.reset_mock()
 
@@ -256,14 +256,14 @@ class TestManager():
                 (three_refs, one_spec, three_refs, [one_spec]),
                 (three_refs, three_specs, three_refs, three_specs)
         ):
-            assert manager.relatedReferences(
+            assert manager.getRelatedReferences(
                 refs_arg, specs_arg, a_context) == method.return_value
             method.assert_called_once_with(
                 expected_refs_arg, expected_specs_arg, a_context, host_session, resultSpec=None)
             method.reset_mock()
 
         # Check optional resultSpec
-        assert manager.relatedReferences(
+        assert manager.getRelatedReferences(
             one_ref, one_spec, a_context, resultSpec=an_entity_spec) == method.return_value
         method.assert_called_once_with(
             [one_ref], [one_spec], a_context, host_session, resultSpec=an_entity_spec)


### PR DESCRIPTION
During the bulk rename for #5 this inconsistency was discovered, where the corresponding `ManagerInterface` method refers to "references", rather than "entities". So rename to be consistent. See https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/5#issuecomment-961902049 (and replies) for more info.