### PR TITLE
[Docs] Fix incorrect refs in Doxygen docs

### DIFF
--- a/doc/src/Examples.dox
+++ b/doc/src/Examples.dox
@@ -31,11 +31,11 @@
  *     """
  *     A minimal host implementation with no document model.
  *     """
- *     def getIdentifier(self):
+ *     def identifier(self):
  *         return "org.openassetio.example.host"
  *
  *
- *     def getDisplayName(self):
+ *     def displayName(self):
  *         return "OpenAssetIO Example Host"
  *
  * # For simplicity, use a filtered console logger, this logs to
@@ -68,7 +68,7 @@
  * We will be providing an example manager implementation soon!
  *
  * @code{.py}
- * managers = session.getRegisteredManagers()
+ * managers = session.registeredManagers()
  * > {
  * >    'org.openassetio.example.manager': {
  * >         'name': 'Example Asset Manager',
@@ -108,8 +108,8 @@
  * The API middleware provides assorted short-circuit validation
  * optimisations that can reduce the number of inter-language hops
  * required. See @ref
- * openassetio.managerAPI.ManagerInterface.ManagerInterface.getInfo
- * "ManagerInterface.getInfo" and the <tt>kField_EntityReferenceMatch*</tt>
+ * openassetio.managerAPI.ManagerInterface.ManagerInterface.info
+ * "ManagerInterface.info" and the <tt>kField_EntityReferenceMatch*</tt>
  * keys.
  *
  * @code{.py}

--- a/doc/src/ForHosts.dox
+++ b/doc/src/ForHosts.dox
@@ -73,10 +73,10 @@
  *
  * - Implement the @ref openassetio.hostAPI.HostInterface class
  *   methods:
- *   @ref openassetio.hostAPI.HostInterface.HostInterface.getIdentifier
- *   "getIdentifier" and @ref
- *   openassetio.hostAPI.HostInterface.HostInterface.getDisplayName
- *   "getDisplayName".
+ *   @ref openassetio.hostAPI.HostInterface.HostInterface.identifier
+ *   "identifier" and @ref
+ *   openassetio.hostAPI.HostInterface.HostInterface.displayName
+ *   "displayName".
  *
  * - Create a @ref openassetio.hostAPI.Session to bootstrap the API,
  *   provide the following objects:
@@ -151,7 +151,7 @@
  * - If you have a document model, implement the entity query methods
  *   in your @ref openassetio.hostAPI.HostInterface class.
  *
- * - You should map any widgets returned by @ref ManagerUIDelegate.getWidgets
+ * - You should map any widgets returned by @ref ManagerUIDelegate.widgets
  *   with the @ref ui.widgets.attributes.kCreateApplicationPanel flag set to
  *   some native panel type, if you have one.
  *


### PR DESCRIPTION
As part of addressing TheFoundryVisionmongers#5, PR TheFoundryVisionmongers#73 removed the `get` prefix from several methods. However, this missed the new "Notes for API Host Developers" and "Examples" pages, which still refer to the old method names.

So update those pages to fix up the method references.