### PR TITLE
[Docs] Decision Record for `ManagerInterface` method naming convention

### DIFF
--- a/decisions/DR003-ManagerInterface-method-naming.md
+++ b/decisions/DR003-ManagerInterface-method-naming.md
@@ -120,7 +120,7 @@ prefix should go after the verb (e.g. `getEntityRelatedReferences`).
 
 #### Cons
 
- - More difficult to explain the [Option 2](#option-2)
+ - More difficult to explain than [Option 2](#option-2)
  - Requires use of "Reference" instead of "EntityReference", in order to 
 prevent illegible names. For example, `getEntityRelatedReferences` is 
 more readable than `getEntityRelatedEntityReferences`, but for 


### PR DESCRIPTION
Decision Record describing naming convention for batch entity methods in `ManagerInterface`.

Part of #43.