### PR TITLE
[Core] Make `Context.actionGroupDepth` protected

### DIFF
--- a/python/openassetio/Context.py
+++ b/python/openassetio/Context.py
@@ -77,7 +77,7 @@ class Context(object):
 
     def __init__(
             self, access=kRead, retention=kTransient, locale=None,
-            managerOptions=None, managerState=None, actionGroupDepth=0):
+            managerOptions=None, managerState=None, _actionGroupDepth=0):
 
         super(Context, self).__init__()
 
@@ -88,7 +88,7 @@ class Context(object):
         self.__managerOptions = managerOptions if managerOptions else {}
         self.__managerState = managerState
 
-        self.__actionGroupDepth = actionGroupDepth
+        self.__actionGroupDepth = _actionGroupDepth
 
     def __getManagerInterfaceState(self):
         # pylint: disable=unused-private-member
@@ -144,13 +144,12 @@ class Context(object):
         # pylint: disable=unused-private-member
         self.__actionGroupDepth = depth
 
-    ## @property actionGroupDepth
+    ## @property _actionGroupDepth
     ## @protected
-    ## @todo https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/135
     ##
     ## Defines the number of action groups in the stack managed by the @ref
     ## openassetio.hostAPI.transactions.TransactionCoordinator "TransactionCoordinator".
-    actionGroupDepth = property(__getActionGroupDepth, __setActionGroupDepth)
+    _actionGroupDepth = property(__getActionGroupDepth, __setActionGroupDepth)
 
     def __getAccess(self):
         # pylint: disable=unused-private-member
@@ -250,7 +249,7 @@ class Context(object):
             ('locale', self.__locale),
             ('managerOptions', self.__managerOptions),
             ('managerState', self.__managerState),
-            ('actionGroupDepth', self.__actionGroupDepth)
+            ('_actionGroupDepth', self.__actionGroupDepth)
         )
         kwargs = ", ".join(["%s=%r" % (i[0], i[1]) for i in data])
         return "Context(%s)" % kwargs

--- a/python/openassetio/hostAPI/Session.py
+++ b/python/openassetio/hostAPI/Session.py
@@ -226,7 +226,7 @@ class Session(Debuggable):
 
         # pylint: disable=protected-access
         ctx.managerInterfaceState = manager._createState(parentState)
-        ctx.actionGroupDepth = 0
+        ctx._actionGroupDepth = 0
 
         return ctx
 

--- a/python/openassetio/hostAPI/transactions.py
+++ b/python/openassetio/hostAPI/transactions.py
@@ -78,12 +78,12 @@ class TransactionCoordinator(Debuggable):
 
         @return int The new depth of the Action Group stack
         """
-        if context.actionGroupDepth == 0:
-            # pylint: disable=protected-access
+        # pylint: disable=protected-access
+        if context._actionGroupDepth == 0:
             self.__manager._startTransaction(context.managerInterfaceState)
 
-        context.actionGroupDepth += 1
-        return context.actionGroupDepth
+        context._actionGroupDepth += 1
+        return context._actionGroupDepth
 
     @debugApiCall
     @auditApiCall("Transactions")
@@ -98,15 +98,15 @@ class TransactionCoordinator(Debuggable):
         @exception RuntimeError If pop is called before push (ie: the
         stack depth is 0)
         """
-        if context.actionGroupDepth == 0:
+        # pylint: disable=protected-access
+        if context._actionGroupDepth == 0:
             raise RuntimeError("Action group popped with none on the stack")
 
-        context.actionGroupDepth -= 1
-        if context.actionGroupDepth == 0:
-            # pylint: disable=protected-access
+        context._actionGroupDepth -= 1
+        if context._actionGroupDepth == 0:
             self.__manager._finishTransaction(context.managerInterfaceState)
 
-        return context.actionGroupDepth
+        return context._actionGroupDepth
 
     @debugApiCall
     @auditApiCall("Transactions")
@@ -121,25 +121,26 @@ class TransactionCoordinator(Debuggable):
         Manager may not have been able to undo-unwind any actions that
         occurred since the first ActionGroup was pushed onto the stack.
         """
+        # pylint: disable=protected-access
+
         status = True
 
-        if context.actionGroupDepth == 0:
+        if context._actionGroupDepth == 0:
             return status
 
-        # pylint: disable=protected-access
         status = self.__manager._cancelTransaction(context.managerInterfaceState)
 
-        context.actionGroupDepth = 0
+        context._actionGroupDepth = 0
 
         return status
 
     @staticmethod
-    def actionGroupDepth(context):
+    def _actionGroupDepth(context):
         """
         @return int The current ActionGroup depth in the context.
-        @todo Should this even be public? Conceptually this is probably API-internal.
         """
-        return context.actionGroupDepth
+        # pylint: disable=protected-access
+        return context._actionGroupDepth
 
     ## @}
 
@@ -171,7 +172,7 @@ class TransactionCoordinator(Debuggable):
         ## @todo Should this clear out the state/dept from the Context?
         # pylint: disable=protected-access
         token = self.__manager._freezeState(context.managerInterfaceState)
-        return "%i_%s" % (context.actionGroupDepth, token)
+        return "%i_%s" % (context._actionGroupDepth, token)
 
     @auditApiCall("Transactions")
     def thawManagerState(self, token):
@@ -197,8 +198,9 @@ class TransactionCoordinator(Debuggable):
         ## @todo Sanitize input
         depth, managerToken = token.split('_', 1)
 
+        # pylint: disable=protected-access
         context = Context()
-        context.actionGroupDepth = int(depth)
+        context._actionGroupDepth = int(depth)
         context.managerInterfaceState = self.__manager._thawState(managerToken)  # pylint: disable=protected-access
         return context
 

--- a/tests/openassetio/hostAPI/test_session.py
+++ b/tests/openassetio/hostAPI/test_session.py
@@ -240,12 +240,13 @@ class Test_Session_createContext:
         assert context_a.access == Context.kRead
         assert context_a.retention == Context.kTransient
         assert context_a.managerInterfaceState is state_a
-        assert context_a.actionGroupDepth == 0
+        assert context_a._actionGroupDepth == 0  # pylint: disable=protected-access
         assert context_a.locale is None
         mock_manager_interface.createState.assert_called_once()
 
     def test_when_called_with_parent_then_props_copied_and_createState_called_with_parent_state(
             self, a_session, mock_manager_interface):
+        # pylint: disable=protected-access
 
         a_session.useManager("com.manager")
 
@@ -255,12 +256,11 @@ class Test_Session_createContext:
         context_a.access = Context.kWrite
         context_a.retention = Context.kSession
         context_a.locale = LocaleSpecification()
-        context_a.actionGroupDepth = 3
+        context_a._actionGroupDepth = 3
         mock_manager_interface.reset_mock()
 
         state_b = "state-b"
         mock_manager_interface.createState.return_value = state_b
-        # pylint: disable=protected-access
         a_host_session = a_session.currentManager()._Manager__hostSession
 
         context_b = a_session.createContext(parent=context_a)
@@ -270,7 +270,7 @@ class Test_Session_createContext:
         assert context_b.access == context_a.access
         assert context_b.retention == context_a.retention
         assert context_b.locale == context_b.locale
-        assert context_b.actionGroupDepth == 0
+        assert context_b._actionGroupDepth == 0
         mock_manager_interface.createState.assert_called_once_with(
             a_host_session, parentState=state_a)
 

--- a/tests/openassetio/hostAPI/test_transactions.py
+++ b/tests/openassetio/hostAPI/test_transactions.py
@@ -94,11 +94,11 @@ class Test_TransactionCoordinator_pushActionGroup:
     def test_actionGroup_depth_is_incremented(
             self, transaction_coordinator, a_context):
 
-        assert a_context.actionGroupDepth == 0
+        assert a_context._actionGroupDepth == 0
         transaction_coordinator.pushActionGroup(a_context)
-        assert a_context.actionGroupDepth == 1
+        assert a_context._actionGroupDepth == 1
         transaction_coordinator.pushActionGroup(a_context)
-        assert a_context.actionGroupDepth == 2
+        assert a_context._actionGroupDepth == 2
 
     def test_when_called_repeatedly_then_startTransaction_only_called_once(
             self, transaction_coordinator, mock_host_session, a_context):
@@ -124,11 +124,11 @@ class Test_TransactionCoordinator_popActionGroup:
     def test_actionGroup_depth_is_decremented(
             self, transaction_coordinator, a_context):
 
-        a_context.actionGroupDepth = 2
+        a_context._actionGroupDepth = 2
         transaction_coordinator.popActionGroup(a_context)
-        assert a_context.actionGroupDepth == 1
+        assert a_context._actionGroupDepth == 1
         transaction_coordinator.popActionGroup(a_context)
-        assert a_context.actionGroupDepth == 0
+        assert a_context._actionGroupDepth == 0
 
     def test_when_called_repeatedly_then_finishTransaction_only_called_once(
             self, transaction_coordinator, mock_host_session, a_context):
@@ -136,15 +136,15 @@ class Test_TransactionCoordinator_popActionGroup:
         mock_interface = transaction_coordinator.manager()._interface()
         state = a_context.managerInterfaceState
 
-        a_context.actionGroupDepth = 2
+        a_context._actionGroupDepth = 2
 
         transaction_coordinator.popActionGroup(a_context)
-        assert a_context.actionGroupDepth == 1
+        assert a_context._actionGroupDepth == 1
         assert_transaction_calls(
             mock_interface, mock_host_session, start=None, finish=None, cancel=None)
 
         transaction_coordinator.popActionGroup(a_context)
-        assert a_context.actionGroupDepth == 0
+        assert a_context._actionGroupDepth == 0
         assert_transaction_calls(
             mock_interface, mock_host_session, start=None, finish=state, cancel=None)
 
@@ -156,7 +156,7 @@ class Test_TransactionCoordinator_popActionGroup:
     def test_when_depth_is_zero_then_RuntimeError_is_raised(
             self, transaction_coordinator, a_context):
 
-        a_context.actionGroupDepth = 0
+        a_context._actionGroupDepth = 0
 
         with pytest.raises(RuntimeError):
             transaction_coordinator.popActionGroup(a_context)
@@ -164,7 +164,7 @@ class Test_TransactionCoordinator_popActionGroup:
     def test_when_depth_is_zero_then_manager_is_not_called(
             self, mock_host_session, transaction_coordinator, a_context):
 
-        a_context.actionGroupDepth = 0
+        a_context._actionGroupDepth = 0
 
         try:
             transaction_coordinator.popActionGroup(a_context)
@@ -188,7 +188,7 @@ class Test_TransactionCoordinator_cancelActions:
         # from the manager.
         mock_interface.cancelTransaction.return_value = False
 
-        a_context.actionGroupDepth = 0
+        a_context._actionGroupDepth = 0
 
         transaction_coordinator.cancelActions(a_context)
         assert_transaction_calls(
@@ -208,14 +208,14 @@ class Test_TransactionCoordinator_cancelActions:
 
         mock_interface.cancelTransaction.return_value = True
 
-        a_context.actionGroupDepth = 1
+        a_context._actionGroupDepth = 1
         assert transaction_coordinator.cancelActions(a_context) is True
         assert_transaction_calls(
             mock_interface, mock_host_session, start=None, finish=None, cancel=state)
 
         mock_interface.cancelTransaction.return_value = False
 
-        a_context.actionGroupDepth = 2
+        a_context._actionGroupDepth = 2
         assert transaction_coordinator.cancelActions(a_context) is False
         assert_transaction_calls(
             mock_interface, mock_host_session, start=None, finish=None, cancel=state)
@@ -223,24 +223,24 @@ class Test_TransactionCoordinator_cancelActions:
     def test_when_depth_is_not_zero_then_depth_is_reset_to_zero_after_call(
             self, transaction_coordinator, a_context):
 
-        a_context.actionGroupDepth = 123
+        a_context._actionGroupDepth = 123
         transaction_coordinator.cancelActions(a_context)
-        assert a_context.actionGroupDepth == 0
+        assert a_context._actionGroupDepth == 0
 
 
-class Test_TransactionCoordinator_actionGroupDepth:
+class Test_TransactionCoordinator__actionGroupDepth:
     # pylint: disable=protected-access
 
     def test_returns_context_depth(self, transaction_coordinator, a_context):
 
-        assert a_context.actionGroupDepth == 0
-        assert transaction_coordinator.actionGroupDepth(a_context) == 0
+        assert a_context._actionGroupDepth == 0
+        assert transaction_coordinator._actionGroupDepth(a_context) == 0
 
         transaction_coordinator.pushActionGroup(a_context)
-        assert transaction_coordinator.actionGroupDepth(a_context) == 1
+        assert transaction_coordinator._actionGroupDepth(a_context) == 1
 
-        a_context.actionGroupDepth = 77
-        assert transaction_coordinator.actionGroupDepth(a_context) == 77
+        a_context._actionGroupDepth = 77
+        assert transaction_coordinator._actionGroupDepth(a_context) == 77
 
 
 class Test_TransactionCoordinator_freeze_thaw:
@@ -259,7 +259,7 @@ class Test_TransactionCoordinator_freeze_thaw:
 
         action_group_depth = 4
 
-        a_context.actionGroupDepth = action_group_depth
+        a_context._actionGroupDepth = action_group_depth
 
         # Freeze
 
@@ -277,7 +277,7 @@ class Test_TransactionCoordinator_freeze_thaw:
         thawed_context = transaction_coordinator.thawManagerState(token)
         mock_manager.thawState.assert_called_once_with(mock_frozen_state, mock_host_session)
         assert thawed_context.managerInterfaceState == state
-        assert thawed_context.actionGroupDepth == action_group_depth
+        assert thawed_context._actionGroupDepth == action_group_depth
 
 
 class Test_ScopedActionGroup:


### PR DESCRIPTION
This data is held in the Context through necessity (any better ideas would be most welcome!), no one outside the API middleware should be accessing this value directly.

The `TransactionCoordinator` and `ScopedActionGroup` classes take care of exposing the related host-facing functionality.

Closes #135.