### PR TITLE
Support un-versioned `clang-tidy`

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -7,12 +7,22 @@ We assume the following system packages are installed
 - CMake 3.21+
 - GCC 9.3
 
+For linting and other build verification options, we assume the
+following packages are installed:
+
+- LLVM 12.0.0
+
 ## Library dependencies
 
 Binary builds additionally require the following packages to be
 available to the CMake build system.
 - Python 3.9 (development install)
 - [pybind11](https://pybind11.readthedocs.io/en/stable/) 2.6.1+
+
+Building and running tests requires the following additional packages:
+
+- catch2 2.13
+- trompeloeil 42
 
 We use the CMake build system for compiling the C++ core library and
 its Python bindings. As such, the library dependencies listed above must

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,15 @@ v1.0.0-alpha.X
   [#348](https://github.com/OpenAssetIO/OpenAssetIO/issues/348)
 
 
+### Improvements
+
+- Switched to preferring un-versioned `clang-tidy` executables when
+  the `OPENASSETIO_ENABLE_CLANG_TIDY` build option is enabled. We
+  currently target LLVM v12, earlier or later versions may yield
+  new or false-positive warnings.
+  [#392](https://github.com/OpenAssetIO/OpenAssetIO/issues/392)
+
+
 v1.0.0-alpha.1
 --------------
 

--- a/cmake/StaticAnalyzers.cmake
+++ b/cmake/StaticAnalyzers.cmake
@@ -2,10 +2,7 @@
 # Copyright 2013-2022 The Foundry Visionmongers Ltd
 
 macro(enable_clang_tidy)
-    # Clang-Tidy warnings vary quite a bit between different versions.
-    # So pin to clang-tidy-12 for now, which happens to be the latest
-    # available in Ubuntu 20.04's (i.e. CI) apt repos.
-    find_program(OPENASSETIO_CLANGTIDY_EXE clang-tidy-12)
+    find_program(OPENASSETIO_CLANGTIDY_EXE NAMES clang-tidy clang-tidy-12)
 
     if (OPENASSETIO_CLANGTIDY_EXE)
         # Construct the clang-tidy command line
@@ -57,7 +54,7 @@ macro(enable_cpplint)
 endmacro()
 
 macro(enable_clang_format)
-    find_program(OPENASSETIO_CLANGFORMAT_EXE clang-format clang-format-10)
+    find_program(OPENASSETIO_CLANGFORMAT_EXE NAMES clang-format clang-format-12)
     if (OPENASSETIO_CLANGFORMAT_EXE)
         file(
             GLOB_RECURSE _sources


### PR DESCRIPTION
Closes #392
