### PR TITLE
[Build] Fix C headers to assume C compiler

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,12 @@ v1.0.0-alpha.X
   their properties.
   [#348](https://github.com/OpenAssetIO/OpenAssetIO/issues/348)
 
+### Bug fixes
+
+- C headers are now C99 compliant. In particular, they no longer 
+  `#include` C++-specific headers. 
+  [#337](https://github.com/OpenAssetIO/OpenAssetIO/issues/337)
+
 
 ### Improvements
 

--- a/src/openassetio-core-c/include/openassetio/c/InfoDictionary.h
+++ b/src/openassetio-core-c/include/openassetio/c/InfoDictionary.h
@@ -2,8 +2,9 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
+#include <stdbool.h>  // NOLINT(modernize-deprecated-headers)
+#include <stddef.h>   // NOLINT(modernize-deprecated-headers)
+#include <stdint.h>   // NOLINT(modernize-deprecated-headers)
 
 #include <openassetio/c/export.h>
 

--- a/src/openassetio-core-c/include/openassetio/c/StringView.h
+++ b/src/openassetio-core-c/include/openassetio/c/StringView.h
@@ -2,7 +2,7 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #pragma once
 
-#include <cstddef>
+#include <stddef.h>  // NOLINT(modernize-deprecated-headers)
 
 #include "./namespace.h"
 


### PR DESCRIPTION
Closes #337. Swap C++ headers for "deprecated" C headers, such that gcc/clang compiles them fine in `c99` mode.

Note that `c99` is the minimum version we can support, since we require `bool` and `int64_t`, which are unavailable in previous C standards.

No tests are included, this is left for #338. As a manual check, assuming
* Working directory is the root of the repository
* Compiler is `clang`
* Build directory is `./cmake-build-debug`

then
```sh
( cd ./src/openassetio-core-c/include/ && find * -name "*.h" | while read f; do echo "#include <$f>"; done ) | clang -c -xc -std=c99 -o /tmp/deleteme.o -Isrc/openassetio-core-c/include -Icmake-build-debug/include -
```
