### PR TITLE
[Lint] Default to trim whitespace in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ indent_style = space
 insert_final_newline = true
 max_line_length = 99
 tab_width = 4
+trim_trailing_whitespace = true
 ij_continuation_indent_size = 8
 # ij_formatter_off_tag = @formatter:off
 # ij_formatter_on_tag = @formatter:on


### PR DESCRIPTION
The reason for not doing this before is that some languages may have significant trailing whitespace. In particular, a double trailing whitespace in markdown forces a line break. However, there are better alternatives to achieving the same effect. The amount of trailing whitespace that slips through is far more of a problem.
