### PR TITLE
[Build] Ignore CMakeUserPresets.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 /resources/build/.vagrant/
 /.pybuild/
 /build
+/CMakeUserPresets.json


### PR DESCRIPTION
CMake user presets can be used to inherit from and override project-level presets on a per-user basis, and hence it is expected not to be overridden by a git checkout.