### PR TITLE
[Core] Decouple symbol namespace version from release version

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,11 @@ v1.0.0-alpha.X
   their properties.
   [#348](https://github.com/OpenAssetIO/OpenAssetIO/issues/348)
 
+- Switched the C/C++ symbol namespace to use a separate ABI version.
+  The version is defined by the major version component of the last
+  release in which the ABI changed.
+  [#377](https://github.com/OpenAssetIO/OpenAssetIO/issues/377)
+
 - Renamed the following trait related types and variables to better
   align with the concepts of the API:
   [#340](https://github.com/OpenAssetIO/OpenAssetIO/issues/340)

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -243,15 +243,15 @@ TAB_SIZE               = 2
 # too much of the subsequent text.
 # '@fqref' prefixes the given symbol with the top-level OpenAssetIO C++
 # namespace, including (inline namespace) version tag. The version tag
-# must be provided as an OPENASSETIO_VERSION environment variable to
-# Doxygen.
+# must be provided as an OPENASSETIO_CORE_ABI_VERSION environment variable
+# to Doxygen.
 # '@fqcref' prefixes the given symbol with the top-level OpenAssetIO C
 # namespace, including version tag. The version tag must be provided as
-# an OPENASSETIO_VERSION environment variable to Doxygen.
+# an OPENASSETIO_CORE_ABI_VERSION environment variable to Doxygen.
 ALIASES                = "envvar=\xrefitem envvar \"Environment Variables\" \"Environment Variable List\"" \
                          "event=\xrefitem event \"Events\" \"Event List\"" \
                          "needsref=" \
-                         "fqref{1}=@ref openassetio::$(OPENASSETIO_VERSION)::\1" \
+                         "fqref{1}=@ref openassetio::$(OPENASSETIO_CORE_ABI_VERSION)::\1" \
                          "fqcref{1}=@ref oa_\1"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
@@ -2096,7 +2096,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = OPENASSETIO_VERSION=$(OPENASSETIO_VERSION) OPENASSETIO_CORE_C_EXPORT=
+PREDEFINED             = OPENASSETIO_CORE_ABI_VERSION=$(OPENASSETIO_CORE_ABI_VERSION) OPENASSETIO_CORE_C_EXPORT=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,7 +20,7 @@ default: container-build
 ##
 
 CONTAINER_VERSION=1.1.1
-OPENASSETIO_VERSION=v0_0
+OPENASSETIO_CORE_ABI_VERSION=v1
 CONTAINER_NAME=openassetio-doc-build
 
 ##
@@ -90,7 +90,7 @@ SASS = ./node_modules/.bin/sass
 
 # Force clean-html as we don't declare all the sources
 html: clean-html src/styles.css tooling
-	. $(VENV)/bin/activate && OPENASSETIO_VERSION=$(OPENASSETIO_VERSION) doxygen ./Doxyfile
+	. $(VENV)/bin/activate && OPENASSETIO_CORE_ABI_VERSION=$(OPENASSETIO_CORE_ABI_VERSION) doxygen ./Doxyfile
 
 tooling: $(SASS) $(VENV)
 

--- a/src/openassetio-core-c/include/openassetio/c/namespace.h
+++ b/src/openassetio-core-c/include/openassetio/c/namespace.h
@@ -2,7 +2,7 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #pragma once
 
-#include <openassetio/export.h>  // For OPENASSETIO_VERSION
+#include <openassetio/export.h>  // For OPENASSETIO_CORE_ABI_VERSION
 
 /**
  * @addtogroup CAPI C API
@@ -15,7 +15,7 @@
  *
  * @hideinitializer
  */
-#define OPENASSETIO_NS(symbol) OPENASSETIO_NS_WITH_VER(OPENASSETIO_VERSION, symbol)
+#define OPENASSETIO_NS(symbol) OPENASSETIO_NS_WITH_VER(OPENASSETIO_CORE_ABI_VERSION, symbol)
 
 /**
  * @}
@@ -26,7 +26,7 @@
  *
  *  Macros are not expanded when using the token pasing operator `##`.
  *  So we need two utility functions, the first expands the value of
- *  `OPENASSETIO_VERSION` passed from `OPENASSETIO_NS` as a `ver`
+ *  `OPENASSETIO_CORE_ABI_VERSION` passed from `OPENASSETIO_NS` as a `ver`
  *  parameter and passes that to the second macro, which does the final
  *  token pasting.
  *

--- a/src/openassetio-core-c/private/StringView.hpp
+++ b/src/openassetio-core-c/private/StringView.hpp
@@ -9,7 +9,7 @@
 #include <openassetio/export.h>
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 /**
  * Copy a source string to a destination C StringView.
  *
@@ -23,5 +23,5 @@ inline void assignStringView(oa_StringView* dest, const std::string_view src) {
   dest->size = std::min(src.size(), dest->capacity);
   strncpy(dest->data, src.data(), dest->size);
 }
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core-c/private/errors.hpp
+++ b/src/openassetio-core-c/private/errors.hpp
@@ -10,7 +10,7 @@
 #include "StringView.hpp"
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace errors {
 /**
  * Throw the appropriate exception for given error code, if any.
@@ -71,5 +71,5 @@ auto catchUnknownExceptionAsCode(oa_StringView *err, Fn &&fn) {
   }
 }
 }  // namespace errors
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core-c/private/handles/Converter.hpp
+++ b/src/openassetio-core-c/private/handles/Converter.hpp
@@ -2,10 +2,10 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #pragma once
 
-#include <openassetio/export.h>  // For OPENASSETIO_VERSION
+#include <openassetio/export.h>  // For OPENASSETIO_CORE_ABI_VERSION
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 /**
  * Provides utilities for converting between C++ types and C handles.
  */
@@ -35,5 +35,5 @@ struct Converter {
   static Type* toInstance(Handle handle) { return reinterpret_cast<Type*>(handle); }
 };
 }  // namespace handles
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core-c/private/handles/InfoDictionary.hpp
+++ b/src/openassetio-core-c/private/handles/InfoDictionary.hpp
@@ -10,9 +10,9 @@
 #include "Converter.hpp"
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace handles {
 using InfoDictionary = Converter<InfoDictionary, oa_InfoDictionary_h>;
 }
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core-c/private/handles/hostAPI/Manager.hpp
+++ b/src/openassetio-core-c/private/handles/hostAPI/Manager.hpp
@@ -10,9 +10,9 @@
 #include "../Converter.hpp"
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace handles::hostAPI {
 using Manager = Converter<openassetio::hostAPI::Manager, oa_hostAPI_Manager_h>;
 }
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core-c/private/handles/managerAPI/ManagerInterface.hpp
+++ b/src/openassetio-core-c/private/handles/managerAPI/ManagerInterface.hpp
@@ -10,10 +10,10 @@
 #include "../Converter.hpp"
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace handles::managerAPI {
 using SharedManagerInterface = Converter<openassetio::managerAPI::ManagerInterfacePtr,
                                          oa_managerAPI_SharedManagerInterface_h>;
 }
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core-c/private/managerAPI/CManagerInterface.cpp
+++ b/src/openassetio-core-c/private/managerAPI/CManagerInterface.cpp
@@ -9,7 +9,7 @@
 #include "../handles/InfoDictionary.hpp"
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace managerAPI {
 
 constexpr size_t kStringBufferSize = 500;
@@ -79,5 +79,5 @@ InfoDictionary CManagerInterfaceAdapter::info() const {
   return infoDict;
 }
 }  // namespace managerAPI
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core-c/private/managerAPI/CManagerInterfaceAdapter.hpp
+++ b/src/openassetio-core-c/private/managerAPI/CManagerInterfaceAdapter.hpp
@@ -9,7 +9,7 @@
 #include <openassetio/managerAPI/ManagerInterface.hpp>
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace managerAPI {
 
 /**
@@ -49,5 +49,5 @@ class OPENASSETIO_CORE_C_EXPORT CManagerInterfaceAdapter : ManagerInterface {
 };
 
 }  // namespace managerAPI
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2013-2022 The Foundry Visionmongers Ltd
 
+#----------------------------------------------------------------------
+# Versioning
+
+# Library ABI version
+# This should be set to the major component of the last release version
+# where the ABI changed.
+set(core_abi_version 1)
 
 #----------------------------------------------------------------------
 # Public headers
@@ -75,7 +82,7 @@ target_include_directories(openassetio-core
 #   (bundles version in export header) and OTIO (uses separate header),
 #   both of which include a long list of additional #defines.
 set(define_version
-    "#define OPENASSETIO_VERSION v${PROJECT_VERSION_MAJOR}_${PROJECT_VERSION_MINOR}")
+    "#define OPENASSETIO_CORE_ABI_VERSION v${core_abi_version}")
 
 # TODO(DF): Allow customising namespace? See OCIO.
 

--- a/src/openassetio-core/TraitsData.cpp
+++ b/src/openassetio-core/TraitsData.cpp
@@ -5,7 +5,7 @@
 #include <unordered_map>
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 class TraitsData::Impl {
  public:
   Impl() = default;
@@ -93,5 +93,5 @@ void TraitsData::setTraitProperty(const trait::TraitId& traitId,
 }
 
 bool TraitsData::operator==(const TraitsData& other) const { return *impl_ == *other.impl_; }
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/hostAPI/Manager.cpp
+++ b/src/openassetio-core/hostAPI/Manager.cpp
@@ -5,7 +5,7 @@
 #include <openassetio/typedefs.hpp>
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace hostAPI {
 
 Manager::Manager(managerAPI::ManagerInterfacePtr managerInterface)
@@ -16,5 +16,5 @@ Str Manager::displayName() const { return managerInterface_->displayName(); }
 InfoDictionary Manager::info() const { return managerInterface_->info(); }
 
 }  // namespace hostAPI
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/InfoDictionary.hpp
+++ b/src/openassetio-core/include/openassetio/InfoDictionary.hpp
@@ -9,7 +9,7 @@
 #include <openassetio/typedefs.hpp>
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 /// Types available as values in a InfoDictionary.
 using InfoDictionaryValue = std::variant<Bool, Int, Float, Str>;
 /**
@@ -17,5 +17,5 @@ using InfoDictionaryValue = std::variant<Bool, Int, Float, Str>;
  * "ManagerInterface::info".
  */
 using InfoDictionary = std::unordered_map<Str, InfoDictionaryValue>;
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/TraitsData.hpp
+++ b/src/openassetio-core/include/openassetio/TraitsData.hpp
@@ -14,7 +14,7 @@
 #include "trait/property.hpp"
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 /**
  * A transport-level container for data exchange between a @ref host and
  * a @ref manager.
@@ -169,5 +169,5 @@ class OPENASSETIO_CORE_EXPORT TraitsData final {
 
 /// Ref-counted smart pointer to underlying TraitsData.
 using TraitsDataPtr = std::shared_ptr<TraitsData>;
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/hostAPI/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostAPI/Manager.hpp
@@ -7,7 +7,7 @@
 #include <openassetio/typedefs.hpp>
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 /**
  This namespace contains code relevant to anyone wanting to add support
  for a host application.
@@ -102,5 +102,5 @@ class OPENASSETIO_CORE_EXPORT Manager {
 };
 
 }  // namespace hostAPI
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/managerAPI/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerAPI/ManagerInterface.hpp
@@ -8,7 +8,7 @@
 #include <openassetio/typedefs.hpp>
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 /**
  This namespace contains code relevant to anyone wanting to add support
  for an asset management system.
@@ -231,5 +231,5 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
 
 using ManagerInterfacePtr = SharedPtr<ManagerInterface>;
 }  // namespace managerAPI
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/trait/TraitBase.hpp
+++ b/src/openassetio-core/include/openassetio/trait/TraitBase.hpp
@@ -11,7 +11,7 @@
 #include "../TraitsData.hpp"
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace trait {
 
 /**
@@ -151,5 +151,5 @@ struct TraitBase {
   TraitsDataPtr data_;
 };
 }  // namespace trait
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/trait/property.hpp
+++ b/src/openassetio-core/include/openassetio/trait/property.hpp
@@ -12,7 +12,7 @@
 #include <openassetio/typedefs.hpp>
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 /**
  * Comprises concrete trait views wrapping @ref TraitsData
  * instances.
@@ -56,5 +56,5 @@ using TraitId = property::Key;
 /// Status of a trait property within a specification.
 enum class TraitPropertyStatus { kFound, kMissing, kInvalidValue };
 }  // namespace trait
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/typedefs.hpp
+++ b/src/openassetio-core/include/openassetio/typedefs.hpp
@@ -9,7 +9,7 @@
 #include <openassetio/export.h>
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 /**
  * @anchor CppPrimitiveTypes
  * @name Primitive Types
@@ -55,5 +55,5 @@ template <class T, typename... Args>
 SharedPtr<T> makeShared(Args&&... args) {
   return std::make_shared<T>(std::forward<Args>(args)...);
 }
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/managerAPI/ManagerInterface.cpp
+++ b/src/openassetio-core/managerAPI/ManagerInterface.cpp
@@ -4,7 +4,7 @@
 #include <openassetio/managerAPI/ManagerInterface.hpp>
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace managerAPI {
 
 ManagerInterface::ManagerInterface() = default;
@@ -12,5 +12,5 @@ ManagerInterface::ManagerInterface() = default;
 InfoDictionary ManagerInterface::info() const { return {}; }
 
 }  // namespace managerAPI
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-python/managerAPI/ManagerInterfaceBinding.cpp
+++ b/src/openassetio-python/managerAPI/ManagerInterfaceBinding.cpp
@@ -9,7 +9,7 @@
 #include "../_openassetio.hpp"
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace managerAPI {
 
 /**
@@ -33,7 +33,7 @@ struct PyManagerInterface : ManagerInterface {
 };
 
 }  // namespace managerAPI
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio
 
 void registerManagerInterface(const py::module& mod) {

--- a/tests/openassetio-core-c/private/managerAPI/MockManagerInterfaceSuite.hpp
+++ b/tests/openassetio-core-c/private/managerAPI/MockManagerInterfaceSuite.hpp
@@ -2,7 +2,7 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #pragma once
 
-#include <openassetio/export.h>  // For OPENASSETIO_VERSION
+#include <openassetio/export.h>  // For OPENASSETIO_CORE_ABI_VERSION
 
 #include <catch2/trompeloeil.hpp>
 
@@ -10,7 +10,7 @@
 #include <handles/Converter.hpp>
 
 namespace openassetio {
-inline namespace OPENASSETIO_VERSION {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace test {
 
 /**
@@ -64,5 +64,5 @@ inline oa_managerAPI_CManagerInterface_s mockManagerInterfaceSuite() {
           }};
 }
 }  // namespace test
-}  // namespace OPENASSETIO_VERSION
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio


### PR DESCRIPTION
We previously used the major and minor release version components to define the C/C++ symbol namespace. This had the downside that it would change with every minor version, forcing a re-compile even if the ABI had not altered.

There are many cases in which either of these two version components may be bumped without the ABI being affected (python only changes, feature additions, etc.).

The new approach freezes the namespace version to the last major version where the ABI changed (as an ABI break would always require a major release). Hopefully this will avoid the need for recompilation in many situations and reduce the maintenance overhead.

Closes #377