### PR TITLE
[Build] `OPENASSETIO_PYTHON_PIP_TIMEOUT` CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,11 @@ if (OPENASSETIO_ENABLE_PYTHON)
         ""
         CACHE STRING
         "Override default Python module install directory, relative to CMAKE_INSTALL_PREFIX")
+
+    # Socket timeout for pip install. Useful to lower if working offline
+    # when all dependencies are already downloaded (pip unfortunately
+    # still attempts to contact pypi).
+    set(OPENASSETIO_PYTHON_PIP_TIMEOUT 15 CACHE STRING "Python pip socket timeout")
 endif ()
 
 # Enable C bindings, built as a separate library that depends on the
@@ -290,6 +295,7 @@ message(STATUS "Build shared libs               = ${BUILD_SHARED_LIBS}")
 message(STATUS "Enable Python module build      = ${OPENASSETIO_ENABLE_PYTHON}")
 if (OPENASSETIO_ENABLE_PYTHON)
     message(STATUS "Python relative install dir     = ${OPENASSETIO_PYTHON_SITEDIR}")
+    message(STATUS "Python pip socket timeout       = ${OPENASSETIO_PYTHON_PIP_TIMEOUT}")
 endif ()
 message(STATUS "Create test targets             = ${OPENASSETIO_ENABLE_TESTS}")
 message(STATUS "Warnings as errors              = ${OPENASSETIO_WARNINGS_AS_ERRORS}")

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -41,6 +41,11 @@ v1.0.0-alpha.X
 - Added CMake presets for development and testing.
   [#315](https://github.com/OpenAssetIO/OpenAssetIO/issues/315)
 
+- Added `OPENASSETIO_PYTHON_PIP_TIMEOUT` CMake cache variable to allow
+  customising `pip install` socket timeout. Useful if working offline
+  with dependencies already downloaded.
+  [#407](https://github.com/OpenAssetIO/OpenAssetIO/issues/407)
+
 - Updated the machine image bootstrap scripts in `resources/build` to
   use the `$WORKSPACE` env var instead of `$GITHUB_WORKSPACE` to
   determine the root of a checkout when configuring the environment.

--- a/src/openassetio-python/CMakeLists.txt
+++ b/src/openassetio-python/CMakeLists.txt
@@ -108,7 +108,7 @@ if (Python_Interpreter_FOUND)
         COMMAND ${CMAKE_COMMAND} -E echo -- Downloading core Python libraries
         COMMAND
         ${Python_EXECUTABLE} -m pip download
-        --retries 0 --timeout 1 --find-links ${python_deps_dir}
+        --retries 0 --timeout ${OPENASSETIO_PYTHON_PIP_TIMEOUT} --find-links ${python_deps_dir}
         --destination-directory ${python_deps_dir}
         setuptools==62.3.2 wheel==0.37.1 pip==22.1
     )
@@ -157,7 +157,7 @@ if (Python_Interpreter_FOUND)
             COMMAND ${CMAKE_COMMAND} -E echo -- Downloading Python test libraries
             COMMAND
             ${Python_EXECUTABLE} -m pip download
-            --retries 0 --timeout 1
+            --retries 0 --timeout ${OPENASSETIO_PYTHON_PIP_TIMEOUT}
             --find-links ${python_deps_dir}
             --destination-directory ${python_deps_dir}
             --requirement "${PROJECT_SOURCE_DIR}/tests/python/requirements.txt"


### PR DESCRIPTION
Closes #407. Add `OPENASSETIO_PYTHON_PIP_TIMEOUT` CMake cache variable to allow customising `pip install` socket timeout. We had issues with hardcoding the value to 1 second as being insufficient for some CI runs. So instead default to pip's own 15 sec default and allow overriding for those who wish to work offline.
