### PR TITLE
[Python] Remove `Holder<T>` alias for `openassetio::shared_ptr`

### DIFF
--- a/src/openassetio-python/TraitsDataBinding.cpp
+++ b/src/openassetio-python/TraitsDataBinding.cpp
@@ -11,11 +11,12 @@
 
 void registerTraitsData(const py::module& mod) {
   using openassetio::TraitsData;
+  using openassetio::TraitsDataPtr;
   namespace trait = openassetio::trait;
   namespace property = openassetio::trait::property;
   using MaybeValue = std::optional<property::Value>;
 
-  py::class_<TraitsData, Holder<TraitsData>>(mod, "TraitsData", py::is_final())
+  py::class_<TraitsData, TraitsDataPtr>(mod, "TraitsData", py::is_final())
       .def(py::init())
       .def(py::init<const TraitsData::TraitSet&>(), py::arg("traitSet"))
       .def(py::init<const TraitsData&>())

--- a/src/openassetio-python/_openassetio.hpp
+++ b/src/openassetio-python/_openassetio.hpp
@@ -14,16 +14,6 @@
 /// Concise pybind alias.
 namespace py = pybind11;
 
-/**
- * Holder type for pybind-registered classes whose instances can exist
- * simultaneously in C++ and Python.
- *
- * Ensuring all such types are constructed and held as a ref-counted
- * smart pointer saves many object lifetime headaches.
- */
-template <class T>
-using Holder = openassetio::SharedPtr<T>;
-
 /// Register the HostInterface class with Python.
 void registerHostInterface(const py::module& mod);
 

--- a/src/openassetio-python/hostAPI/HostInterfaceBinding.cpp
+++ b/src/openassetio-python/hostAPI/HostInterfaceBinding.cpp
@@ -38,9 +38,10 @@ struct PyHostInterface : HostInterface {
 
 void registerHostInterface(const py::module& mod) {
   using openassetio::hostAPI::HostInterface;
+  using openassetio::hostAPI::HostInterfacePtr;
   using openassetio::hostAPI::PyHostInterface;
 
-  py::class_<HostInterface, PyHostInterface, Holder<HostInterface>>(mod, "HostInterface")
+  py::class_<HostInterface, PyHostInterface, HostInterfacePtr>(mod, "HostInterface")
       .def(py::init())
       .def("identifier", &HostInterface::identifier)
       .def("displayName", &HostInterface::displayName)

--- a/src/openassetio-python/managerAPI/HostBinding.cpp
+++ b/src/openassetio-python/managerAPI/HostBinding.cpp
@@ -9,8 +9,9 @@
 void registerHost(const py::module& mod) {
   using openassetio::hostAPI::HostInterfacePtr;
   using openassetio::managerAPI::Host;
+  using openassetio::managerAPI::HostPtr;
 
-  py::class_<Host, Holder<Host>>(mod, "Host", py::is_final())
+  py::class_<Host, HostPtr>(mod, "Host", py::is_final())
       .def(py::init<HostInterfacePtr>(), py::arg("hostInterface").none(false))
       .def("identifier", &Host::identifier)
       .def("displayName", &Host::displayName)

--- a/src/openassetio-python/managerAPI/ManagerInterfaceBinding.cpp
+++ b/src/openassetio-python/managerAPI/ManagerInterfaceBinding.cpp
@@ -38,10 +38,10 @@ struct PyManagerInterface : ManagerInterface {
 
 void registerManagerInterface(const py::module& mod) {
   using openassetio::managerAPI::ManagerInterface;
+  using openassetio::managerAPI::ManagerInterfacePtr;
   using openassetio::managerAPI::PyManagerInterface;
 
-  py::class_<ManagerInterface, PyManagerInterface, Holder<ManagerInterface>>(mod,
-                                                                             "ManagerInterface")
+  py::class_<ManagerInterface, PyManagerInterface, ManagerInterfacePtr>(mod, "ManagerInterface")
       .def(py::init())
       .def("identifier", &ManagerInterface::identifier)
       .def("displayName", &ManagerInterface::displayName)


### PR DESCRIPTION
We added this abstraction to facilitate easier refactoring later on. In use though, it hampers readability of binding code, and potentially allows the pybind holder to differ from what ever pointer we use internally, which could have dire side-effects.

Closes #432