### PR TITLE
[Tests] Fix includes in `MockManagerInterfaceSuite`

### DIFF
--- a/tests/openassetio-core-c/private/managerAPI/MockManagerInterfaceSuite.hpp
+++ b/tests/openassetio-core-c/private/managerAPI/MockManagerInterfaceSuite.hpp
@@ -4,6 +4,10 @@
 
 #include <openassetio/export.h>  // For OPENASSETIO_CORE_ABI_VERSION
 
+#include <openassetio/c/StringView.h>
+#include <openassetio/c/managerAPI/CManagerInterface.h>
+
+#include <catch2/catch.hpp>
 #include <catch2/trompeloeil.hpp>
 
 // private headers


### PR DESCRIPTION
Inadvertently had been relying on this file always being included
in another file that already had these.
