### PR TITLE
Pass `HostSession` to C++ `Manager` during construction

### DIFF
--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -75,7 +75,7 @@ class Manager(_openassetio.hostAPI.Manager, Debuggable):
         session the manager is part of.
         """
 
-        _openassetio.hostAPI.Manager .__init__(self, interfaceInstance)
+        _openassetio.hostAPI.Manager .__init__(self, interfaceInstance, hostSession)
         Debuggable.__init__(self)
 
         self.__impl = interfaceInstance

--- a/src/openassetio-core-c/include/openassetio/c/hostAPI/Manager.h
+++ b/src/openassetio-core-c/include/openassetio/c/hostAPI/Manager.h
@@ -7,6 +7,7 @@
 #include "../InfoDictionary.h"
 #include "../StringView.h"
 #include "../errors.h"
+#include "../managerAPI/HostSession.h"
 #include "../managerAPI/ManagerInterface.h"
 #include "../namespace.h"
 
@@ -60,20 +61,24 @@ typedef struct oa_hostAPI_Manager_t* oa_hostAPI_Manager_h;
  * @param[out] handle
  * @param managerInterfaceHandle  A handle to a
  * \fqref{managerAPI::ManagerInterface} that the `Manager` will delegate
+ * @param hostSessionHandle  A handle to a
+ * \fqref{managerAPI::HostSession} that the `Manager` will supply to the
+ * held interface as required.
  * to.
  *
  **/
-// TODO(DF): The ownership semantic of a `ManagerInterface` handle is
-//  "shared" (i.e. it wraps a dynamically allocated `shared_ptr`),
-//  however there is no way to "release" a `ManagerInterface` handle.
-//  We need to figure out where these handles are created and what API
-//  we need around them - probably a `dtor`, at minimum. Or possibly
-//  `Manager`s in the C API should only be constructed via some factory,
-//  and there is no need for this `ctor` and thus no need for a
-//  `ManagerInterface_h` handle?
+// TODO(DF): The ownership semantic of a
+// `ManagerInterface`/`HostSession` handle is "shared" (i.e. it wraps a
+// dynamically allocated `shared_ptr`), however there is no way to
+// "release" a `ManagerInterface` handle. We need to figure out where
+// these handles are created and what API we need around them - probably
+// a `dtor`, at minimum. Or possibly `Manager`s in the C API should only
+// be constructed via some factory, and there is no need for this `ctor`
+// and thus no need for a `ManagerInterface_h` handle?
 OPENASSETIO_CORE_C_EXPORT oa_ErrorCode
 oa_hostAPI_Manager_ctor(oa_StringView* err, oa_hostAPI_Manager_h* handle,
-                        oa_managerAPI_SharedManagerInterface_h managerInterfaceHandle);
+                        oa_managerAPI_SharedManagerInterface_h managerInterfaceHandle,
+                        oa_managerAPI_SharedHostSession_h hostSessionHandle);
 
 /**
  * Destructor function.

--- a/src/openassetio-core-c/include/openassetio/c/managerAPI/HostSession.h
+++ b/src/openassetio-core-c/include/openassetio/c/managerAPI/HostSession.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#pragma once
+
+#include "../namespace.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/**
+ * @addtogroup CAPI C API
+ * @{
+ */
+
+/**
+ * @defgroup oa_managerAPI_SharedHostSession oa_managerAPI_SharedHostSession
+ *
+ * C API for the \fqref{managerAPI::HostSession}
+ * "managerAPI::HostSession C++ type".
+ *
+ * @{
+ */
+
+/**
+ * @defgroup oa_managerAPI_SharedHostSession_aliases Aliases
+ *
+ * @{
+ */
+#define oa_managerAPI_SharedHostSession_t OPENASSETIO_NS(managerAPI_SharedHostSession_t)
+#define oa_managerAPI_SharedHostSession_h OPENASSETIO_NS(managerAPI_SharedHostSession_h)
+
+/// @todo HostSession method bindings
+
+/// @}
+// oa_managerAPI_SharedHostSession_aliases
+
+/**
+ * Opaque handle type representing a @fqref{managerAPI::HostSession}
+ * "HostSession" instance.
+ */
+// NOLINTNEXTLINE(modernize-use-using)
+typedef struct oa_managerAPI_SharedHostSession_t* oa_managerAPI_SharedHostSession_h;
+
+/// @}
+// oa_managerAPI_SharedHostSession
+/// @}
+// CAPI
+#ifdef __cplusplus
+}
+#endif

--- a/src/openassetio-core-c/private/handles/managerAPI/HostSession.hpp
+++ b/src/openassetio-core-c/private/handles/managerAPI/HostSession.hpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#pragma once
+
+#include <openassetio/c/managerAPI/HostSession.h>
+#include <openassetio/export.h>
+
+#include <openassetio/managerAPI/HostSession.hpp>
+
+#include "../Converter.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace handles::managerAPI {
+using SharedHostSession =
+    Converter<openassetio::managerAPI::HostSessionPtr, oa_managerAPI_SharedHostSession_h>;
+}
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core-c/private/hostAPI/Manager.cpp
+++ b/src/openassetio-core-c/private/hostAPI/Manager.cpp
@@ -10,13 +10,16 @@
 #include <openassetio/c/namespace.h>
 
 #include <openassetio/hostAPI/Manager.hpp>
+#include <openassetio/managerAPI/HostSession.hpp>
 #include <openassetio/managerAPI/ManagerInterface.hpp>
 
 #include "../StringView.hpp"
 #include "../errors.hpp"
 #include "../handles/InfoDictionary.hpp"
 #include "../handles/hostAPI/Manager.hpp"
+#include "../handles/managerAPI/HostSession.hpp"
 #include "../handles/managerAPI/ManagerInterface.hpp"
+#include "openassetio/c/managerAPI/HostSession.h"
 
 namespace errors = openassetio::errors;
 namespace handles = openassetio::handles;
@@ -25,15 +28,18 @@ namespace managerAPI = openassetio::managerAPI;
 
 extern "C" {
 
-oa_ErrorCode oa_hostAPI_Manager_ctor(
-    oa_StringView* err, oa_hostAPI_Manager_h* handle,
-    oa_managerAPI_SharedManagerInterface_h managerInterfaceHandle) {
+oa_ErrorCode oa_hostAPI_Manager_ctor(oa_StringView* err, oa_hostAPI_Manager_h* handle,
+                                     oa_managerAPI_SharedManagerInterface_h managerInterfaceHandle,
+                                     oa_managerAPI_SharedHostSession_h hostSessionHandle) {
   return errors::catchUnknownExceptionAsCode(err, [&] {
     managerAPI::ManagerInterfacePtr& managerInterfacePtr =
         *handles::managerAPI::SharedManagerInterface::toInstance(managerInterfaceHandle);
 
+    managerAPI::HostSessionPtr& hostSessionPtr =
+        *handles::managerAPI::SharedHostSession::toInstance(hostSessionHandle);
+
     auto* manager = new hostAPI::ManagerPtr;
-    *manager = std::make_shared<hostAPI::Manager>(managerInterfacePtr);
+    *manager = std::make_shared<hostAPI::Manager>(managerInterfacePtr, hostSessionPtr);
     *handle = handles::hostAPI::SharedManager::toHandle(manager);
 
     return oa_ErrorCode_kOK;

--- a/src/openassetio-core/hostAPI/Manager.cpp
+++ b/src/openassetio-core/hostAPI/Manager.cpp
@@ -8,8 +8,9 @@ namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace hostAPI {
 
-Manager::Manager(managerAPI::ManagerInterfacePtr managerInterface)
-    : managerInterface_{std::move(managerInterface)} {}
+Manager::Manager(managerAPI::ManagerInterfacePtr managerInterface,
+                 managerAPI::HostSessionPtr hostSession)
+    : managerInterface_{std::move(managerInterface)}, hostSession_{std::move(hostSession)} {}
 
 Str Manager::identifier() const { return managerInterface_->identifier(); }
 Str Manager::displayName() const { return managerInterface_->displayName(); }

--- a/src/openassetio-core/include/openassetio/hostAPI/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostAPI/Manager.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <openassetio/export.h>
+#include <openassetio/managerAPI/HostSession.hpp>
 #include <openassetio/managerAPI/ManagerInterface.hpp>
 #include <openassetio/typedefs.hpp>
 
@@ -42,7 +43,8 @@ namespace hostAPI {
  */
 class OPENASSETIO_CORE_EXPORT Manager {
  public:
-  explicit Manager(managerAPI::ManagerInterfacePtr managerInterface);
+  explicit Manager(managerAPI::ManagerInterfacePtr managerInterface,
+                   managerAPI::HostSessionPtr hostSession);
 
   /**
    * @name Asset Management System Information
@@ -99,6 +101,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
 
  private:
   managerAPI::ManagerInterfacePtr managerInterface_;
+  managerAPI::HostSessionPtr hostSession_;
 };
 
 using ManagerPtr = SharedPtr<Manager>;

--- a/src/openassetio-python/hostAPI/ManagerBinding.cpp
+++ b/src/openassetio-python/hostAPI/ManagerBinding.cpp
@@ -12,7 +12,8 @@ void registerManager(const py::module& mod) {
   using openassetio::managerAPI::ManagerInterfacePtr;
 
   py::class_<Manager, ManagerPtr>(mod, "Manager")
-      .def(py::init<ManagerInterfacePtr>(), py::arg("managerInterface").none(false))
+      .def(py::init<ManagerInterfacePtr, openassetio::managerAPI::HostSessionPtr>(),
+           py::arg("managerInterface").none(false), py::arg("hostSession").none(false))
       .def("identifier", &Manager::identifier)
       .def("displayName", &Manager::displayName)
       .def("info", &Manager::info);

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -172,7 +172,7 @@ class ValidatingMockManagerInterface(ManagerInterface):
     def setRelatedReferences(self, entityRef, relationshipTraitsData, relatedRefs, context,
                 hostSession, append=True):
         return self.mock.setRelatedReferences(
-            entityRef, relationshipTraitsData, relatedRefs, context, hostSession, append=True)
+            entityRef, relationshipTraitsData, relatedRefs, context, hostSession, append=append)
 
     def preflight(self, targetEntityRefs, traitSet, context, hostSession):
         self.__assertIsIterableOf(targetEntityRefs, str)

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -16,14 +16,15 @@
 """
 Shared fixtures/code for pytest cases.
 """
-# pylint: disable=missing-function-docstring
+# pylint: disable=missing-function-docstring,redefined-outer-name
 from unittest import mock
 import sys
 
 import pytest
 
 from openassetio import Context, TraitsData
-from openassetio.managerAPI import ManagerInterface, HostSession
+from openassetio.log import LoggerInterface
+from openassetio.managerAPI import ManagerInterface, Host, HostSession
 from openassetio.hostAPI import HostInterface
 
 # pylint: disable=invalid-name
@@ -55,6 +56,14 @@ def unload_openassetio_modules():
 
 
 @pytest.fixture
+def mock_logger():
+    """
+    Fixture providing a mock that conforms to the LoggerInterface.
+    """
+    return mock.create_autospec(spec=LoggerInterface)
+
+
+@pytest.fixture
 def mock_host_interface():
     """
     Fixture for a `HostInterface` that forwards method calls to an
@@ -64,12 +73,35 @@ def mock_host_interface():
 
 
 @pytest.fixture
+def mock_host_session(mock_host_interface, mock_logger):
+    """
+    Fixture for a `HostSesssion`, configured with a mock_host_interface,
+    that forwards method calls to an internal public `mock.Mock` instance.
+    """
+    return MockHostSession(Host(mock_host_interface), mock_logger)
+
+
+@pytest.fixture
 def mock_manager_interface():
     """
     Fixture for a `ManagerInterface` that asserts parameter types and
     forwards method calls to an internal public `mock.Mock` instance.
     """
     return ValidatingMockManagerInterface()
+
+
+class MockHostSession(HostSession):
+    """
+    `HostSession` that forwards calls to an internal mock.
+    @see mock_host_session
+    """
+
+    def __init__(self, host, logger):
+        super().__init__(host, logger)
+        self.mock = mock.create_autospec(HostSession, spec_set=True, instance=True)
+
+    def host(self):
+        return self.mock.host()
 
 
 class ValidatingMockManagerInterface(ManagerInterface):

--- a/tests/python/openassetio/hostAPI/test_manager.py
+++ b/tests/python/openassetio/hostAPI/test_manager.py
@@ -21,8 +21,6 @@ Tests that cover the openassetio.hostAPI.Manager wrapper class.
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 
-from unittest import mock
-
 import pytest
 
 from openassetio import Context, TraitsData, managerAPI
@@ -32,13 +30,8 @@ from openassetio.hostAPI import Manager
 ## @todo Remove comments regarding Entity methods when splitting them from core API
 
 @pytest.fixture
-def host_session():
-    return mock.create_autospec(managerAPI.HostSession)
-
-
-@pytest.fixture
-def manager(mock_manager_interface, host_session):
-    return Manager(mock_manager_interface, host_session)
+def manager(mock_manager_interface, mock_host_session):
+    return Manager(mock_manager_interface, mock_host_session)
 
 
 @pytest.fixture
@@ -85,16 +78,16 @@ def some_refs():
 class Test_Manager_init:
 
     def test_interface_returns_the_constructor_supplied_object(
-            self, mock_manager_interface, host_session):
+            self, mock_manager_interface, mock_host_session):
 
         # pylint: disable=protected-access
-        a_manager = Manager(mock_manager_interface, host_session)
+        a_manager = Manager(mock_manager_interface, mock_host_session)
         assert a_manager._interface() is mock_manager_interface
 
     def test_when_constructed_with_ManagerInterface_as_None_then_raises_TypeError(
-            self, host_session):
+            self, mock_host_session):
         with pytest.raises(TypeError) as err:
-            Manager(None, host_session)
+            Manager(None, mock_host_session)
 
         assert str(err.value) == (
             '__init__(): incompatible constructor arguments. The following argument types '
@@ -184,144 +177,144 @@ class Test_Manager_info:
 class Test_Manager_updateTerminology:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session):
+            self, manager, mock_manager_interface, mock_host_session):
 
         method = mock_manager_interface.mock.updateTerminology
         a_dict = {"k", "v"}
         assert manager.updateTerminology(a_dict) is a_dict
-        method.assert_called_once_with(a_dict, host_session)
+        method.assert_called_once_with(a_dict, mock_host_session)
 
 
 class Test_Manager_getSettings:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session):
+            self, manager, mock_manager_interface, mock_host_session):
 
         method = mock_manager_interface.mock.getSettings
         assert manager.getSettings() == method.return_value
-        method.assert_called_once_with(host_session)
+        method.assert_called_once_with(mock_host_session)
 
 
 class Test_Manager_setSettings:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session):
+            self, manager, mock_manager_interface, mock_host_session):
 
         method = mock_manager_interface.mock.setSettings
         a_dict = {"k", "v"}
         assert manager.setSettings(a_dict) == method.return_value
-        method.assert_called_once_with(a_dict, host_session)
+        method.assert_called_once_with(a_dict, mock_host_session)
 
 
 class Test_Manager_initialize:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session):
+            self, manager, mock_manager_interface, mock_host_session):
 
         method = mock_manager_interface.mock.initialize
         assert manager.initialize() == method.return_value
-        method.assert_called_once_with(host_session)
+        method.assert_called_once_with(mock_host_session)
 
 
 class Test_Manager_prefetch:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, some_refs, a_context):
+            self, manager, mock_manager_interface, mock_host_session, some_refs, a_context):
 
         method = mock_manager_interface.mock.prefetch
         assert manager.prefetch(some_refs, a_context) == method.return_value
-        method.assert_called_once_with(some_refs, a_context, host_session)
+        method.assert_called_once_with(some_refs, a_context, mock_host_session)
 
 
 class Test_Manager_flushCaches:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session):
+            self, manager, mock_manager_interface, mock_host_session):
 
         method = mock_manager_interface.mock.flushCaches
         assert manager.flushCaches() == method.return_value
-        method.assert_called_once_with(host_session)
+        method.assert_called_once_with(mock_host_session)
 
 
 class Test_Manager_isEntityReference:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, some_refs):
+            self, manager, mock_manager_interface, mock_host_session, some_refs):
 
         method = mock_manager_interface.mock.isEntityReference
         assert manager.isEntityReference(some_refs) == method.return_value
-        method.assert_called_once_with(some_refs, host_session)
+        method.assert_called_once_with(some_refs, mock_host_session)
 
 
 class Test_Manager_entityExists:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, some_refs, a_context):
+            self, manager, mock_manager_interface, mock_host_session, some_refs, a_context):
 
         method = mock_manager_interface.mock.entityExists
         assert manager.entityExists(some_refs, a_context) == method.return_value
-        method.assert_called_once_with(some_refs, a_context, host_session)
+        method.assert_called_once_with(some_refs, a_context, mock_host_session)
 
 
 class Test_Manager_defaultEntityReference:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, a_context,
+            self, manager, mock_manager_interface, mock_host_session, a_context,
             some_entity_trait_sets):
 
         method = mock_manager_interface.mock.defaultEntityReference
         assert manager.defaultEntityReference(some_entity_trait_sets, a_context) \
                 == method.return_value
-        method.assert_called_once_with(some_entity_trait_sets, a_context, host_session)
+        method.assert_called_once_with(some_entity_trait_sets, a_context, mock_host_session)
 
 
 class Test_Manager_entityName:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, some_refs, a_context):
+            self, manager, mock_manager_interface, mock_host_session, some_refs, a_context):
 
         method = mock_manager_interface.mock.entityName
         assert manager.entityName(some_refs, a_context) == method.return_value
-        method.assert_called_once_with(some_refs, a_context, host_session)
+        method.assert_called_once_with(some_refs, a_context, mock_host_session)
 
 
 class Test_Manager_entityDisplayNamer:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, some_refs, a_context):
+            self, manager, mock_manager_interface, mock_host_session, some_refs, a_context):
 
         method = mock_manager_interface.mock.entityDisplayName
         assert manager.entityDisplayName(some_refs, a_context) == method.return_value
-        method.assert_called_once_with(some_refs, a_context, host_session)
+        method.assert_called_once_with(some_refs, a_context, mock_host_session)
 
 
 class Test_Manager_entityVersion:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, some_refs, a_context):
+            self, manager, mock_manager_interface, mock_host_session, some_refs, a_context):
 
         method = mock_manager_interface.mock.entityVersion
         assert manager.entityVersion(some_refs, a_context) == method.return_value
-        method.assert_called_once_with(some_refs, a_context, host_session)
+        method.assert_called_once_with(some_refs, a_context, mock_host_session)
 
 
 class Test_Manager_entityVersions:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, some_refs, a_context):
+            self, manager, mock_manager_interface, mock_host_session, some_refs, a_context):
 
         method = mock_manager_interface.mock.entityVersions
 
         assert manager.entityVersions(some_refs, a_context) == method.return_value
         method.assert_called_once_with(
-            some_refs, a_context, host_session, includeMetaVersions=False, maxNumVersions=-1)
+            some_refs, a_context, mock_host_session, includeMetaVersions=False, maxNumVersions=-1)
         method.reset_mock()
 
         max_results = 5
         assert manager.entityVersions(
             some_refs, a_context, maxNumVersions=max_results) == method.return_value
         method.assert_called_once_with(
-            some_refs, a_context, host_session,
+            some_refs, a_context, mock_host_session,
             includeMetaVersions=False, maxNumVersions=max_results)
         method.reset_mock()
 
@@ -330,19 +323,19 @@ class Test_Manager_entityVersions:
             some_refs, a_context, maxNumVersions=max_results,
             includeMetaVersions=include_meta) == method.return_value
         method.assert_called_once_with(
-            some_refs, a_context, host_session, includeMetaVersions=include_meta,
+            some_refs, a_context, mock_host_session, includeMetaVersions=include_meta,
             maxNumVersions=max_results)
 
 
 class Test_Manager_finalizedEntityVersion:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, some_refs, a_context):
+            self, manager, mock_manager_interface, mock_host_session, some_refs, a_context):
 
         method = mock_manager_interface.mock.finalizedEntityVersion
         assert manager.finalizedEntityVersion(some_refs, a_context) == method.return_value
         method.assert_called_once_with(
-            some_refs, a_context, host_session, overrideVersionName=None)
+            some_refs, a_context, mock_host_session, overrideVersionName=None)
         method.reset_mock()
 
         a_version_name = "aVersion"
@@ -350,13 +343,13 @@ class Test_Manager_finalizedEntityVersion:
         assert manager.finalizedEntityVersion(
             some_refs, a_context, overrideVersionName=a_version_name) == method.return_value
         method.assert_called_once_with(
-            some_refs, a_context, host_session, overrideVersionName=a_version_name)
+            some_refs, a_context, mock_host_session, overrideVersionName=a_version_name)
 
 
 class Test_Manager_getRelatedReferences:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, a_ref, an_empty_traitsdata,
+            self, manager, mock_manager_interface, mock_host_session, a_ref, an_empty_traitsdata,
             an_entity_trait_set, a_context):
 
         # pylint: disable=too-many-locals
@@ -389,7 +382,7 @@ class Test_Manager_getRelatedReferences:
             assert manager.getRelatedReferences(
                 refs_arg, datas_arg, a_context) == method.return_value
             method.assert_called_once_with(
-                expected_refs_arg, expected_datas_arg, a_context, host_session,
+                expected_refs_arg, expected_datas_arg, a_context, mock_host_session,
                 resultTraitSet=None)
             method.reset_mock()
 
@@ -398,48 +391,51 @@ class Test_Manager_getRelatedReferences:
             one_ref, one_data, a_context, resultTraitSet=an_entity_trait_set) \
                     == method.return_value
         method.assert_called_once_with(
-            [one_ref], [one_data], a_context, host_session, resultTraitSet=an_entity_trait_set)
+            [one_ref], [one_data], a_context, mock_host_session,
+            resultTraitSet=an_entity_trait_set)
 
 
 class Test_Manager_resolve:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, some_refs, an_entity_trait_set,
-            a_context):
+            self, manager, mock_manager_interface, mock_host_session, some_refs,
+            an_entity_trait_set, a_context):
 
         method = mock_manager_interface.mock.resolve
         assert manager.resolve(some_refs, an_entity_trait_set, a_context) \
                 == method.return_value
-        method.assert_called_once_with(some_refs, an_entity_trait_set, a_context, host_session)
+        method.assert_called_once_with(some_refs, an_entity_trait_set, a_context,
+                                       mock_host_session)
 
 
 class Test_Manager_managentPolicy:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, some_entity_trait_sets,
+            self, manager, mock_manager_interface, mock_host_session, some_entity_trait_sets,
             a_context):
 
         method = mock_manager_interface.mock.managementPolicy
         assert manager.managementPolicy(some_entity_trait_sets, a_context) == method.return_value
-        method.assert_called_once_with(some_entity_trait_sets, a_context, host_session)
+        method.assert_called_once_with(some_entity_trait_sets, a_context, mock_host_session)
 
 
 class Test_Manager_preflight:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, some_refs, an_entity_trait_set,
-            a_context):
+            self, manager, mock_manager_interface, mock_host_session, some_refs,
+            an_entity_trait_set, a_context):
 
         method = mock_manager_interface.mock.preflight
         assert manager.preflight(some_refs, an_entity_trait_set, a_context) \
                 == method.return_value
-        method.assert_called_once_with(some_refs, an_entity_trait_set, a_context, host_session)
+        method.assert_called_once_with(some_refs, an_entity_trait_set, a_context,
+                                       mock_host_session)
 
 
 class Test_Manager_register:
 
     def test_wraps_the_the_held_interface_register_methods(
-            self, manager, mock_manager_interface, host_session, some_refs, a_traitsdata,
+            self, manager, mock_manager_interface, mock_host_session, some_refs, a_traitsdata,
             a_context):
 
         datas = [a_traitsdata for _ in some_refs]
@@ -450,7 +446,7 @@ class Test_Manager_register:
 
         assert manager.register(some_refs, datas, a_context) \
                 == register_method.return_value
-        register_method.assert_called_once_with(some_refs, datas, a_context, host_session)
+        register_method.assert_called_once_with(some_refs, datas, a_context, mock_host_session)
 
 
     def test_when_called_with_mixed_array_lengths_then_IndexError_is_raised(

--- a/tests/python/openassetio/hostAPI/test_manager.py
+++ b/tests/python/openassetio/hostAPI/test_manager.py
@@ -86,17 +86,16 @@ class Test_Manager_init:
 
     def test_when_constructed_with_ManagerInterface_as_None_then_raises_TypeError(
             self, mock_host_session):
-        with pytest.raises(TypeError) as err:
+
+        # Check the message is both helpful and that the bindings
+        # were loaded in the correct order such that types are
+        # described correctly.
+        matchExpr = \
+            r".+The following argument types are supported:[^(]+" \
+            r"Manager\([^,]+managerAPI.ManagerInterface,[^,]+managerAPI.HostSession.+"
+
+        with pytest.raises(TypeError, match=matchExpr):
             Manager(None, mock_host_session)
-
-        assert str(err.value) == (
-            '__init__(): incompatible constructor arguments. The following argument types '
-            'are supported:\n'
-            '    1. openassetio._openassetio.hostAPI.Manager(managerInterface: '
-            'openassetio._openassetio.managerAPI.ManagerInterface)\n'
-            '\n'
-            'Invoked with: None')
-
 
 class Test_Manager_identifier:
 

--- a/tests/python/openassetio/hostAPI/test_terminology.py
+++ b/tests/python/openassetio/hostAPI/test_terminology.py
@@ -24,7 +24,7 @@ Tests that cover the openassetio.hostAPI.terminology module.
 import pytest
 
 import openassetio.hostAPI.terminology as tgy
-from openassetio.hostAPI import Manager, Session
+from openassetio.hostAPI import Manager
 
 
 all_terminology_keys = (
@@ -73,9 +73,9 @@ class MockTerminologyManager(Manager):
 
 
 @pytest.fixture
-def mock_manager(mock_manager_interface):
+def mock_manager(mock_manager_interface, mock_host_session):
     return MockTerminologyManager(
-        mock_manager_interface, mock.create_autospec(Session))
+        mock_manager_interface, mock_host_session)
 
 
 @pytest.fixture

--- a/tests/python/openassetio/hostAPI/test_terminology.py
+++ b/tests/python/openassetio/hostAPI/test_terminology.py
@@ -21,8 +21,6 @@ Tests that cover the openassetio.hostAPI.terminology module.
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 
-from unittest import mock
-
 import pytest
 
 import openassetio.hostAPI.terminology as tgy


### PR DESCRIPTION
Closes #447, required for #445.