### PR TITLE
[Core] Split `Manager.createContext`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,11 +35,13 @@ v1.0.0-alpha.X
 - Removed `Session::createContext`.
   [#430](https://github.com/OpenAssetIO/OpenAssetIO/issues/430)
 
-- Added `createContext`, `freezeContext` and `thawContext` methods to
-  the `Manager` class to facilitate context creation and the
-  serialization of a manager's state for persistence or distribution.
+- Added `createContext`, `createChildContext`, `freezeContext` and
+  `thawContext` methods to the `Manager` class to facilitate context
+  creation and the serialization of a manager's state for persistence or
+  distribution.
   [#421](https://github.com/OpenAssetIO/OpenAssetIO/issues/421),
   [#430](https://github.com/OpenAssetIO/OpenAssetIO/issues/430)
+  [#452](https://github.com/OpenAssetIO/OpenAssetIO/issues/452)
 
 - Marked `Host` class as `final` in both Python and C++ and so it cannot
   be subclassed.

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -1172,7 +1172,7 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
         Create a state that is a child of the supplied state.
 
         This method is called whenever a child @ref Context is made by
-        @ref openassetio.hostAPI.Manager.Manager.createContext. The
+        @ref openassetio.hostAPI.Manager.Manager.createChildContext. The
         return is then stored in the newly created Context, and is
         consequently available to all the API calls in the
         ManagerInterface that take a Context instance via

--- a/src/openassetio-core/include/openassetio/Context.hpp
+++ b/src/openassetio-core/include/openassetio/Context.hpp
@@ -24,9 +24,10 @@ inline namespace OPENASSETIO_CORE_ABI_VERSION {
  *  not need to be used directly.
  *
  *  @warning Contexts should never be directly constructed. Hosts should
- *  use @ref openassetio.hostAPI.Manager.Manager.createContext. A
- *  Manager implementation should never need to create a context of it's
- *  own, one will always be supplied through the ManagerInterface entry
+ *  use @ref openassetio.hostAPI.Manager.Manager.createContext or @ref
+ *  openassetio.hostAPI.Manager.Manager.createChildContext. A Manager
+ *  implementation should never need to create a context of it's own,
+ *  one will always be supplied through the ManagerInterface entry
  *  points.
  */
 struct Context final {

--- a/src/openassetio-core/include/openassetio/managerAPI/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerAPI/ManagerInterface.hpp
@@ -88,11 +88,13 @@ namespace managerAPI {
  *
  * When a @fqref{Context} "Context" object is constructed by @ref
  * openassetio.hostAPI.Manager.Manager.createContext, the @needsref
- * createState or @needsref createChildState method will be called, and
- * the resulting state object stored in the context. This context will
- * then be re-used across related API calls to your implementation of
- * the ManagerInterface. You can use this to determine which calls may
- * be part of a specific 'action' in the same host, or logically grouped
+ * createState (or @needsref createChildState for @ref
+ * openassetio.hostAPI.Manager.Manager.createChildContext
+ * "createChildContext") method will be called, and the resulting state
+ * object stored in the context. This context will then be re-used
+ * across related API calls to your implementation of the
+ * ManagerInterface. You can use this to determine which calls may be
+ * part of a specific 'action' in the same host, or logically grouped
  * processes such as a batch render. This should allow you to implement
  * stable resolution of @ref meta_version "meta-versions" or other
  * resolve-time concepts.

--- a/tests/python/openassetio/hostAPI/test_manager.py
+++ b/tests/python/openassetio/hostAPI/test_manager.py
@@ -485,6 +485,9 @@ class Test_Manager_createContext:
         assert context_a.locale is None
         mock_manager_interface.mock.createState.assert_called_once_with(mock_host_session)
 
+
+class Test_Manager_createChildContext:
+
     def test_when_called_with_parent_then_props_copied_and_createState_called_with_parent_state(
             self, manager, mock_manager_interface, mock_host_session):
 
@@ -499,7 +502,7 @@ class Test_Manager_createContext:
         state_b = managerAPI.ManagerStateBase()
         mock_manager_interface.mock.createChildState.return_value = state_b
 
-        context_b = manager.createContext(parent=context_a)
+        context_b = manager.createChildContext(context_a)
 
         assert context_b is not context_a
         assert context_b.managerState is state_b


### PR DESCRIPTION
This commit splits context creation into two discrete methods (similar to how `createState` is split for `ManagerInterface`. Principally as it more clearly expresses intent, and simplifies language bindings as there are no longer any optional/defaulted arguments.

Closes #452