### PR TITLE
[Core] Rename context persistence methods

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -32,16 +32,23 @@ v1.0.0-alpha.X
   methods, and `TransactionCoordinator` helpers.
   [#421](https://github.com/OpenAssetIO/OpenAssetIO/issues/421)
 
-- Removed `Session::createContext`.
+- Removed the `Session` methods `createContext`, `freezeContext` and
+  `thawContext`.
   [#430](https://github.com/OpenAssetIO/OpenAssetIO/issues/430)
+  [#445](https://github.com/OpenAssetIO/OpenAssetIO/issues/445)
 
-- Added `createContext`, `createChildContext`, `freezeContext` and
-  `thawContext` methods to the `Manager` class to facilitate context
-  creation and the serialization of a manager's state for persistence or
-  distribution.
+- Added `createContext`, `createChildContext`,
+  `persistenceTokenForContext` and `contextFromPersistenceToken` methods
+  to the `Manager` class to facilitate context creation and the
+  serialization of a manager's state for persistence or distribution.
   [#421](https://github.com/OpenAssetIO/OpenAssetIO/issues/421),
   [#430](https://github.com/OpenAssetIO/OpenAssetIO/issues/430)
   [#452](https://github.com/OpenAssetIO/OpenAssetIO/issues/452)
+
+- Renamed the `ManagerInterface` methods `freezeState` and `thawState`
+  to `persistenceTokenForState` and `stateFromPersistenceToken` to
+  better describe their behavior.
+  [#452](https://github.com/OpenAssetIO/OpenAssetIO/issues/445)
 
 - Marked `Host` class as `final` in both Python and C++ and so it cannot
   be subclassed.

--- a/doc/src/Glossary.dox
+++ b/doc/src/Glossary.dox
@@ -294,8 +294,8 @@
  *
  *   @see @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.createState "ManagerInterface.createState"
  *   @see @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.createChildState "ManagerInterface.createChildState"
- *   @see @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.freezeState "ManagerInterface.freezeState"
- *   @see @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.thawState "ManagerInterface.thawState"
+ *   @see @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.persistenceTokenForState "ManagerInterface.persistenceTokenForState"
+ *   @see @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.stateFromPersistenceToken "ManagerInterface.stateFromPersistenceToken"
  *
  *
  * @section meta_version Meta-version

--- a/doc/src/ManagerState.dox
+++ b/doc/src/ManagerState.dox
@@ -66,12 +66,14 @@
  * Distributed processing requires the same context to be shared by
  * multiple discrete working processes.
  *
- * The @ref openassetio.hostAPI.Manager.Manager.freezeContext
- * "Manager.freezeContext" and @ref openassetio.hostAPI.Manager.Manager.thawContext
- * "thawContext" methods provide a mechanism by which a @ref host
- * can obtain a portable version of the manager's state token for a
- * given context for distribution to other processes that are logically
- * connected.
+ * The @ref
+ * openassetio.hostAPI.Manager.Manager.persistenceTokenForContext
+ * "Manager.persistenceTokenForContext" and @ref
+ * openassetio.hostAPI.Manager.Manager.contextFromPersistenceToken
+ * "contextFromPersistenceToken" methods provide a mechanism by which a
+ * @ref host can obtain a portable version of the manager's state token
+ * for a given context for distribution to other processes that are
+ * logically connected.
  *
  * @startuml
  * actor user
@@ -89,7 +91,7 @@
  * worker -> worker : context.access = context.kWrite
  * worker -> Manager : working_reference = preflight(["ref://asset"], context)[0]
  * Manager --> worker : "ref://asset=v4&state=inflight"
- * worker -> Manager : freezeContext(context)
+ * worker -> Manager : persistenceTokenForContext(context)
  * Manager --> worker : token
  * worker -> worker : write_state_file(token, {"ref://asset": working_entity_reference})
  * worker --> scheduler
@@ -102,7 +104,7 @@
  *     activate worker
  *     activate Manager
  *     worker -> worker : token, ref_map = read_state_file("openassetio.json")
- *     worker -> Manager : thawContext(token)
+ *     worker -> Manager : contextFromPersistenceToken(token)
  *     Manager --> worker : context
  *     worker -> worker : context.access = context.kWrite
  *     worker -> worker : working_reference = ref_map["ref://asset"]
@@ -119,7 +121,7 @@
  * activate worker
  * activate Manager
  * worker -> worker : token, ref_map = read_state_file("openassetio.json")
- * worker -> Manager : thawContext(token)
+ * worker -> Manager : contextFromPersistenceToken(token)
  * Manager --> worker : context
  * worker -> worker : context.access = context.kWrite
  * worker -> worker : working_reference = ref_map["ref://asset"]
@@ -148,7 +150,7 @@
  *
  * @section stable_resolution_manager_state_guidelines Implementation Guidelines
  *
- * - Because a thawed state may be passed to multiple child processes,
- *   the manager must be prepared for the state to be restored more than once, at
- *   the same time.
+ * - Because a state restored from a persistence token may be passed to
+ *   multiple child processes, the manager must be prepared for the
+ *   state to be restored more than once, at the same time.
  */

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -1120,8 +1120,8 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
         fails.
 
         @see @ref createChildState
-        @see @ref freezeState
-        @see @ref thawState
+        @see @ref persistenceTokenForState
+        @see @ref stateFromPersistenceToken
         """
         return None
 
@@ -1159,35 +1159,36 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
         fails.
 
         @see @ref createState
-        @see @ref freezeState
-        @see @ref thawState
+        @see @ref persistenceTokenForState
+        @see @ref stateFromPersistenceToken
         """
         return None
 
 
-    def freezeState(self, state, hostSession):
+    def persistenceTokenForState(self, state, hostSession):
         """
         Returns a string that encapsulates the current state of the
         ManagerInterface represented by the supplied state
-        object,(created by @ref createState) so that can be restored
-        later, or in another process.
+        object, (created by @ref createState or @ref createChildState)
+        so that can be restored later, or in another process.
 
         @return `str` A string that can be used to restore the stack.
 
-        @see @ref thawState
+        @see @ref stateFromPersistenceToken
         """
         return ""
 
-    def thawState(self, token, hostSession):
+    def stateFromPersistenceToken(self, token, hostSession):
         """
-        Restores the supplied state object to a previously frozen state.
+        Restores the supplied state object to a previously persisted
+        state.
 
         @return `object` A state object, as per createState(), except
         restored to the previous state encapsulated in the token, which
-        is the same string as returned by freezeState.
+        is the same string as returned by persistenceTokenForState.
 
         @exception exceptions.StateError If the supplied token is not
-        meaningful, or that a state has already been thawed.
+        meaningful, or that a state has already been restored.
         """
         return None
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -186,11 +186,11 @@ class ValidatingMockManagerInterface(ManagerInterface):
     def createChildState(self, hostSession, parentState):
         return self.mock.createChildState(hostSession, parentState)
 
-    def freezeState(self, state, hostSession):
-        return self.mock.freezeState(state, hostSession)
+    def persistenceTokenForState(self, state, hostSession):
+        return self.mock.persistenceTokenForState(state, hostSession)
 
-    def thawState(self, token, hostSession):
-        return self.mock.thawState(token, hostSession)
+    def stateFromPersistenceToken(self, token, hostSession):
+        return self.mock.stateFromPersistenceToken(token, hostSession)
 
     def identifier(self):
         return self.mock.identifier()

--- a/tests/python/openassetio/hostAPI/test_manager.py
+++ b/tests/python/openassetio/hostAPI/test_manager.py
@@ -514,37 +514,38 @@ class Test_Manager_createChildContext:
         mock_manager_interface.mock.createState.assert_not_called()
 
 
-class Test_Manager_freezeContext:
+class Test_Manager_persistenceTokenForContext:
 
-    def test_when_called_then_the_managers_frozen_token_is_returned(
+    def test_when_called_then_the_managers_persistence_token_is_returned(
              self, manager, mock_manager_interface, mock_host_session):
 
-        expected_token = "a_frozen_token"
-        mock_manager_interface.mock.freezeState.return_value = expected_token
+        expected_token = "a_persistence_token"
+        mock_manager_interface.mock.persistenceTokenForState.return_value = expected_token
 
         initial_state = managerAPI.ManagerStateBase()
         a_context = Context()
         a_context.managerState = initial_state
 
-        actual_token = manager.freezeContext(a_context)
+        actual_token = manager.persistenceTokenForContext(a_context)
 
         assert actual_token == expected_token
 
-        mock_manager_interface.mock.freezeState.assert_called_once_with(
+        mock_manager_interface.mock.persistenceTokenForState.assert_called_once_with(
             initial_state, mock_host_session)
 
 
-class Test_Manager_thawContext:
+class Test_Manager_contextFromPersistenceToken:
 
-    def test_when_called_then_the_managers_thawed_state_is_set_in_the_context(
+    def test_when_called_then_the_managers_restored_state_is_set_in_the_context(
              self, manager, mock_manager_interface, mock_host_session):
 
         expected_state = managerAPI.ManagerStateBase()
-        mock_manager_interface.mock.thawState.return_value = expected_state
+        mock_manager_interface.mock.stateFromPersistenceToken.return_value = expected_state
 
-        a_token = "frozen_token"
-        a_context = manager.thawContext(a_token)
+        a_token = "a_persistence_token"
+        a_context = manager.contextFromPersistenceToken(a_token)
 
         assert a_context.managerState is expected_state
 
-        mock_manager_interface.mock.thawState.assert_called_once_with(a_token, mock_host_session)
+        mock_manager_interface.mock.stateFromPersistenceToken.assert_called_once_with(
+                a_token, mock_host_session)


### PR DESCRIPTION
Part of #445, renames the various `freeze` and `thaw` methods.