### PR TITLE
[Examples] Support custom `managementPolicy` responses in BAL

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -138,6 +138,11 @@ v1.0.0-alpha.X
 - Updated the Ubuntu bootstrap script to ensure `clang-format` and
   `clang-tidy` use the v12 alternatives.
 
+- Added support for customisable `managementPolicy` responses to
+  the `BasicAssetLibrary` example/test manager. See:
+    `resources/examples/manager/BasicAssetLibrary/schema.json`
+  [#459](https://github.com/OpenAssetIO/OpenAssetIO/issues/459)
+
 
 ### Bug fixes
 

--- a/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
+++ b/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
@@ -89,8 +89,9 @@ class BasicAssetLibraryInterface(ManagerInterface):
 
     def managementPolicy(self, traitSets, context, hostSession):
         # pylint: disable=unused-argument
-        policy = constants.kManaged if context.isForRead() else constants.kIgnored
-        return [policy for _ in traitSets]
+        if not context.isForRead():
+            return [constants.kIgnored for _ in traitSets]
+        return [bal.managementPolicy(trait_set, self.__library) for trait_set in traitSets]
 
     def isEntityReference(self, tokens, hostSession):
         # pylint: disable=unused-argument

--- a/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/bal.py
+++ b/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/bal.py
@@ -30,6 +30,7 @@ from collections import namedtuple
 from urllib.parse import urlparse
 
 
+from openassetio import constants
 from openassetio.exceptions import InvalidEntityReference
 
 
@@ -96,3 +97,21 @@ def entity(entity_info: EntityInfo, library: dict) -> Entity:
     Retrieves the Entity data addressed by the supplied EntityInfo
     """
     return Entity(**library["entities"][entity_info.name]["versions"][-1])
+
+
+def managementPolicy(trait_set: set[str], library: dict) -> int:
+    """
+    Retrieves the management policy for the supplied trait set. The
+    default will be used unless an alternate default or trait set
+    specific exception is provided in the library.
+    """
+    read_policies = library.get("managementPolicy", {}).get("read", {})
+    exceptions = read_policies.get("exceptions", [])
+    matching_policies = [e["policy"] for e in exceptions if set(e["traitSet"]) == trait_set]
+
+    # By default, cooperatively manager all trait sets, unless the
+    # library tells us otherwise.
+    policy = read_policies.get("default", constants.kManaged)
+    if matching_policies:
+        policy = matching_policies[0]
+    return policy

--- a/resources/examples/manager/BasicAssetLibrary/schema.json
+++ b/resources/examples/manager/BasicAssetLibrary/schema.json
@@ -5,6 +5,49 @@
   "description": "The data store that backs an instance of the BAL manager",
   "type": "object",
   "properties": {
+    "managementPolicy": {
+      "description": "Custom managementPolicy responses",
+      "type": "object",
+      "properties": {
+        "read": {
+          "type": "object",
+          "description": "Custom managementPolicy responses for read access contexts",
+          "properties": {
+            "default": {
+              "description": "The default policy unless an exception is specified",
+              "type": "integer",
+              "minimum": 0
+            },
+            "exceptions": {
+              "descriptions": "Custom policies that override the default",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "description": "A policy for a specific trait set, that must match the request exactly",
+                "properties": {
+                  "traitSet": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "policy": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["traitSet", "policy"]
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "additionalProperties": false
+      }
+    },
     "entities": {
       "description": "The entities in the library, they key is used as the entity name.",
       "type": "object",

--- a/resources/examples/manager/BasicAssetLibrary/tests/resources/library_business_logic_suite_customManagementPolicy.json
+++ b/resources/examples/manager/BasicAssetLibrary/tests/resources/library_business_logic_suite_customManagementPolicy.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenAssetIO/OpenAssetIO/main/resources/examples/manager/BasicAssetLibrary/schema.json",
+  "managementPolicy": {
+    "read": {
+      "default": 4,
+      "exceptions": [
+        {
+          "traitSet": ["an", "ignored", "trait", "set"],
+          "policy": 0
+        },
+        {
+            "traitSet": ["a", "non", "exclusive", "trait", "set"],
+            "policy": 1
+        }
+      ]
+    }
+  },
+  "entities": {}
+}


### PR DESCRIPTION
Adds the ability to customize the `managementPolicy` response returned by BAL. Amended defaults, or trait set specific policies can be supplied using new keys in the library JSON file.

We decided to keep-it-simple for now, and just have the JSON hold the raw policy value. Its a little opaque, but we can revisit this when we have more use cases.

NB: This also follows the "BAL style" of "slightly rough and ready programming".

Closes #459