### PR TITLE
[CI] Temporarily disable macOS CI due to pybind issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,9 @@ jobs:
         - os: windows-2019
           vcvars: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat"
         - os: ubuntu-20.04
-        - os: macos-10.15
+        # Temporarily disabling macOS CI due to pybind issue, see:
+        #   https://github.com/conan-io/conan-center-index/pull/11075
+        # - os: macos-10.15
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
`pybind` is no longer available for mac in conan center.

See:
  https://github.com/conan-io/conan-center-index/pull/11075
  https://github.com/pybind/pybind11/issues/3081
