### PR TITLE
[Docs] Conform use of `fqref`

### DIFF
--- a/doc/src/EntitiesTraitsSpecifications.dox
+++ b/doc/src/EntitiesTraitsSpecifications.dox
@@ -221,7 +221,7 @@
  * @subsection locale_specifications Locale Specifications
  *
  * Specifications only ever intended for use in the
- * @fqref{Context::locale} "Context.locale" (to describe
+ * @fqref{Context.locale} "Context.locale" (to describe
  * which part of a host or application is calling the API) are known as
  * "locale specifications".
  *

--- a/doc/src/Examples.dox
+++ b/doc/src/Examples.dox
@@ -20,7 +20,7 @@
  * discover available @ref ManagerPlugin "ManagerPlugins".
  *
  * It also includes a bare-minimum example of a
- * @fqref{hostAPI::HostInterface} "HostInterface" implementation.
+ * @fqref{hostAPI.HostInterface} "HostInterface" implementation.
  *
  * @code{.py}
  * from openassetio.log import ConsoleLogger, SeverityFilter
@@ -109,8 +109,8 @@
  *
  * The API middleware provides assorted short-circuit validation
  * optimisations that can reduce the number of inter-language hops
- * required. See @fqref{managerAPI::ManagerInterface::info}
- * "ManagerInterface::info" and the `kField_EntityReferencesMatchPrefix`
+ * required. See @fqref{managerAPI.ManagerInterface.info}
+ * "ManagerInterface.info" and the `kField_EntityReferencesMatchPrefix`
  * key.
  *
  * @code{.py}

--- a/doc/src/ForHosts.dox
+++ b/doc/src/ForHosts.dox
@@ -26,7 +26,7 @@
  *
  * - The specific implementation of the @ref HostInterface class
  *   provided by a host when starting a @ref session is wrapped in the
- *   @fqref{managerAPI::Host} "Host" class before being
+ *   @fqref{managerAPI.Host} "Host" class before being
  *   exposed to the manager. This is to allow for assorted middleware
  *   auditing/logging functionality, and provide a degree of isolation
  *   against future API changes.
@@ -71,15 +71,15 @@
  *
  * @subsection host_todo_required_resolution Required for Simple Resolution
  *
- * - Implement the @fqref{hostAPI::HostInterface} "HostInterface" class
+ * - Implement the @fqref{hostAPI.HostInterface} "HostInterface" class
  *   methods:
- *   @fqref{hostAPI::HostInterface::identifier} "identifier" and
- *   @fqref{hostAPI::HostInterface::displayName} "displayName".
+ *   @fqref{hostAPI.HostInterface.identifier} "identifier" and
+ *   @fqref{hostAPI.HostInterface.displayName} "displayName".
  *
  * - Create a @ref openassetio.hostAPI.Session to bootstrap the API,
  *   provide the following objects:
  *    - An instance of the custom class derived from
- *      @fqref{hostAPI::HostInterface} "HostInterface".
+ *      @fqref{hostAPI.HostInterface} "HostInterface".
  *    - A `logger` (derived from
  *      @ref openassetio.log.LoggerInterface "LoggerInterface"), for
  *      simple console logging you can use a

--- a/doc/src/ForManagers.dox
+++ b/doc/src/ForManagers.dox
@@ -81,7 +81,7 @@
  *   implement @fqref{managerAPI.ManagerInterface.createState}
  *   "createState", and return some token that can be used as an anchor.
  *   A new token will be requested each time a @ref Context is made, and
- *   will then be available via @fqref{Context::managerState}
+ *   will then be available via @fqref{Context.managerState}
  *   "Context.managerState" in any call that receives a context. Hosts
  *   will take care of managing the lifetime of any given Context in
  *   terms that are meaningful for the user. Eg. the state token will be
@@ -105,8 +105,8 @@
  *
  * - Implement the @ref openassetio.managerAPI.ManagerInterface
  *   "ManagerInterface" class methods
- *   @fqref{managerAPI::ManagerInterface::identifier} "identifier" an
- *   @fqref{managerAPI::ManagerInterface::displayName} "displayName".
+ *   @fqref{managerAPI.ManagerInterface.identifier} "identifier" an
+ *   @fqref{managerAPI.ManagerInterface.displayName} "displayName".
  *
  * - Implement @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.managementPolicy
  *   "managementPolicy" to control which Host-side data types you wish to be

--- a/doc/src/Glossary.dox
+++ b/doc/src/Glossary.dox
@@ -192,7 +192,7 @@
  *
  * @section HostInterface
  *
- * The @fqref{hostAPI::HostInterface} "HostInterface" class is the
+ * The @fqref{hostAPI.HostInterface} "HostInterface" class is the
  * abstract interface that any @ref host must implement in order to
  * initialize the API. It will usually contain logic to map native
  * features of the host into the well-known terms defined by this API.
@@ -209,7 +209,7 @@
  * Within OpenAssetIO, the term "locale" is used to define which part of
  * a @ref host "host's" implementation is making a particular call to
  * the API. A suitably configured @fqref{TraitsData} "TraitsData"
- * instance is supplied through the @fqref{Context::locale}
+ * instance is supplied through the @fqref{Context.locale}
  * "locale" property of the @fqref{Context} "Context", which is in turn
  * supplied to most @ref ManagerInterface method calls.
  *

--- a/doc/src/MainPage.dox
+++ b/doc/src/MainPage.dox
@@ -170,7 +170,7 @@
  *
  * The first step in any integration is to write an implementation of
  * one of the two abstract interfaces defined by the API, illustrated in
- * orange above - either the @fqref{hostAPI::HostInterface}
+ * orange above - either the @fqref{hostAPI.HostInterface}
  * "HostInterface" or @ref
  * openassetio.managerAPI.ManagerInterface.ManagerInterface
  * "ManagerInterface".
@@ -180,13 +180,13 @@
  *   "ManagerInterface". This is a stateless, re-entrant interface that is
  *   the sole entry point for all interactions with the host.
  *
- * - The @fqref{hostAPI::HostInterface} "HostInterface" represents the
+ * - The @fqref{hostAPI.HostInterface} "HostInterface" represents the
  *   caller of the API. It allows the asset management system to
  *   customize the @ref publish "publishing" process if desired and/or
  *   query additional information about the host.
  *
  * The interface implementations are "wrapped" in the
- * @fqref{managerAPI::Host} "Host" or
+ * @fqref{managerAPI.Host} "Host" or
  * @ref openassetio.hostAPI.Manager.Manager "Manager" classes by the
  * API before being passed to the other side, to provide state
  * management and audit functionality.

--- a/doc/src/ManagerState.dox
+++ b/doc/src/ManagerState.dox
@@ -37,7 +37,7 @@
  * "ManagerInterface.createState" (or
  * @fqref{managerAPI.ManagerInterface.createChildState}
  * "ManagerInterface.createChildState") method will be called, and the
- * returned token stored in the Context's @fqref{Context::managerState}
+ * returned token stored in the Context's @fqref{Context.managerState}
  * "managerState" property.
  *
  * @startuml

--- a/doc/src/Testing.dox
+++ b/doc/src/Testing.dox
@@ -28,7 +28,7 @@
  * values to pass to methods such as
  * @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.isEntityReference
  * "isEntityReference", and the expected values from methods such as
- * @fqref{managerAPI::ManagerInterface::identifier} "identifier"
+ * @fqref{managerAPI.ManagerInterface.identifier} "identifier"
  *
  * The file should set a top level variable called `fixtures`, holding
  * a dict structured as-per the `fixtures` parameter documented

--- a/python/openassetio/Trait.py
+++ b/python/openassetio/Trait.py
@@ -41,8 +41,8 @@ class Trait:
 
     In addition, the derived class should implement appropriate typed
     accessor / mutator methods that internally call the wrapped
-    data's @fqref{TraitsData::getTraitProperty}
-    "getTraitProperty" / @fqref{TraitsData::setTraitProperty}
+    data's @fqref{TraitsData.getTraitProperty}
+    "getTraitProperty" / @fqref{TraitsData.setTraitProperty}
     "setTraitProperty".
 
     @note Attempting to access a trait's properties without first

--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -234,7 +234,7 @@ class Manager(_openassetio.hostAPI.Manager, Debuggable):
         write context) all of the supplied traits through @needsref
         resolve and @ref register.
 
-        @warning The @fqref{Context::access} "access" of the supplied
+        @warning The @fqref{Context.access} "access" of the supplied
         context will be considered by the manager. If it is set to read,
         then it's response applies to resolution. If write, then it
         applies to publishing. Ignored reads can allow optimisations in
@@ -870,7 +870,7 @@ class Manager(_openassetio.hostAPI.Manager, Debuggable):
         temporary working path or some such.
 
         @note It's vital that the @ref Context is well configured here,
-        in particular the @fqref{Context::retention}
+        in particular the @fqref{Context.retention}
         "Context.retention".
 
         @warning The working @ref entity_reference returned by this

--- a/python/openassetio/hostAPI/ManagerFactoryInterface.py
+++ b/python/openassetio/hostAPI/ManagerFactoryInterface.py
@@ -58,8 +58,8 @@ class ManagerFactoryInterface(object, metaclass=abc.ABCMeta):
             use.
             @li **identifier** It's identifier
             @li **info** The info dict from the Manager (see:
-            @fqref{managerAPI::ManagerInterface::info}
-            "ManagerInterface::info")
+            @fqref{managerAPI.ManagerInterface.info}
+            "ManagerInterface.info")
             @li **plugin** The plugin class that represents the Manager
             (see: @ref openassetio.pluginSystem.ManagerPlugin "ManagerPlugin")
         """

--- a/python/openassetio/hostAPI/Session.py
+++ b/python/openassetio/hostAPI/Session.py
@@ -61,7 +61,7 @@ class Session(Debuggable):
     def __init__(self, hostInterface, logger, managerFactory):
         # pylint: disable=line-too-long
         """
-        @param hostInterface \fqref{hostAPI::HostInterface} The current
+        @param hostInterface \fqref{hostAPI.HostInterface} The current
         HostInterface instance (note: only a single currently active
         HostInterface is supported, so if multiple sessions are created,
         they should all use the same HostInterface instance).

--- a/python/openassetio/hostAPI/__init__.py
+++ b/python/openassetio/hostAPI/__init__.py
@@ -28,5 +28,5 @@ from .Manager import Manager
 from .ManagerFactoryInterface import ManagerFactoryInterface
 from .Session import Session
 
-## Python binding of \fqref{hostAPI::HostInterface} "C++ HostInterface".
+## Python binding of \fqref{hostAPI.HostInterface} "C++ HostInterface".
 HostInterface = _openassetio.hostAPI.HostInterface

--- a/python/openassetio/managerAPI/HostSession.py
+++ b/python/openassetio/managerAPI/HostSession.py
@@ -35,7 +35,7 @@ class HostSession(_openassetio.managerAPI.HostSession):
     directly constructed, cached or otherwise persisted by a Manager.
 
     The HostSession provides access to:
-      - A concrete instance of the @fqref{hostAPI::HostInterface}
+      - A concrete instance of the @fqref{hostAPI.HostInterface}
         "HostInterface", implemented by the tool or
         application that initiated the API session.
       - A logging callback. All user-facing messaging should be directed
@@ -43,7 +43,7 @@ class HostSession(_openassetio.managerAPI.HostSession):
         presented to the user.
 
     @see @ref log
-    @see @fqref{hostAPI::HostInterface} "HostInterface"
+    @see @fqref{hostAPI.HostInterface} "HostInterface"
     """
     kDebugAPI = LoggerInterface.kDebugAPI
     kDebug = LoggerInterface.kDebug

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -274,7 +274,7 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
         files, and not involve the manager in any actions realting to
         scene files.
 
-        @warning The @fqref{Context::access} "access"
+        @warning The @fqref{Context.access} "access"
         specified in the supplied context should be carefully considered.
         A host will independently query the policy for both read and
         write access to determine if resolution and publishing features
@@ -990,7 +990,7 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
         host should retry from the beginning of any given process.
 
         @note it is important for the implementation to pay attention
-        to @fqref{Context::retention} "Context.retention", as not all
+        to @fqref{Context.retention} "Context.retention", as not all
         hosts will support the reference changing at this point.
 
         @see @ref register
@@ -1063,7 +1063,7 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
         host should retry from the beginning of any given process.
 
         @note it is important for the implementation to pay attention to
-        @fqref{Context::retention} "retention", as not all Hosts will
+        @fqref{Context.retention} "retention", as not all Hosts will
         support the reference changing at this point.
 
         @see @fqref{TraitsData} "TraitsData"

--- a/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
+++ b/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
@@ -96,8 +96,8 @@ class PluginSystemManagerFactory(ManagerFactoryInterface):
           use.
           @li **identifier** It's identifier
           @li **info** The info dict from the Manager (see:
-          @fqref{managerAPI::ManagerInterface::info}
-          "ManagerInterface::info")
+          @fqref{managerAPI.ManagerInterface.info}
+          "ManagerInterface.info")
           @li **plugin** The plugin class that represents the Manager
           (see: @ref openassetio.pluginSystem.ManagerPlugin
           "ManagerPlugin")

--- a/python/openassetio/test/manager/_implementation.py
+++ b/python/openassetio/test/manager/_implementation.py
@@ -164,7 +164,7 @@ class _ValidatorTestLoader(unittest.loader.TestLoader):
 
 class _ValidatorHarnessHostInterface(hostAPI.HostInterface):
     """
-    Minimal required OpenAssetIO \fqref{hostAPI::HostInterface}
+    Minimal required OpenAssetIO \fqref{hostAPI.HostInterface}
     "HostInterface" implementation.
 
     @private

--- a/src/openassetio-core-c/include/openassetio/c/hostAPI/Manager.h
+++ b/src/openassetio-core-c/include/openassetio/c/hostAPI/Manager.h
@@ -23,7 +23,7 @@ extern "C" {
 /**
  * @defgroup oa_hostAPI_Manager oa_hostAPI_Manager
  *
- * C API for the \fqref{hostAPI::Manager} "hostAPI::Manager C++ type".
+ * C API for the \fqref{hostAPI.Manager} "hostAPI::Manager C++ type".
  *
  * @{
  */
@@ -45,7 +45,7 @@ extern "C" {
 // oa_hostAPI_Manager_aliases
 
 /**
- * Opaque handle type representing a \fqref{hostAPI::Manager} "Manager".
+ * Opaque handle type representing a \fqref{hostAPI.Manager} "Manager".
  */
 // NOLINTNEXTLINE(modernize-use-using)
 typedef struct oa_hostAPI_Manager_t* oa_hostAPI_Manager_h;
@@ -53,16 +53,16 @@ typedef struct oa_hostAPI_Manager_t* oa_hostAPI_Manager_h;
 /**
  * Constructor function.
  *
- * Allocates a new \fqref{hostAPI::Manager} "Manager", which should be
+ * Allocates a new \fqref{hostAPI.Manager} "Manager", which should be
  * deallocated by \fqcref{hostAPI_Manager_dtor} "dtor" when the
  * `Manager` is no longer in use.
  *
  * @param[out] err Storage for error message, if any.
  * @param[out] handle
  * @param managerInterfaceHandle  A handle to a
- * \fqref{managerAPI::ManagerInterface} that the `Manager` will delegate
+ * \fqref{managerAPI.ManagerInterface} that the `Manager` will delegate
  * @param hostSessionHandle  A handle to a
- * \fqref{managerAPI::HostSession} that the `Manager` will supply to the
+ * \fqref{managerAPI.HostSession} that the `Manager` will supply to the
  * held interface as required.
  * to.
  *
@@ -83,7 +83,7 @@ oa_hostAPI_Manager_ctor(oa_StringView* err, oa_hostAPI_Manager_h* handle,
 /**
  * Destructor function.
  *
- * Deallocates a \fqref{hostAPI::Manager} "Manager" that was previously
+ * Deallocates a \fqref{hostAPI.Manager} "Manager" that was previously
  * created using \fqcref{hostAPI_Manager_ctor}. The handle should not
  * be used after calling this function.
  */
@@ -91,7 +91,7 @@ OPENASSETIO_CORE_C_EXPORT void oa_hostAPI_Manager_dtor(oa_hostAPI_Manager_h hand
 
 /**
  * C equivalent of the
- * @fqref{hostAPI::Manager::identifier} "identifier"
+ * @fqref{hostAPI.Manager.identifier} "identifier"
  * member function.
  *
  * @param[out] err Storage for error message, if any.
@@ -107,7 +107,7 @@ OPENASSETIO_CORE_C_EXPORT oa_ErrorCode oa_hostAPI_Manager_identifier(oa_StringVi
 
 /**
  * C equivalent of the
- * @fqref{hostAPI::Manager::displayName} "displayName"
+ * @fqref{hostAPI.Manager.displayName} "displayName"
  * member function.
  *
  * @param[out] err Storage for error message, if any.
@@ -124,7 +124,7 @@ OPENASSETIO_CORE_C_EXPORT oa_ErrorCode oa_hostAPI_Manager_displayName(oa_StringV
 
 /**
  * C equivalent of the
- * @fqref{hostAPI::Manager::info} "info"
+ * @fqref{hostAPI.Manager.info} "info"
  * member function.
  *
  * @param[out] err Storage for error message, if any.

--- a/src/openassetio-core-c/include/openassetio/c/managerAPI/CManagerInterface.h
+++ b/src/openassetio-core-c/include/openassetio/c/managerAPI/CManagerInterface.h
@@ -19,7 +19,7 @@ extern "C" {
  * @defgroup oa_managerAPI_CManagerInterface oa_managerAPI_CManagerInterface
  *
  * C API that C plugins must implement to satisfy the
- * \fqref{managerAPI::ManagerInterface} "ManagerInterface" contract.
+ * \fqref{managerAPI.ManagerInterface} "ManagerInterface" contract.
  *
  * @{
  */
@@ -38,7 +38,7 @@ extern "C" {
 
 /**
  * Opaque handle type provided by @ref manager plugins that provide
- * their @fqref{managerAPI::ManagerInterface} "ManagerInterface"
+ * their @fqref{managerAPI.ManagerInterface} "ManagerInterface"
  * implementation via the C API plugin system.
  *
  * The associated @fqcref{managerAPI_CManagerInterface_s}
@@ -56,13 +56,13 @@ typedef struct oa_managerAPI_CManagerInterface_t* oa_managerAPI_CManagerInterfac
 
 /**
  * Function pointer suite provided by @ref manager plugins that provide
- * the @fqref{managerAPI::ManagerInterface} "ManagerInterface"
+ * the @fqref{managerAPI.ManagerInterface} "ManagerInterface"
  * implementation via the C API plugin system.
  *
  * Instances of this suite are provided by a @ref manager C plugin.
  *
  * The function pointers correspond to member functions of the
- * @fqref{managerAPI::ManagerInterface} "ManagerInterface" C++ class,
+ * @fqref{managerAPI.ManagerInterface} "ManagerInterface" C++ class,
  * and are expected to provide the same functionality but as a
  * C-friendly API.
  *
@@ -88,7 +88,7 @@ typedef struct {
 
   /**
    * C equivalent of the
-   * @fqref{managerAPI::ManagerInterface::identifier} "identifier"
+   * @fqref{managerAPI.ManagerInterface.identifier} "identifier"
    * member function.
    *
    * @param[out] err Storage for error message, if any.
@@ -103,7 +103,7 @@ typedef struct {
 
   /**
    * C equivalent of the
-   * @fqref{managerAPI::ManagerInterface::displayName} "displayName"
+   * @fqref{managerAPI.ManagerInterface.displayName} "displayName"
    * member function.
    *
    * @param[out] err Storage for error message, if any.
@@ -119,7 +119,7 @@ typedef struct {
 
   /**
    * C equivalent of the
-   * @fqref{managerAPI::ManagerInterface::info} "info"
+   * @fqref{managerAPI.ManagerInterface.info} "info"
    * member function.
    *
    * @param[out] err Storage for error message, if any.

--- a/src/openassetio-core-c/include/openassetio/c/managerAPI/HostSession.h
+++ b/src/openassetio-core-c/include/openassetio/c/managerAPI/HostSession.h
@@ -15,7 +15,7 @@ extern "C" {
 /**
  * @defgroup oa_managerAPI_SharedHostSession oa_managerAPI_SharedHostSession
  *
- * C API for the \fqref{managerAPI::HostSession}
+ * C API for the \fqref{managerAPI.HostSession}
  * "managerAPI::HostSession C++ type".
  *
  * @{
@@ -35,7 +35,7 @@ extern "C" {
 // oa_managerAPI_SharedHostSession_aliases
 
 /**
- * Opaque handle type representing a @fqref{managerAPI::HostSession}
+ * Opaque handle type representing a @fqref{managerAPI.HostSession}
  * "HostSession" instance.
  */
 // NOLINTNEXTLINE(modernize-use-using)

--- a/src/openassetio-core-c/include/openassetio/c/managerAPI/ManagerInterface.h
+++ b/src/openassetio-core-c/include/openassetio/c/managerAPI/ManagerInterface.h
@@ -15,7 +15,7 @@ extern "C" {
 /**
  * @defgroup oa_managerAPI_SharedManagerInterface oa_managerAPI_SharedManagerInterface
  *
- * C API for the \fqref{managerAPI::ManagerInterface}
+ * C API for the \fqref{managerAPI.ManagerInterface}
  * "managerAPI::ManagerInterface C++ type".
  *
  * @{
@@ -33,7 +33,7 @@ extern "C" {
 // oa_managerAPI_SharedManagerInterface_aliases
 
 /**
- * Opaque handle type representing a @fqref{managerAPI::ManagerInterface}
+ * Opaque handle type representing a @fqref{managerAPI.ManagerInterface}
  * "ManagerInterface" instance.
  */
 // NOLINTNEXTLINE(modernize-use-using)

--- a/src/openassetio-core/include/openassetio/InfoDictionary.hpp
+++ b/src/openassetio-core/include/openassetio/InfoDictionary.hpp
@@ -13,8 +13,8 @@ inline namespace OPENASSETIO_CORE_ABI_VERSION {
 /// Types available as values in a InfoDictionary.
 using InfoDictionaryValue = std::variant<Bool, Int, Float, Str>;
 /**
- * Dictionary type used for @fqref{managerAPI::ManagerInterface::info}
- * "ManagerInterface::info".
+ * Dictionary type used for @fqref{managerAPI.ManagerInterface.info}
+ * "ManagerInterface.info".
  */
 using InfoDictionary = std::unordered_map<Str, InfoDictionaryValue>;
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-core/include/openassetio/managerAPI/Host.hpp
+++ b/src/openassetio-core/include/openassetio/managerAPI/Host.hpp
@@ -22,7 +22,7 @@ namespace managerAPI {
  * Hosts should never be directly constructed by the Manager's
  * implementation. Instead, the @ref managerAPI.HostSession class
  * provided to all manager API entry points provides access to the
- * current host through the @fqref{managerAPI::HostSession::host}
+ * current host through the @fqref{managerAPI.HostSession.host}
  * "HostSession.host" method
  *
  * @todo Add auditing functionality.

--- a/src/openassetio-core/include/openassetio/managerAPI/HostSession.hpp
+++ b/src/openassetio-core/include/openassetio/managerAPI/HostSession.hpp
@@ -20,11 +20,11 @@ namespace managerAPI {
  * directly constructed, cached or otherwise persisted by a Manager.
  *
  * The HostSession provides access to:
- *   - A concrete instance of the @fqref{managerAPI::Host} "Host",
+ *   - A concrete instance of the @fqref{managerAPI.Host} "Host",
  *     implemented by the tool or application that initiated the API
  *     session.
  *
- * @see @fqref{managerAPI::Host} "Host"
+ * @see @fqref{managerAPI.Host} "Host"
  *
  * @todo Expose logging mechanism through HostSession
  */

--- a/src/openassetio-core/include/openassetio/managerAPI/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerAPI/ManagerInterface.hpp
@@ -312,7 +312,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * @fqref{hostAPI.Manager.createContext} "createContext". The return
    * is then stored in the newly created Context, and is consequently
    * available to all the API calls in the ManagerInterface that take a
-   * Context instance via @fqref{Context::managerState} "managerState".
+   * Context instance via @fqref{Context.managerState} "managerState".
    * Your implementation can then use this to anchor the api call to a
    * particular snapshot of the state of the asset inventory.
    *
@@ -346,7 +346,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * @fqref{hostAPI.Manager.createChildContext} "createChildContext".
    * The return is then stored in the newly created Context, and is
    * consequently available to all the API calls in the ManagerInterface
-   * that take a Context instance via @fqref{Context::managerState}
+   * that take a Context instance via @fqref{Context.managerState}
    * "managerState". Your implementation can then use this to anchor the
    * api call to a particular snapshot of the state of the asset
    * inventory.


### PR DESCRIPTION
We had a mix of . and :: use when invoking the custom Doxygen command 'fqref.' Both work, but we elected to use . as the documentation is used for multiple languages.

Closes #472