### PR TITLE
[Core] Add and use forward declaration macros

### DIFF
--- a/contributing/CODING_STANDARDS.md
+++ b/contributing/CODING_STANDARDS.md
@@ -52,18 +52,64 @@ and consistency trade-offs.
 
 ### Classes
 
+#### Smart pointers
+
 C++ classes that represent system components with reference semantics
 (as opposed to 'value' types) should inherit
 `std::enable_shared_from_this` and define a peer `Ptr` alias using
 `std::shared_ptr`.
 
-```cpp
-class MyClass : std::enable_shared_from_this<MyClass> { ... };
-using MyClassPtr = std::shared_ptr<MyClass>;
-```
-
 This is to simplify memory management across the complex range of
 language bindings within the project.
+
+There is a convenience macro `OPENASSETIO_DECLARE_PTR` available in
+`typedefs.hpp` that should be used to declare the `shared_ptr`. A macro
+gives us a single point of change should we wish to alter or add more
+declarations.
+
+Usage example:
+
+```cpp
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace managerApi {
+
+OPENASSETIO_DECLARE_PTR(Host)
+
+class OPENASSETIO_CORE_EXPORT Host final {
+...
+```
+
+#### Forward declarations
+
+To decrease coupling and improve compile times it is idiomatic in C++ to
+forward declare classes when the full definition is not yet required, so
+that `#include`ing the class's associated header can be deferred until
+needed (typically within the `.cpp` source file).
+
+There is a convenience macro `OPENASSETIO_FWD_DECLARE` in `typedefs.hpp`
+that should be used to forward declare classes. The macro wraps the
+class declaration in the appropriate top-level namespaces, plus
+optionally a child namespace (depending on whether one or two arguments
+are provided). Hence the macro should be used _outside_ of any other
+namespace.
+
+Usage example:
+
+```cpp
+#include <openassetio/typedefs.hpp>
+
+OPENASSETIO_FWD_DECLARE(hostApi, HostInterface)
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+...
+```
+
+> **Warning**: The Windows MSVC compiler mangles `struct` and `class`
+> declarations differently in the compiled binary. Since the above
+> macro forward declares using `class`, we must avoid using `struct`
+> to define classes or we risk linker errors on Windows.
 
 ## C
 

--- a/resources/perftest/perftest.cpp
+++ b/resources/perftest/perftest.cpp
@@ -1,14 +1,15 @@
-#include <algorithm>
 #include <chrono>
 #include <functional>
 #include <iostream>
+#include <numeric>
 #include <random>
 #include <string>
 #include <unordered_map>
-#include <numeric>
 
 #include <openassetio/Context.hpp>
 #include <openassetio/TraitsData.hpp>
+#include <openassetio/hostApi/HostInterface.hpp>
+#include <openassetio/managerApi/Host.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 
 #include "lib.hpp"
@@ -381,7 +382,7 @@ struct Benchmarker {
     // Summary statistics.
 
     std::cout << "\n";
-    std::cout <<"numerator/denominator, mean, std dev\n";
+    std::cout << "numerator/denominator, mean, std dev\n";
 
     for (Idx ratioIdx = 0; ratioIdx < kRatioPairs.size(); ++ratioIdx) {
       std::cout << kCases[kRatioPairs[ratioIdx].first].name << "/"

--- a/src/openassetio-core/hostApi/Manager.cpp
+++ b/src/openassetio-core/hostApi/Manager.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <openassetio/Context.hpp>
 #include <openassetio/hostApi/Manager.hpp>
+#include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/typedefs.hpp>
 

--- a/src/openassetio-core/include/openassetio/Context.hpp
+++ b/src/openassetio-core/include/openassetio/Context.hpp
@@ -6,12 +6,15 @@
 #include <memory>
 
 #include <openassetio/export.h>
-#include <openassetio/TraitsData.hpp>
-#include <openassetio/managerApi/ManagerStateBase.hpp>
 #include <openassetio/typedefs.hpp>
+
+OPENASSETIO_FWD_DECLARE(TraitsData)
+OPENASSETIO_FWD_DECLARE(managerApi, ManagerStateBase)
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
+OPENASSETIO_DECLARE_PTR(Context)
+
 /**
  *  The Context object is used to convey information about the calling
  *  environment to a @ref manager. It encapsulates several key access
@@ -153,7 +156,5 @@ class Context final {
     return access == kReadMultiple || access == kWriteMultiple;
   }
 };
-
-using ContextPtr = std::shared_ptr<Context>;
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/Context.hpp
+++ b/src/openassetio-core/include/openassetio/Context.hpp
@@ -31,7 +31,8 @@ inline namespace OPENASSETIO_CORE_ABI_VERSION {
  *  own, one will always be supplied through the ManagerInterface entry
  *  points.
  */
-struct Context final {
+class Context final {
+ public:
   /**
    * Storage for enum name lookup array.
    */

--- a/src/openassetio-core/include/openassetio/TraitsData.hpp
+++ b/src/openassetio-core/include/openassetio/TraitsData.hpp
@@ -15,6 +15,8 @@
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
+OPENASSETIO_DECLARE_PTR(TraitsData)
+
 /**
  * A transport-level container for data exchange between a @ref host and
  * a @ref manager.
@@ -166,8 +168,5 @@ class OPENASSETIO_CORE_EXPORT TraitsData final {
   class Impl;
   std::unique_ptr<Impl> impl_;
 };
-
-/// Ref-counted smart pointer to underlying TraitsData.
-using TraitsDataPtr = std::shared_ptr<TraitsData>;
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/hostApi/HostInterface.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/HostInterface.hpp
@@ -11,6 +11,9 @@
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace hostApi {
+
+OPENASSETIO_DECLARE_PTR(HostInterface)
+
 /**
  * The HostInterface provides an abstraction of the 'caller of the
  * API'. Colloquially, we refer to this as the '@ref host'. This may be
@@ -62,7 +65,7 @@ class OPENASSETIO_CORE_EXPORT HostInterface {
    *
    * @return host identifier.
    */
-  [[nodiscard]] virtual openassetio::Str identifier() const = 0;
+  [[nodiscard]] virtual Str identifier() const = 0;
 
   /**
    * Returns a human readable name to be used to reference this
@@ -90,8 +93,6 @@ class OPENASSETIO_CORE_EXPORT HostInterface {
   [[nodiscard]] virtual InfoDictionary info() const;
   /// @}
 };
-
-using HostInterfacePtr = std::shared_ptr<HostInterface>;
 }  // namespace hostApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -6,10 +6,12 @@
 #include <string>
 
 #include <openassetio/export.h>
-#include <openassetio/Context.hpp>
-#include <openassetio/managerApi/HostSession.hpp>
-#include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/InfoDictionary.hpp>
 #include <openassetio/typedefs.hpp>
+
+OPENASSETIO_FWD_DECLARE(managerApi, HostSession)
+OPENASSETIO_FWD_DECLARE(managerApi, ManagerInterface)
+OPENASSETIO_FWD_DECLARE(Context)
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -20,6 +22,9 @@ inline namespace OPENASSETIO_CORE_ABI_VERSION {
  If you are a asset management system developer, see @ref managerApi.
 */
 namespace hostApi {
+
+OPENASSETIO_DECLARE_PTR(Manager)
+
 /**
  * The Manager is the Host facing representation of an @ref
  * asset_management_system. The Manager class shouldn't be directly
@@ -244,8 +249,6 @@ class OPENASSETIO_CORE_EXPORT Manager {
   managerApi::ManagerInterfacePtr managerInterface_;
   managerApi::HostSessionPtr hostSession_;
 };
-
-using ManagerPtr = std::shared_ptr<Manager>;
 }  // namespace hostApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/managerApi/Host.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/Host.hpp
@@ -5,12 +5,17 @@
 #include <memory>
 
 #include <openassetio/export.h>
-#include <openassetio/hostApi/HostInterface.hpp>
+#include <openassetio/InfoDictionary.hpp>
 #include <openassetio/typedefs.hpp>
+
+OPENASSETIO_FWD_DECLARE(hostApi, HostInterface)
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace managerApi {
+
+OPENASSETIO_DECLARE_PTR(Host)
+
 /**
  * The Host object represents the tool or application that created a
  * session with OpenAssetIO, and wants to query or store information
@@ -78,8 +83,6 @@ class OPENASSETIO_CORE_EXPORT Host final {
  private:
   hostApi::HostInterfacePtr hostInterface_;
 };
-
-using HostPtr = std::shared_ptr<Host>;
 
 }  // namespace managerApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-core/include/openassetio/managerApi/HostSession.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/HostSession.hpp
@@ -5,12 +5,16 @@
 #include <memory>
 
 #include <openassetio/export.h>
-#include <openassetio/managerApi/Host.hpp>
 #include <openassetio/typedefs.hpp>
+
+OPENASSETIO_FWD_DECLARE(managerApi, Host)
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace managerApi {
+
+OPENASSETIO_DECLARE_PTR(HostSession)
+
 /**
  * The HostSession is a manager-facing class that represents a discrete
  * API session started by a @ref host in order to communicate with a
@@ -42,8 +46,6 @@ class OPENASSETIO_CORE_EXPORT HostSession {
  private:
   HostPtr host_;
 };
-
-using HostSessionPtr = std::shared_ptr<HostSession>;
 }  // namespace managerApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -8,9 +8,10 @@
 
 #include <openassetio/export.h>
 #include <openassetio/InfoDictionary.hpp>
-#include <openassetio/managerApi/HostSession.hpp>
-#include <openassetio/managerApi/ManagerStateBase.hpp>
 #include <openassetio/typedefs.hpp>
+
+OPENASSETIO_FWD_DECLARE(managerApi, ManagerStateBase)
+OPENASSETIO_FWD_DECLARE(managerApi, HostSession)
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -21,6 +22,8 @@ inline namespace OPENASSETIO_CORE_ABI_VERSION {
  If you are a tool or application developer, see @ref hostApi.
 */
 namespace managerApi {
+
+OPENASSETIO_DECLARE_PTR(ManagerInterface)
 
 /**
  * This Interface binds a @ref asset_management_system into
@@ -418,8 +421,6 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * @}
    */
 };
-
-using ManagerInterfacePtr = std::shared_ptr<ManagerInterface>;
 }  // namespace managerApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerStateBase.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerStateBase.hpp
@@ -24,7 +24,8 @@ namespace managerApi {
  * @see @ref stable_resolution
  * @see @ref manager_state
  */
-struct ManagerStateBase {
+class ManagerStateBase {
+ public:
   virtual ~ManagerStateBase() = default;
 };
 

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerStateBase.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerStateBase.hpp
@@ -10,6 +10,9 @@
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace managerApi {
+
+OPENASSETIO_DECLARE_PTR(ManagerStateBase)
+
 /**
  * An abstract base for all @ref manager_state objects.
  *
@@ -28,8 +31,6 @@ class ManagerStateBase {
  public:
   virtual ~ManagerStateBase() = default;
 };
-
-using ManagerStateBasePtr = std::shared_ptr<ManagerStateBase>;
 }  // namespace managerApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/typedefs.hpp
+++ b/src/openassetio-core/include/openassetio/typedefs.hpp
@@ -51,5 +51,83 @@ template <class T, typename... Args>
 std::shared_ptr<T> makeShared(Args&&... args) {
   return std::make_shared<T>(std::forward<Args>(args)...);
 }
+
+/**
+ * Forward declare a shared_ptr for a given class.
+ *
+ * Assumes the surrounding namespace is valid for the given class.
+ */
+#define OPENASSETIO_DECLARE_PTR(Class)             \
+  /* NOLINTNEXTLINE(bugprone-macro-parentheses) */ \
+  class Class;                                     \
+  using Class##Ptr = std::shared_ptr<Class>;
+
+/**
+ * Forward declare a class and its smart pointers.
+ *
+ * Wraps the declaration in the top-level openassetio and ABI
+ * namespaces.
+ *
+ * If two arguments are given, then the first argument gives a namespace
+ * to further wrap the declarations in, and the second argument gives
+ * the class name.
+ *
+ * If only a single argument is provided, then this is assumed to be
+ * the class name and is only wrapped in the top-level namespaces.
+ */
+#define OPENASSETIO_FWD_DECLARE(...) \
+  OPENASSETIO_PP_EXPAND(             \
+      OPENASSETIO_FWD_DECLARE_(__VA_ARGS__, IN_NS(__VA_ARGS__), TOP_LEVEL_NS(__VA_ARGS__), 0))
+
+/**
+ * @private Utility to forward declare a class and its smart pointers.
+ *
+ * Wraps the declarations in the top-level openassetio and ABI
+ * namespaces, then the provided namespace.
+ */
+#define OPENASSETIO_FWD_DECLARE_IN_NS(Namespace, Class) \
+  namespace openassetio {                               \
+  inline namespace OPENASSETIO_CORE_ABI_VERSION {       \
+  namespace Namespace {                                 \
+  OPENASSETIO_DECLARE_PTR(Class)                        \
+  }                                                     \
+  }                                                     \
+  }
+
+/**
+ * @private Utility to forward declare a class and its smart pointers.
+ *
+ * Wraps the declarations in the top-level openassetio and ABI
+ * namespaces.
+ */
+#define OPENASSETIO_FWD_DECLARE_TOP_LEVEL_NS(Class) \
+  namespace openassetio {                           \
+  inline namespace OPENASSETIO_CORE_ABI_VERSION {   \
+  OPENASSETIO_DECLARE_PTR(Class)                    \
+  }                                                 \
+  }
+
+/**
+ * @private Utility to dispatch to the appropriate single-argument or
+ * two-argument macro.
+ */
+#define OPENASSETIO_FWD_DECLARE_(_2, _1, IN_NS_OR_TOP_LEVEL, ...) \
+  OPENASSETIO_FWD_DECLARE_##IN_NS_OR_TOP_LEVEL
+
+/**
+ * @private Utility to work around MSVC treatment of variadic macros.
+ *
+ * When `x` is a function-like macro call, the effect is to defer
+ * expansion of `x` until the next pass, so that any `__VA_ARGS__` used
+ * in the `x` call are substituted on the earlier pass. If we don't use
+ * this trick, then MSVC treats the `__VA_ARGS__` as a single argument
+ * to the macro, even if it contains multiple arguments.
+ *
+ * This could also be worked around by using the `/Zc:preprocessor`
+ * compiler switch when building with MSVC. However, we would rather
+ * avoid mandating specific compiler switches for hosts/plugins when
+ * possible.
+ */
+#define OPENASSETIO_PP_EXPAND(x) x
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-python/ContextBinding.cpp
+++ b/src/openassetio-python/ContextBinding.cpp
@@ -4,6 +4,8 @@
 #include <pybind11/stl.h>
 
 #include <openassetio/Context.hpp>
+#include <openassetio/TraitsData.hpp>
+#include <openassetio/managerApi/ManagerStateBase.hpp>
 
 #include "_openassetio.hpp"
 

--- a/src/openassetio-python/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/hostApi/ManagerBinding.cpp
@@ -2,7 +2,10 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #include <pybind11/stl.h>
 
+#include <openassetio/Context.hpp>
 #include <openassetio/hostApi/Manager.hpp>
+#include <openassetio/managerApi/HostSession.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
 
 #include "../_openassetio.hpp"
 

--- a/src/openassetio-python/managerApi/HostBinding.cpp
+++ b/src/openassetio-python/managerApi/HostBinding.cpp
@@ -2,6 +2,7 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #include <pybind11/stl.h>
 
+#include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/managerApi/Host.hpp>
 
 #include "../_openassetio.hpp"


### PR DESCRIPTION
Closes #446. 

Best practice in C++ is to forward declare types where possible, to reduce compilation time as well as reliance on transient
`#include`s that tightly couple units of code together. 

To keep this DRY, add macros that forward declare classes and their associated smart pointer wrappers (currently just `shared_ptr`). Then use these macros across C++ headers.
