### PR TITLE
C++ Factory methods

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -99,6 +99,11 @@ v1.0.0-alpha.X
   `openassetio.test.manager` `apiComplianceSuite` to validate manager
   implementations agains this requirement.
 
+- Made the constructors of the following classes private: `Context`,
+  `Host`, `HostSession`, `Manager`, `TraitsData`. The static `make`
+  methods should be used to construct new instances.
+  [#481](https://github.com/OpenAssetIO/OpenAssetIO/issues/481)
+
 
 ### Improvements
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -104,6 +104,10 @@ v1.0.0-alpha.X
   methods should be used to construct new instances.
   [#481](https://github.com/OpenAssetIO/OpenAssetIO/issues/481)
 
+- Removed the `makeShared` pointer factory. The per-class static `make`
+  methods should be used instead.
+  [#481](https://github.com/OpenAssetIO/OpenAssetIO/issues/481)
+
 
 ### Improvements
 

--- a/contributing/CODING_STANDARDS.md
+++ b/contributing/CODING_STANDARDS.md
@@ -57,7 +57,8 @@ and consistency trade-offs.
 C++ classes that represent system components with reference semantics
 (as opposed to 'value' types) should inherit
 `std::enable_shared_from_this` and define a peer `Ptr` alias using
-`std::shared_ptr`.
+`std::shared_ptr`. Their constructors should be private, and a static
+`make` method provided.
 
 This is to simplify memory management across the complex range of
 language bindings within the project.
@@ -77,6 +78,12 @@ namespace managerApi {
 OPENASSETIO_DECLARE_PTR(Host)
 
 class OPENASSETIO_CORE_EXPORT Host final {
+public:
+    static HostPtr make(...);
+
+private:
+    Host(...);
+}
 ...
 ```
 

--- a/resources/perftest/lib.cpp
+++ b/resources/perftest/lib.cpp
@@ -19,7 +19,7 @@ VectorManagerInterface::Results VectorManagerInterface::resolve(
       results[idx] = ErrorCodeAndMessage{kErrorInvalidEntityReference, "not found in database"};
 
     } else {
-      auto traitsData = std::make_shared<openassetio::TraitsData>();
+      auto traitsData = openassetio::TraitsData::make();
 
       for (const auto& traitId : traitSet) {
         if (traitId == openassetio::LocateableContentTrait::kId) {
@@ -46,7 +46,7 @@ void CallbackManagerInterface::resolve(
                     ErrorCodeAndMessage{kErrorInvalidEntityReference, "not found in database"});
 
     } else {
-      auto traitsData = std::make_shared<openassetio::TraitsData>();
+      auto traitsData = openassetio::TraitsData::make();
 
       for (const auto& traitId : traitSet) {
         if (traitId == openassetio::LocateableContentTrait::kId) {
@@ -74,7 +74,7 @@ void CallbackFnPtrManagerInterface::resolve(
                     ErrorCodeAndMessage{kErrorInvalidEntityReference, "not found in database"});
 
     } else {
-      auto traitsData = std::make_shared<openassetio::TraitsData>();
+      auto traitsData = openassetio::TraitsData::make();
 
       for (const auto& traitId : traitSet) {
         if (traitId == openassetio::LocateableContentTrait::kId) {

--- a/resources/perftest/perftest.cpp
+++ b/resources/perftest/perftest.cpp
@@ -52,13 +52,13 @@ struct Fixture {
   /// Dummy host application to call with resolve()d element.
   HostApplication hostApplication{};
   /// Context required for API methods.
-  const openassetio::ContextPtr context = std::make_shared<openassetio::Context>();
+  const openassetio::ContextPtr context = openassetio::Context::make();
   /// Host required for HostSession.
   openassetio::managerApi::HostPtr host =
-      std::make_shared<openassetio::managerApi::Host>(std::make_shared<HostImpl>());
+      openassetio::managerApi::Host::make(std::make_shared<HostImpl>());
   /// HostSession required for API methods.
   const openassetio::managerApi::HostSessionPtr hostSession =
-      std::make_shared<openassetio::managerApi::HostSession>(host);
+      openassetio::managerApi::HostSession::make(host);
 
  private:
   /// A dummy HostInterface implementation to satisfy abstract base.

--- a/src/openassetio-core-c/private/hostApi/Manager.cpp
+++ b/src/openassetio-core-c/private/hostApi/Manager.cpp
@@ -39,7 +39,7 @@ oa_ErrorCode oa_hostApi_Manager_ctor(oa_StringView* err, oa_hostApi_Manager_h* h
         *handles::managerApi::SharedHostSession::toInstance(hostSessionHandle);
 
     auto* manager = new hostApi::ManagerPtr;
-    *manager = std::make_shared<hostApi::Manager>(managerInterfacePtr, hostSessionPtr);
+    *manager = hostApi::Manager::make(managerInterfacePtr, hostSessionPtr);
     *handle = handles::hostApi::SharedManager::toHandle(manager);
 
     return oa_ErrorCode_kOK;

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 target_sources(
     openassetio-core
     PRIVATE
+    Context.cpp
     TraitsData.cpp
     hostApi/HostInterface.cpp
     hostApi/Manager.cpp

--- a/src/openassetio-core/Context.cpp
+++ b/src/openassetio-core/Context.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#include <openassetio/Context.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+ContextPtr Context::make(Access access, Retention retention, TraitsDataPtr locale,
+                         managerApi::ManagerStateBasePtr managerState) {
+  return std::shared_ptr<Context>(
+      new Context(access, retention, std::move(locale), std::move(managerState)));
+}
+
+Context::Context(Access access_, Retention retention_, TraitsDataPtr locale_,
+                 managerApi::ManagerStateBasePtr managerState_)
+    : access{access_},
+      retention{retention_},
+      locale{std::move(locale_)},
+      managerState{std::move(managerState_)} {}
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/TraitsData.cpp
+++ b/src/openassetio-core/TraitsData.cpp
@@ -65,6 +65,16 @@ class TraitsData::Impl {
   PropertiesByTrait data_;
 };
 
+TraitsDataPtr TraitsData::make() { return std::shared_ptr<TraitsData>(new TraitsData()); }
+
+TraitsDataPtr TraitsData::make(const TraitSet& traitSet) {
+  return std::shared_ptr<TraitsData>(new TraitsData(traitSet));
+}
+
+TraitsDataPtr TraitsData::make(const TraitsDataConstPtr& other) {
+  return std::shared_ptr<TraitsData>(new TraitsData(*other));
+}
+
 TraitsData::TraitsData() : impl_{std::make_unique<Impl>()} {}
 
 TraitsData::TraitsData(const TraitSet& traitSet) : impl_{std::make_unique<Impl>(traitSet)} {}

--- a/src/openassetio-core/include/openassetio/Context.hpp
+++ b/src/openassetio-core/include/openassetio/Context.hpp
@@ -34,7 +34,7 @@ OPENASSETIO_DECLARE_PTR(Context)
  *  own, one will always be supplied through the ManagerInterface entry
  *  points.
  */
-class Context final {
+class OPENASSETIO_CORE_EXPORT Context final {
  public:
   /**
    * Storage for enum name lookup array.
@@ -80,7 +80,7 @@ class Context final {
    * then it will hint as to whether the Host is wanting to choose a
    * new file name to save, or open an existing one.
    */
-  Access access{kUnknown};
+  Access access;
 
   /**
    * A concession to the fact that it's not always possible to fully
@@ -102,7 +102,7 @@ class Context final {
    * to handle these situations correctly, Hosts are required to set
    * this property to reflect their ability to persist this information.
    */
-  Retention retention{kTransient};
+  Retention retention;
 
   /**
    * In many situations, the @ref trait_set of the desired @ref entity
@@ -119,7 +119,7 @@ class Context final {
    * include information such as whether or not multi-selection is
    * required.
    */
-  TraitsDataPtr locale{};
+  TraitsDataPtr locale;
 
   /**
    * The opaque state token owned by the @ref manager, used to
@@ -127,8 +127,18 @@ class Context final {
    *
    * @see @ref stable_resolution
    */
-  managerApi::ManagerStateBasePtr managerState{};
+  managerApi::ManagerStateBasePtr managerState;
 
+  /**
+   * Constructs a new context.
+   *
+   * @warning This method should never be called directly by host code -
+   * @fqref{hostApi.Manager.createContext} "Manager.createContext"
+   * should always be used instead.
+   */
+  [[nodiscard]] static ContextPtr make(Access access = kUnknown, Retention retention = kTransient,
+                                       TraitsDataPtr locale = nullptr,
+                                       managerApi::ManagerStateBasePtr managerState = nullptr);
   /**
    * @return `true` if the context is any of the 'Read' based access
    * patterns. If the access is unknown (Access::kUnknown), then `false`
@@ -155,6 +165,10 @@ class Context final {
   [[nodiscard]] inline bool isForMultiple() const {
     return access == kReadMultiple || access == kWriteMultiple;
   }
+
+ private:
+  Context(Access access, Retention retention, TraitsDataPtr locale,
+          managerApi::ManagerStateBasePtr managerState);
 };
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/TraitsData.hpp
+++ b/src/openassetio-core/include/openassetio/TraitsData.hpp
@@ -76,21 +76,21 @@ class OPENASSETIO_CORE_EXPORT TraitsData final {
   /**
    * Construct an empty instance, with no traits.
    */
-  TraitsData();
+  static TraitsDataPtr make();
 
   /**
    * Construct such that this instance has the given set of traits.
    *
-   * @param traitSet The consituent traits IDs.
+   * @param traitSet The constituent traits IDs.
    */
-  explicit TraitsData(const TraitSet& traitSet);
+  static TraitsDataPtr make(const TraitSet& traitSet);
 
   /**
    * Construct such that this instance is a deep copy of the other.
    *
    * @param other The instance to copy.
    */
-  TraitsData(const TraitsData& other);
+  static TraitsDataPtr make(const TraitsDataConstPtr& other);
 
   /**
    * Defaulted destructor.
@@ -165,6 +165,10 @@ class OPENASSETIO_CORE_EXPORT TraitsData final {
   bool operator==(const TraitsData& other) const;
 
  private:
+  TraitsData();
+  explicit TraitsData(const TraitSet& traitSet);
+  TraitsData(const TraitsData& other);
+
   class Impl;
   std::unique_ptr<Impl> impl_;
 };

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -52,8 +52,12 @@ OPENASSETIO_DECLARE_PTR(Manager)
  */
 class OPENASSETIO_CORE_EXPORT Manager {
  public:
-  explicit Manager(managerApi::ManagerInterfacePtr managerInterface,
-                   managerApi::HostSessionPtr hostSession);
+  /**
+   * Constructs a new Manager wrapping the supplied manager interface
+   * and host session.
+   */
+  static ManagerPtr make(managerApi::ManagerInterfacePtr managerInterface,
+                         managerApi::HostSessionPtr hostSession);
 
   /**
    * @name Asset Management System Information
@@ -246,6 +250,9 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * @}
    */
  private:
+  explicit Manager(managerApi::ManagerInterfacePtr managerInterface,
+                   managerApi::HostSessionPtr hostSession);
+
   managerApi::ManagerInterfacePtr managerInterface_;
   managerApi::HostSessionPtr hostSession_;
 };

--- a/src/openassetio-core/include/openassetio/managerApi/Host.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/Host.hpp
@@ -36,7 +36,10 @@ OPENASSETIO_DECLARE_PTR(Host)
  */
 class OPENASSETIO_CORE_EXPORT Host final {
  public:
-  explicit Host(hostApi::HostInterfacePtr hostInterface);
+  /**
+   * Constructs a new Host wrapping the supplied host interface.
+   */
+  [[nodiscard]] static HostPtr make(hostApi::HostInterfacePtr hostInterface);
 
   /**
    * @name Host Information
@@ -81,6 +84,7 @@ class OPENASSETIO_CORE_EXPORT Host final {
    */
 
  private:
+  explicit Host(hostApi::HostInterfacePtr hostInterface);
   hostApi::HostInterfacePtr hostInterface_;
 };
 

--- a/src/openassetio-core/include/openassetio/managerApi/HostSession.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/HostSession.hpp
@@ -36,7 +36,10 @@ OPENASSETIO_DECLARE_PTR(HostSession)
  */
 class OPENASSETIO_CORE_EXPORT HostSession {
  public:
-  explicit HostSession(HostPtr host);
+  /**
+   * Constructs a new HostSession holding the supplied host.
+   */
+  static HostSessionPtr make(HostPtr host);
 
   /**
    * @return The host that initiated the API session.
@@ -44,6 +47,7 @@ class OPENASSETIO_CORE_EXPORT HostSession {
   [[nodiscard]] HostPtr host() const;
 
  private:
+  explicit HostSession(HostPtr host);
   HostPtr host_;
 };
 }  // namespace managerApi

--- a/src/openassetio-core/include/openassetio/typedefs.hpp
+++ b/src/openassetio-core/include/openassetio/typedefs.hpp
@@ -46,12 +46,6 @@ using Str = std::string;
  * @}
  */
 
-/// Make an instance wrapped in a shared smart pointer.
-template <class T, typename... Args>
-std::shared_ptr<T> makeShared(Args&&... args) {
-  return std::make_shared<T>(std::forward<Args>(args)...);
-}
-
 /**
  * Forward declare a shared_ptr for a given class.
  *

--- a/src/openassetio-core/managerApi/Host.cpp
+++ b/src/openassetio-core/managerApi/Host.cpp
@@ -8,6 +8,10 @@ namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace managerApi {
 
+HostPtr Host::make(hostApi::HostInterfacePtr hostInterface) {
+  return std::shared_ptr<Host>(new Host(std::move(hostInterface)));
+}
+
 Host::Host(hostApi::HostInterfacePtr hostInterface) : hostInterface_{std::move(hostInterface)} {}
 
 Str Host::identifier() const { return hostInterface_->identifier(); }

--- a/src/openassetio-core/managerApi/HostSession.cpp
+++ b/src/openassetio-core/managerApi/HostSession.cpp
@@ -8,6 +8,10 @@ namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace managerApi {
 
+HostSessionPtr HostSession::make(HostPtr host) {
+  return std::shared_ptr<HostSession>(new HostSession(std::move(host)));
+}
+
 HostSession::HostSession(HostPtr host) : host_{std::move(host)} {}
 
 HostPtr HostSession::host() const { return host_; }

--- a/src/openassetio-python/ContextBinding.cpp
+++ b/src/openassetio-python/ContextBinding.cpp
@@ -37,8 +37,7 @@ void registerContext(const py::module& mod) {
   context.def_readonly_static("kRetentionNames", &Context::kRetentionNames);
 
   context
-      .def(py::init<Context::Access, Context::Retention, TraitsDataPtr, ManagerStateBasePtr>(),
-           py::arg_v("access", Context::Access::kUnknown),
+      .def(py::init(&Context::make), py::arg_v("access", Context::Access::kUnknown),
            py::arg_v("retention", Context::Retention::kTransient),
            py::arg_v("locale", TraitsDataPtr{}), py::arg_v("managerState", ManagerStateBasePtr{}))
       .def_readwrite("access", &Context::access)

--- a/src/openassetio-python/TraitsDataBinding.cpp
+++ b/src/openassetio-python/TraitsDataBinding.cpp
@@ -11,15 +11,18 @@
 
 void registerTraitsData(const py::module& mod) {
   using openassetio::TraitsData;
+  using openassetio::TraitsDataConstPtr;
   using openassetio::TraitsDataPtr;
   namespace trait = openassetio::trait;
   namespace property = openassetio::trait::property;
   using MaybeValue = std::optional<property::Value>;
 
   py::class_<TraitsData, TraitsDataPtr>(mod, "TraitsData", py::is_final())
-      .def(py::init())
-      .def(py::init<const TraitsData::TraitSet&>(), py::arg("traitSet"))
-      .def(py::init<const TraitsData&>())
+      .def(py::init(static_cast<TraitsDataPtr (*)()>(&TraitsData::make)))
+      .def(
+          py::init(static_cast<TraitsDataPtr (*)(const TraitsData::TraitSet&)>(&TraitsData::make)),
+          py::arg("traitSet"))
+      .def(py::init(static_cast<TraitsDataPtr (*)(const TraitsDataConstPtr&)>(&TraitsData::make)))
       .def("traitSet", &TraitsData::traitSet)
       .def("hasTrait", &TraitsData::hasTrait, py::arg("id"))
       .def("addTrait", &TraitsData::addTrait)

--- a/src/openassetio-python/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/hostApi/ManagerBinding.cpp
@@ -15,8 +15,8 @@ void registerManager(const py::module& mod) {
   using openassetio::managerApi::ManagerInterfacePtr;
 
   py::class_<Manager, ManagerPtr>(mod, "Manager")
-      .def(py::init<ManagerInterfacePtr, openassetio::managerApi::HostSessionPtr>(),
-           py::arg("managerInterface").none(false), py::arg("hostSession").none(false))
+      .def(py::init(&Manager::make), py::arg("managerInterface").none(false),
+           py::arg("hostSession").none(false))
       .def("identifier", &Manager::identifier)
       .def("displayName", &Manager::displayName)
       .def("info", &Manager::info)

--- a/src/openassetio-python/managerApi/HostBinding.cpp
+++ b/src/openassetio-python/managerApi/HostBinding.cpp
@@ -13,7 +13,7 @@ void registerHost(const py::module& mod) {
   using openassetio::managerApi::HostPtr;
 
   py::class_<Host, HostPtr>(mod, "Host", py::is_final())
-      .def(py::init<HostInterfacePtr>(), py::arg("hostInterface").none(false))
+      .def(py::init(&Host::make), py::arg("hostInterface").none(false))
       .def("identifier", &Host::identifier)
       .def("displayName", &Host::displayName)
       .def("info", &Host::info);

--- a/src/openassetio-python/managerApi/HostSessionBinding.cpp
+++ b/src/openassetio-python/managerApi/HostSessionBinding.cpp
@@ -13,6 +13,6 @@ void registerHostSession(const py::module& mod) {
   using openassetio::managerApi::HostSessionPtr;
 
   py::class_<HostSession, HostSessionPtr>(mod, "HostSession")
-      .def(py::init<HostPtr>(), py::arg("host").none(false))
+      .def(py::init(&HostSession::make), py::arg("host").none(false))
       .def("host", &HostSession::host);
 }

--- a/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
+++ b/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
@@ -63,8 +63,8 @@ SCENARIO("A Manager is constructed and destructed") {
 
   GIVEN("a shared pointer to a HostSession and its C handle") {
     auto* hostInterface = new DeathwatchedMockHostInterface{};
-    auto hostSessionPtr = openassetio::makeShared<managerApi::HostSession>(
-        openassetio::makeShared<managerApi::Host>(hostApi::HostInterfacePtr{hostInterface}));
+    auto hostSessionPtr = managerApi::HostSession::make(
+        managerApi::Host::make(hostApi::HostInterfacePtr{hostInterface}));
     oa_managerApi_SharedHostSession_h hostSessionHandle =
         handles::managerApi::SharedHostSession::toHandle(&hostSessionPtr);
 
@@ -116,8 +116,8 @@ SCENARIO("A Manager is constructed and destructed") {
     auto* hostInterface = new DeathwatchedMockHostInterface{};
     // We must have this expectation here to avoid a false positive.
     REQUIRE_DESTRUCTION(*hostInterface);
-    auto hostSessionPtr = openassetio::makeShared<managerApi::HostSession>(
-        openassetio::makeShared<managerApi::Host>(hostApi::HostInterfacePtr(hostInterface)));
+    auto hostSessionPtr = managerApi::HostSession::make(
+        managerApi::Host::make(hostApi::HostInterfacePtr(hostInterface)));
     oa_managerApi_SharedHostSession_h hostSessionHandle =
         handles::managerApi::SharedHostSession::toHandle(&hostSessionPtr);
 
@@ -159,14 +159,11 @@ SCENARIO("A host calls Manager::identifier") {
         openassetio::makeShared<MockManagerInterface>();
     auto& mockManagerInterface = static_cast<MockManagerInterface&>(*mockManagerInterfacePtr);
     // Create a HostSession with our mock HostInterface
-    managerApi::HostSessionPtr hostSessionPtr =
-        openassetio::makeShared<openassetio::managerApi::HostSession>(
-            openassetio::makeShared<managerApi::Host>(
-                openassetio::makeShared<MockHostInterface>()));
+    managerApi::HostSessionPtr hostSessionPtr = managerApi::HostSession::make(
+        managerApi::Host::make(openassetio::makeShared<MockHostInterface>()));
 
     // Create the Manager under test.
-    hostApi::ManagerPtr manager =
-        openassetio::makeShared<hostApi::Manager>(mockManagerInterfacePtr, hostSessionPtr);
+    hostApi::ManagerPtr manager = hostApi::Manager::make(mockManagerInterfacePtr, hostSessionPtr);
     // Create the handle for the Manager under test.
     oa_hostApi_Manager_h managerHandle = handles::hostApi::SharedManager::toHandle(&manager);
 
@@ -224,14 +221,11 @@ SCENARIO("A host calls Manager::displayName") {
         openassetio::makeShared<MockManagerInterface>();
     auto& mockManagerInterface = static_cast<MockManagerInterface&>(*mockManagerInterfacePtr);
     // Create a HostSession with our mock HostInterface
-    managerApi::HostSessionPtr hostSessionPtr =
-        openassetio::makeShared<openassetio::managerApi::HostSession>(
-            openassetio::makeShared<managerApi::Host>(
-                openassetio::makeShared<MockHostInterface>()));
+    managerApi::HostSessionPtr hostSessionPtr = managerApi::HostSession::make(
+        managerApi::Host::make(openassetio::makeShared<MockHostInterface>()));
 
     // Create the Manager under test.
-    hostApi::ManagerPtr manager =
-        openassetio::makeShared<hostApi::Manager>(mockManagerInterfacePtr, hostSessionPtr);
+    hostApi::ManagerPtr manager = hostApi::Manager::make(mockManagerInterfacePtr, hostSessionPtr);
     // Create the handle for the Manager under test.
     oa_hostApi_Manager_h managerHandle = handles::hostApi::SharedManager::toHandle(&manager);
 
@@ -289,14 +283,11 @@ SCENARIO("A host calls Manager::info") {
         openassetio::makeShared<MockManagerInterface>();
     auto& mockManagerInterface = static_cast<MockManagerInterface&>(*mockManagerInterfacePtr);
     // Create a HostSession with our mock HostInterface
-    managerApi::HostSessionPtr hostSessionPtr =
-        openassetio::makeShared<openassetio::managerApi::HostSession>(
-            openassetio::makeShared<managerApi::Host>(
-                openassetio::makeShared<MockHostInterface>()));
+    managerApi::HostSessionPtr hostSessionPtr = managerApi::HostSession::make(
+        managerApi::Host::make(openassetio::makeShared<MockHostInterface>()));
 
     // Create the Manager under test.
-    hostApi::ManagerPtr manager =
-        std::make_shared<hostApi::Manager>(mockManagerInterfacePtr, hostSessionPtr);
+    hostApi::ManagerPtr manager = hostApi::Manager::make(mockManagerInterfacePtr, hostSessionPtr);
     // Create the handle for the Manager under test.
     oa_hostApi_Manager_h managerHandle = handles::hostApi::SharedManager::toHandle(&manager);
 

--- a/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
+++ b/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
@@ -156,11 +156,11 @@ SCENARIO("A host calls Manager::identifier") {
   GIVEN("a Manager and its C handle") {
     // Create mock ManagerInterface to inject and assert on.
     managerApi::ManagerInterfacePtr mockManagerInterfacePtr =
-        openassetio::makeShared<MockManagerInterface>();
+        std::make_shared<MockManagerInterface>();
     auto& mockManagerInterface = static_cast<MockManagerInterface&>(*mockManagerInterfacePtr);
     // Create a HostSession with our mock HostInterface
     managerApi::HostSessionPtr hostSessionPtr = managerApi::HostSession::make(
-        managerApi::Host::make(openassetio::makeShared<MockHostInterface>()));
+        managerApi::Host::make(std::make_shared<MockHostInterface>()));
 
     // Create the Manager under test.
     hostApi::ManagerPtr manager = hostApi::Manager::make(mockManagerInterfacePtr, hostSessionPtr);
@@ -218,11 +218,11 @@ SCENARIO("A host calls Manager::displayName") {
   GIVEN("a Manager and its C handle") {
     // Create mock ManagerInterface to inject and assert on.
     managerApi::ManagerInterfacePtr mockManagerInterfacePtr =
-        openassetio::makeShared<MockManagerInterface>();
+        std::make_shared<MockManagerInterface>();
     auto& mockManagerInterface = static_cast<MockManagerInterface&>(*mockManagerInterfacePtr);
     // Create a HostSession with our mock HostInterface
     managerApi::HostSessionPtr hostSessionPtr = managerApi::HostSession::make(
-        managerApi::Host::make(openassetio::makeShared<MockHostInterface>()));
+        managerApi::Host::make(std::make_shared<MockHostInterface>()));
 
     // Create the Manager under test.
     hostApi::ManagerPtr manager = hostApi::Manager::make(mockManagerInterfacePtr, hostSessionPtr);
@@ -280,11 +280,11 @@ SCENARIO("A host calls Manager::info") {
   GIVEN("a Manager and its C handle") {
     // Create mock ManagerInterface to inject and assert on.
     managerApi::ManagerInterfacePtr mockManagerInterfacePtr =
-        openassetio::makeShared<MockManagerInterface>();
+        std::make_shared<MockManagerInterface>();
     auto& mockManagerInterface = static_cast<MockManagerInterface&>(*mockManagerInterfacePtr);
     // Create a HostSession with our mock HostInterface
     managerApi::HostSessionPtr hostSessionPtr = managerApi::HostSession::make(
-        managerApi::Host::make(openassetio::makeShared<MockHostInterface>()));
+        managerApi::Host::make(std::make_shared<MockHostInterface>()));
 
     // Create the Manager under test.
     hostApi::ManagerPtr manager = hostApi::Manager::make(mockManagerInterfacePtr, hostSessionPtr);

--- a/tests/openassetio-core/CMakeLists.txt
+++ b/tests/openassetio-core/CMakeLists.txt
@@ -17,6 +17,11 @@ install(
 target_sources(openassetio-core-cpp-test-exe
     PRIVATE
     main.cpp
+    ContextTest.cpp
+    TraitsDataTest.cpp
+    hostApi/ManagerTest.cpp
+    managerApi/HostTest.cpp
+    managerApi/HostSessionTest.cpp
     managerApi/ManagerStateBaseTest.cpp
     trait/TraitBaseTest.cpp
 )

--- a/tests/openassetio-core/ContextTest.cpp
+++ b/tests/openassetio-core/ContextTest.cpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#include <type_traits>
+
+#include <catch2/catch.hpp>
+
+#include <openassetio/Context.hpp>
+
+OPENASSETIO_FWD_DECLARE(TraitsData)
+OPENASSETIO_FWD_DECLARE(managerApi, ManagerStateBase)
+
+using openassetio::Context;
+
+SCENARIO("Context constructor is private") {
+  STATIC_REQUIRE_FALSE(std::is_constructible_v<Context, Context::Access, Context::Retention,
+                                               openassetio::TraitsDataPtr,
+                                               openassetio::managerApi::ManagerStateBasePtr>);
+}

--- a/tests/openassetio-core/TraitsDataTest.cpp
+++ b/tests/openassetio-core/TraitsDataTest.cpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#include <type_traits>
+
+#include <catch2/catch.hpp>
+
+#include <openassetio/TraitsData.hpp>
+#include <openassetio/trait/property.hpp>
+
+using openassetio::Int;
+using openassetio::TraitsData;
+using openassetio::TraitsDataPtr;
+using openassetio::trait::property::Key;
+using openassetio::trait::property::Value;
+
+SCENARIO("TraitsData constructor is private") {
+  STATIC_REQUIRE_FALSE(std::is_constructible_v<TraitsData>);
+}
+
+SCENARIO("TraitsData trait set constructor is private") {
+  STATIC_REQUIRE_FALSE(std::is_constructible_v<TraitsData, const TraitsData::TraitSet&>);
+}
+
+SCENARIO("TraitsData copy constructor is private") {
+  STATIC_REQUIRE_FALSE(std::is_constructible_v<TraitsData, const openassetio::TraitsData&>);
+}
+
+SCENARIO("TraitsData make from other creates a deep copy") {
+  GIVEN("an instance with existing data") {
+    TraitsDataPtr data = TraitsData::make();
+    data->setTraitProperty("a", "a", Int(1));
+    WHEN("a copy is made using the make copy constructor") {
+      TraitsDataPtr copy = TraitsData::make(data);
+      WHEN("existing values are queried") {
+        THEN("property data has been copied") {
+          Value someValue;
+          Int value;
+          REQUIRE(copy->getTraitProperty(&someValue, "a", "a"));
+          value = *std::get_if<Int>(&someValue);
+          CHECK(value == Int(1));
+        }
+      }
+      AND_WHEN("the data is modified") {
+        data->setTraitProperty("a", "a", Int(3));
+        THEN("the copy is unchanged") {
+          Value someValue;
+          Int value;
+          REQUIRE(copy->getTraitProperty(&someValue, "a", "a"));
+          value = *std::get_if<Int>(&someValue);
+          CHECK(value == Int(1));
+        }
+      }
+    }
+  }
+}

--- a/tests/openassetio-core/hostApi/ManagerTest.cpp
+++ b/tests/openassetio-core/hostApi/ManagerTest.cpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#include <type_traits>
+
+#include <catch2/catch.hpp>
+
+#include <openassetio/hostApi/Manager.hpp>
+
+OPENASSETIO_FWD_DECLARE(managerApi, ManagerInterface)
+
+SCENARIO("Manager constructor is private") {
+  STATIC_REQUIRE_FALSE(std::is_constructible_v<openassetio::hostApi::Manager,
+                                               openassetio::managerApi::ManagerInterfacePtr>);
+}

--- a/tests/openassetio-core/managerApi/HostSessionTest.cpp
+++ b/tests/openassetio-core/managerApi/HostSessionTest.cpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#include <type_traits>
+
+#include <catch2/catch.hpp>
+
+#include <openassetio/managerApi/HostSession.hpp>
+
+OPENASSETIO_FWD_DECLARE(managerApi, Host)
+
+SCENARIO("HostSession constructor is private") {
+  STATIC_REQUIRE_FALSE(std::is_constructible_v<openassetio::managerApi::HostSession,
+                                               openassetio::managerApi::HostPtr>);
+}

--- a/tests/openassetio-core/managerApi/HostTest.cpp
+++ b/tests/openassetio-core/managerApi/HostTest.cpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#include <type_traits>
+
+#include <catch2/catch.hpp>
+
+#include <openassetio/managerApi/Host.hpp>
+
+OPENASSETIO_FWD_DECLARE(hostApi, HostInterface)
+
+SCENARIO("Host constructor is private") {
+  STATIC_REQUIRE_FALSE(std::is_constructible_v<openassetio::managerApi::Host,
+                                               openassetio::hostApi::HostInterfacePtr>);
+}

--- a/tests/openassetio-core/trait/TraitBaseTest.cpp
+++ b/tests/openassetio-core/trait/TraitBaseTest.cpp
@@ -37,7 +37,7 @@ struct TestTrait : trait::TraitBase<TestTrait> {
 
 SCENARIO("Retrieving the undelying data") {
   GIVEN("Some known traits data") {
-    TraitsDataPtr data = openassetio::makeShared<TraitsData>();
+    TraitsDataPtr data = TraitsData::make();
 
     WHEN("a trait instance is constructed with data") {
       TestTrait trait(data);
@@ -57,7 +57,7 @@ SCENARIO("Retrieving the undelying data") {
 
 SCENARIO("Checking a trait is valid") {
   GIVEN("Some known traits data") {
-    TraitsDataPtr data = openassetio::makeShared<TraitsData>();
+    TraitsDataPtr data = TraitsData::make();
 
     AND_GIVEN("the data has the trait set") {
       data->addTrait(TestTrait::kId);
@@ -77,7 +77,7 @@ SCENARIO("Checking a trait is valid") {
 
 SCENARIO("Imbuing a trait to the traits data held by a trait instance") {
   GIVEN("Some known traits data held by a trait") {
-    TraitsDataPtr data = openassetio::makeShared<TraitsData>();
+    TraitsDataPtr data = TraitsData::make();
     TestTrait trait(data);
 
     AND_GIVEN("the data does not have the trait set") {
@@ -92,9 +92,9 @@ SCENARIO("Imbuing a trait to the traits data held by a trait instance") {
 
       WHEN("the trait is imbued") {
         THEN("is a noop") {
-          const TraitsData oldData(*data);
+          TraitsDataPtr oldData = TraitsData::make(data);
           trait.imbue();
-          CHECK(*data == oldData);
+          CHECK(*data == *oldData);
         }
       }
     }
@@ -103,7 +103,7 @@ SCENARIO("Imbuing a trait to the traits data held by a trait instance") {
 
 SCENARIO("Imbuing a trait to an arbitrary traits data instance") {
   GIVEN("Some known traits data") {
-    TraitsDataPtr data = openassetio::makeShared<TraitsData>();
+    TraitsDataPtr data = TraitsData::make();
 
     AND_GIVEN("the data does not have the trait set") {
       WHEN("the trait is imbued to the data") {
@@ -115,9 +115,9 @@ SCENARIO("Imbuing a trait to an arbitrary traits data instance") {
       data->addTrait(TestTrait::kId);
       WHEN("the trait is imbued to the data") {
         THEN("is a noop") {
-          const TraitsData oldData(*data);
+          TraitsDataPtr oldData = TraitsData::make(data);
           TestTrait::imbueTo(data);
-          CHECK(*data == oldData);
+          CHECK(*data == *oldData);
         }
       }
     }


### PR DESCRIPTION
This deliberately omits classes that are not constructed by API code, or callers of the API (from either side). `HostInterface`, `ManagerInterface` and `ManagerStateBase` are only ever constructed by their direct owners (the host, the manager's plugin and manager respectively).

Closes #481