### PR TITLE
[Core] Minimal C++ logging interface

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -129,11 +129,12 @@ v1.0.0-alpha.X
   [#370](https://github.com/OpenAssetIO/OpenAssetIO/issues/370)
 
 - Migrated the following classes to C++: `Context`, `Host`,
-  `HostInterface` and `HostSession`. Debug and audit functionality is
-  left for future work.
+  `HostInterface`, `HostSession` and `LoggerInterface`. Debug and audit
+  functionality is left for future work.
   [#291](https://github.com/OpenAssetIO/OpenAssetIO/issues/291)
   [#331](https://github.com/OpenAssetIO/OpenAssetIO/issues/331)
   [#455](https://github.com/OpenAssetIO/OpenAssetIO/issues/455)
+  [#504](https://github.com/OpenAssetIO/OpenAssetIO/issues/504)
 
 - Migrated the following `ManagerInterface` methods to C++
   `initialize`, `managementPolicy`, `createState`, `createChildState`,

--- a/python/openassetio/_core/debug.py
+++ b/python/openassetio/_core/debug.py
@@ -24,7 +24,7 @@ kDebug and kDebugApi logging severity displays
 
 In order to use these decorators the target class must derive from
 Debuggable, and have its `_debugLogFn` set to an callable that matches
-the @ref openassetio.log.LoggerInterface.log signature. This
+the @fqref{LoggerInterface.log} "LoggerInterface.log" signature. This
 callback will be used to output debug information. If no callback is
 set, no debug output will be produced.
 

--- a/python/openassetio/managerApi/HostSession.py
+++ b/python/openassetio/managerApi/HostSession.py
@@ -75,21 +75,3 @@ class HostSession(_openassetio.managerApi.HostSession):
         @see @ref openassetio.log "log"
         """
         self.__logger.log(message, severity)
-
-    def progress(self, decimalProgress, message=None):
-        """
-        Logs the supplied progress. Hosts may implement specific
-        handling for progress messages, mapping them to custom UI
-        element. If not, it will be logged as-per other messages, with a
-        kProgress severity.
-
-        @param decimalProgress float, Normalised progress between 0 and
-        1, if set to a value less than 0 it will be considered
-        cancelled, if greater than one, complete.
-
-        @param message str, A string message to display with the
-        progress. If None is supplied, it is assumed that there is no
-        message and the previous message may remain. Set to an empty
-        string if it is desired to always clear the previous message.
-        """
-        self.__logger.progress(decimalProgress, message=message)

--- a/python/openassetio/managerApi/ManagerInterface.py
+++ b/python/openassetio/managerApi/ManagerInterface.py
@@ -87,7 +87,6 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
     result in output being lost.
 
     @see @ref openassetio.managerApi.HostSession.HostSession.log "HostSession.log"
-    @see @ref openassetio.managerApi.HostSession.HostSession.progress "HostSession.progress"
 
     Exceptions should be thrown to handle any in-flight errors that
     occur.  The error should be mapped to a derived class of

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(
     openassetio-core
     PRIVATE
     Context.cpp
+    LoggerInterface.cpp
     TraitsData.cpp
     hostApi/HostInterface.cpp
     hostApi/Manager.cpp

--- a/src/openassetio-core/LoggerInterface.cpp
+++ b/src/openassetio-core/LoggerInterface.cpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#include <iomanip>
+#include <sstream>
+
+#include <openassetio/LoggerInterface.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+LoggerInterface::~LoggerInterface() = default;
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/Context.hpp
+++ b/src/openassetio-core/include/openassetio/Context.hpp
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include <openassetio/export.h>
+#include <openassetio/enum.hpp>
 #include <openassetio/typedefs.hpp>
 
 OPENASSETIO_FWD_DECLARE(TraitsData)
@@ -36,16 +37,6 @@ OPENASSETIO_DECLARE_PTR(Context)
  */
 class OPENASSETIO_CORE_EXPORT Context final {
  public:
-  /**
-   * Storage for enum name lookup array.
-   */
-  template <std::size_t N>
-  using EnumNames = std::array<std::string_view, N>;
-  /**
-   * Explicit enum type so that name lookups do not require a cast.
-   */
-  using EnumIdx = EnumNames<0>::size_type;
-
   /**
    * @name Access Pattern
    */

--- a/src/openassetio-core/include/openassetio/LoggerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/LoggerInterface.hpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+
+#include <openassetio/export.h>
+#include <openassetio/enum.hpp>
+#include <openassetio/typedefs.hpp>
+
+#pragma once
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+OPENASSETIO_DECLARE_PTR(LoggerInterface)
+/**
+ * An abstract base class that defines the receiving interface for
+ * log messages generated a @ref manager or the API middleware.
+ */
+class OPENASSETIO_CORE_EXPORT LoggerInterface {
+ public:
+  /**
+   * @name Log Severity
+   * @{
+   */
+  enum Severity : EnumIdx { kCritical = 0, kError, kWarning, kProgress, kInfo, kDebug, kDebugApi };
+
+  static constexpr EnumNames<7> kSeverityNames{"critical", "error", "warning", "progress",
+                                               "info",     "debug", "debugApi"};
+  /// @}
+
+  virtual ~LoggerInterface() = 0;
+
+  /**
+   * Logs a message to the user.
+   *
+   * This method must be implemented to present the supplied message
+   * to the user in an appropriate fashion.
+   *
+   * @param message The message string to be logged.
+   *
+   * @param severity One of the severity constants defined in @ref
+   * Severity.
+   */
+  virtual void log(const Str& message, Severity severity) const = 0;
+};
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/enum.hpp
+++ b/src/openassetio-core/include/openassetio/enum.hpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#pragma once
+#include <array>
+#include <cstddef>
+#include <string_view>
+
+#include <openassetio/export.h>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+/**
+ * Storage for enum name lookup array.
+ */
+template <std::size_t N>
+using EnumNames = std::array<std::string_view, N>;
+/**
+ * Explicit enum type so that name lookups do not require a cast.
+ */
+using EnumIdx = EnumNames<0>::size_type;
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -79,8 +79,6 @@ OPENASSETIO_DECLARE_PTR(ManagerInterface)
  *
  * @see @ref openassetio.managerApi.HostSession.HostSession.log
  * "HostSession.log"
- * @see @ref openassetio.managerApi.HostSession.HostSession.progress
- * "HostSession.progress"
  *
  * Exceptions should be thrown to handle any in-flight errors that
  * occur. The error should be mapped to a derived class of

--- a/src/openassetio-python/CMakeLists.txt
+++ b/src/openassetio-python/CMakeLists.txt
@@ -42,6 +42,7 @@ target_sources(
     PRIVATE
     _openassetio.cpp
     ContextBinding.cpp
+    LoggerInterfaceBinding.cpp
     TraitsDataBinding.cpp
     hostApi/ManagerBinding.cpp
     hostApi/HostInterfaceBinding.cpp

--- a/src/openassetio-python/LoggerInterfaceBinding.cpp
+++ b/src/openassetio-python/LoggerInterfaceBinding.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <openassetio/LoggerInterface.hpp>
+
+#include "_openassetio.hpp"
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+/**
+ * Trampoline class required for pybind to bind pure virtual methods
+ * and allow C++ -> Python calls via a C++ instance.
+ */
+struct PyLoggerInterface : LoggerInterface {
+  using LoggerInterface::LoggerInterface;
+
+  void log(const Str& message, Severity severity) const override {
+    PYBIND11_OVERRIDE_PURE(void, LoggerInterface, log, message, severity);
+  }
+};
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio
+
+void registerLoggerInterface(const py::module& mod) {
+  using openassetio::Float;
+  using openassetio::LoggerInterface;
+  using openassetio::LoggerInterfacePtr;
+  using openassetio::PyLoggerInterface;
+  using openassetio::Str;
+
+  py::class_<LoggerInterface, PyLoggerInterface, LoggerInterfacePtr> loggerInterface{
+      mod, "LoggerInterface"};
+
+  py::enum_<LoggerInterface::Severity>{loggerInterface, "Severity", py::arithmetic()}
+      .value("kCritical", LoggerInterface::Severity::kCritical)
+      .value("kError", LoggerInterface::Severity::kError)
+      .value("kWarning", LoggerInterface::Severity::kWarning)
+      .value("kProgress", LoggerInterface::Severity::kProgress)
+      .value("kInfo", LoggerInterface::Severity::kInfo)
+      .value("kDebug", LoggerInterface::Severity::kDebug)
+      .value("kDebugApi", LoggerInterface::Severity::kDebugApi)
+      .export_values();
+
+  loggerInterface.def_readonly_static("kSeverityNames", &LoggerInterface::kSeverityNames);
+
+  loggerInterface.def(py::init())
+      .def("log", &LoggerInterface::log, py::arg("message"), py::arg("severity"));
+}

--- a/src/openassetio-python/_openassetio.cpp
+++ b/src/openassetio-python/_openassetio.cpp
@@ -15,6 +15,7 @@ PYBIND11_MODULE(_openassetio, mod) {
   py::module managerApi = mod.def_submodule("managerApi");
   py::module hostApi = mod.def_submodule("hostApi");
 
+  registerLoggerInterface(mod);
   registerTraitsData(mod);
   registerManagerStateBase(managerApi);
   registerContext(mod);

--- a/src/openassetio-python/_openassetio.hpp
+++ b/src/openassetio-python/_openassetio.hpp
@@ -14,6 +14,9 @@
 /// Concise pybind alias.
 namespace py = pybind11;
 
+/// Register the LoggerInterface class with Python.
+void registerLoggerInterface(const py::module& mod);
+
 /// Register the Context class with Python.
 void registerContext(const py::module& mod);
 

--- a/tests/python/openassetio/managerApi/test_hostsession.py
+++ b/tests/python/openassetio/managerApi/test_hostsession.py
@@ -65,9 +65,8 @@ class Test_HostSession_host:
         assert actual_host is a_host
 
 
-class TestHostSession():
-
-    def test_log(self, host_session, mock_logger):
+class TestHostSession_log:
+    def test_forwards_to_logger(self, host_session, mock_logger):
         mock_logger.reset_mock()
 
         a_message = "A message"
@@ -75,14 +74,3 @@ class TestHostSession():
 
         host_session.log(a_message, a_severity)
         mock_logger.log.assert_called_once_with(a_message, a_severity)
-
-    def test_progress(self, host_session, mock_logger):
-        a_progress = 0.1
-
-        host_session.progress(a_progress)
-        mock_logger.progress.assert_called_once_with(a_progress, None)
-
-        for message in ("A message", "", None):
-            mock_logger.reset_mock()
-            host_session.progress(a_progress, message=message)
-            mock_logger.progress.assert_called_once_with(a_progress, message=message)


### PR DESCRIPTION
Closes #504.

Migrate the `LoggerInterface` to C++ with Python bindings., removing `LoggerInterface.progress()` along the way.

This will then enable future work to fully migrate `HostSession` and `ManagerFactoryInterface` C++ without requiring Python wrappers.

Testing is a little minimal. We currently have no (Python->)C++->Python `log()` calls.  Once `HostSession` is migrated to C++, its Python tests will implicitly include a round-trip of `log()` through C++.