### PR TITLE
[Core] Rename `ManagerFactoryInterface`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,13 @@ v1.0.0-alpha.X
   consistency with the rest of the codebase.
   [#457](https://github.com/OpenAssetIO/OpenAssetIO/issues/457)
 
+- Renamed both `ManagerFactoryInterface` as well as the subclass
+  `PluginSystemManagerFactory` to `ManagerInterfaceFactoryInterface`
+  and `PluginSystemManagerInterfaceFactory`, respectively, to avoid
+  potential ambiguity. I.e. that they instantiate instances of
+  `ManagerInterface` rather than `Manager`.
+  [#506](https://github.com/OpenAssetIO/OpenAssetIO/issues/506)
+
 - Renamed the `LoggerInterface` constant `kDebugAPI` to `kDebugApi`.
   [#457](https://github.com/OpenAssetIO/OpenAssetIO/issues/457)
 

--- a/doc/src/Examples.dox
+++ b/doc/src/Examples.dox
@@ -25,7 +25,7 @@
  * @code{.py}
  * from openassetio.log import ConsoleLogger, SeverityFilter
  * from openassetio.hostApi import HostInterface, Manager, Session
- * from openassetio.pluginSystem import PluginSystemManagerFactory
+ * from openassetio.pluginSystem import PluginSystemManagerInterfaceFactory
  *
  * class ExampleHost(HostInterface):
  *     """
@@ -48,7 +48,7 @@
  * # We need to provide the mechanism by which managers are created, the
  * # built-in plugin system allows these to be loaded from
  * # FOUNDRY_ASSET_PLUGIN_PATH.
- * factory = PluginSystemManagerFactory(logger)
+ * factory = PluginSystemManagerInterfaceFactory(logger)
  *
  * # We then need out implementation of the HostInterface class
  * host_interface = ExampleHost()

--- a/doc/src/ForHosts.dox
+++ b/doc/src/ForHosts.dox
@@ -87,8 +87,8 @@
  *      in a @ref openassetio.log.SeverityFilter "SeverityFilter".
  *    - A `managerFactory` capable of instantiating managers,
  *      in the majority of cases a default-configured @ref
- *      openassetio.pluginSystem.PluginSystemManagerFactory
- *      "PluginSystemManagerFactory" will be sufficient.
+ *      openassetio.pluginSystem.PluginSystemManagerInterfaceFactory
+ *      "PluginSystemManagerInterfaceFactory" will be sufficient.
  *
  * - Create, persist and configure a @ref Context as appropriate for
  *   all calls to the API.

--- a/python/openassetio/hostApi/ManagerInterfaceFactoryInterface.py
+++ b/python/openassetio/hostApi/ManagerInterfaceFactoryInterface.py
@@ -14,30 +14,30 @@
 #   limitations under the License.
 #
 """
-@namespace openassetio.hostApi.ManagerFactoryInterface
-A single-class module, providing the ManagerFactoryInterface class.
+@namespace openassetio.hostApi.ManagerInterfaceFactoryInterface
+A single-class module, providing the ManagerInterfaceFactoryInterface class.
 """
 
 
 import abc
 
 
-__all__ = ['ManagerFactoryInterface']
+__all__ = ['ManagerInterfaceFactoryInterface']
 
 
-class ManagerFactoryInterface(object, metaclass=abc.ABCMeta):
+class ManagerInterfaceFactoryInterface(object, metaclass=abc.ABCMeta):
     """
     Manager Factories are responsible for instantiating classes that
     derive from @ref openassetio.managerApi.ManagerInterface or @needsref
     openassetio-ui.implementation.ManagerUIDelegate for use within an
     host.
 
-    ManagerFactoryInterface defines the abstract interface that any such
-    factory must adopt.
+    ManagerInterfaceFactoryInterface defines the abstract interface that
+    any such factory must adopt.
     """
 
     def __init__(self, logger):
-        super(ManagerFactoryInterface, self).__init__()
+        super(ManagerInterfaceFactoryInterface, self).__init__()
         self._logger = logger
 
     @abc.abstractmethod

--- a/python/openassetio/hostApi/Session.py
+++ b/python/openassetio/hostApi/Session.py
@@ -74,17 +74,17 @@ class Session(Debuggable):
         desired.
 
         @param managerFactory
-        openassetio.hostApi.ManagerFactoryInterface An in stance of some
+        openassetio.hostApi.ManagerInterfaceFactoryInterface An in stance of some
         factory that will provide instances of a manager's
         ManagerInterface as required by the session.
 
           @see @ref useManager
           @see @ref currentManager
           @see @ref openassetio.log "log"
-          @see @ref openassetio.hostApi.ManagerFactoryInterface
-          "ManagerFactoryInterface"
-          @see @ref openassetio.pluginSystem.PluginSystemManagerFactory
-          "PluginSystemManagerFactory"
+          @see @ref openassetio.hostApi.ManagerInterfaceFactoryInterface
+          "ManagerInterfaceFactoryInterface"
+          @see @ref openassetio.pluginSystem.PluginSystemManagerInterfaceFactory
+          "PluginSystemManagerInterfaceFactory"
         """
         super(Session, self).__init__()
 
@@ -111,7 +111,8 @@ class Session(Debuggable):
     def registeredManagers(self):
         # pylint: disable=line-too-long
         """
-        @see @ref openassetio.pluginSystem.PluginSystemManagerFactory.PluginSystemManagerFactory.managers "managers"
+        @see @ref openassetio.pluginSystem.PluginSystemManagerInterfaceFactory.PluginSystemManagerInterfaceFactory.managers
+        "managers"
         """
         return self._factory.managers()
 

--- a/python/openassetio/hostApi/__init__.py
+++ b/python/openassetio/hostApi/__init__.py
@@ -25,7 +25,7 @@ see @ref openassetio.managerApi.
 
 from .. import _openassetio  # pylint: disable=no-name-in-module
 from .Manager import Manager
-from .ManagerFactoryInterface import ManagerFactoryInterface
+from .ManagerInterfaceFactoryInterface import ManagerInterfaceFactoryInterface
 from .Session import Session
 
 ## Python binding of \fqref{hostApi.HostInterface} "C++ HostInterface".

--- a/python/openassetio/pluginSystem/ManagerPlugin.py
+++ b/python/openassetio/pluginSystem/ManagerPlugin.py
@@ -77,8 +77,8 @@ class ManagerPlugin(PluginSystemPlugin):
         to be bound to the Host-facing @ref openassetio.hostApi.Manager.
 
         Generally this is only directly called by the @ref
-        openassetio.pluginSystem.PluginSystemManagerFactory. It may be
-        called multiple times in a session, but there as the
+        openassetio.pluginSystem.PluginSystemManagerInterfaceFactory. It
+        may be called multiple times in a session, but there as the
         ManagerInterface API itself is specified as being stateless
         (aside from any internal caching/etc...) then there is no
         pre-requisite to always return a new instance.

--- a/python/openassetio/pluginSystem/PluginSystemManagerInterfaceFactory.py
+++ b/python/openassetio/pluginSystem/PluginSystemManagerInterfaceFactory.py
@@ -14,21 +14,22 @@
 #   limitations under the License.
 #
 """
-@namespace openassetio.pluginSystem.PluginSystemManagerFactory
-A single-class module, providing the PluginSystemManagerFactory class.
+@namespace openassetio.pluginSystem.PluginSystemManagerInterfaceFactory
+A single-class module, providing the PluginSystemManagerInterfaceFactory
+class.
 """
 
 import os
 
-from ..hostApi.ManagerFactoryInterface import ManagerFactoryInterface
+from ..hostApi.ManagerInterfaceFactoryInterface import ManagerInterfaceFactoryInterface
 
 from .PluginSystem import PluginSystem
 
 
-__all__ = ['PluginSystemManagerFactory', ]
+__all__ = ['PluginSystemManagerInterfaceFactory', ]
 
 
-class PluginSystemManagerFactory(ManagerFactoryInterface):
+class PluginSystemManagerInterfaceFactory(ManagerInterfaceFactoryInterface):
     """
     A Factory to manage @ref openassetio.pluginSystem.ManagerPlugin
     derived plugins and instantiation of Manager and UIDelegate
@@ -46,7 +47,7 @@ class PluginSystemManagerFactory(ManagerFactoryInterface):
 
     def __init__(self, logger, paths=None):
 
-        super(PluginSystemManagerFactory, self).__init__(logger)
+        super(PluginSystemManagerInterfaceFactory, self).__init__(logger)
 
         self.__pluginManager = None
         self.__instances = {}

--- a/python/openassetio/pluginSystem/__init__.py
+++ b/python/openassetio/pluginSystem/__init__.py
@@ -23,4 +23,4 @@ openassetio package.
 from .ManagerPlugin import ManagerPlugin
 from .PluginSystem import PluginSystem
 from .PluginSystemPlugin import PluginSystemPlugin
-from .PluginSystemManagerFactory import PluginSystemManagerFactory
+from .PluginSystemManagerInterfaceFactory import PluginSystemManagerInterfaceFactory

--- a/python/openassetio/test/manager/_implementation.py
+++ b/python/openassetio/test/manager/_implementation.py
@@ -35,7 +35,7 @@ def createHarness(managerIdentifier, settings=None):
     """
     hostInterface = _ValidatorHarnessHostInterface()
     logger = log.SeverityFilter(log.ConsoleLogger())
-    managerFactory = pluginSystem.PluginSystemManagerFactory(logger)
+    managerFactory = pluginSystem.PluginSystemManagerInterfaceFactory(logger)
 
     session = hostApi.Session(hostInterface, logger, managerFactory)
     session.useManager(managerIdentifier, settings)

--- a/tests/python/openassetio/hostApi/test_session.py
+++ b/tests/python/openassetio/hostApi/test_session.py
@@ -26,12 +26,12 @@ from unittest import mock
 import pytest
 
 from openassetio import constants, exceptions, log
-from openassetio.hostApi import Session, Manager, ManagerFactoryInterface
+from openassetio.hostApi import Session, Manager, ManagerInterfaceFactoryInterface
 
 
 @pytest.fixture
 def mock_manager_factory(mock_manager_interface):
-    factory = mock.create_autospec(spec=ManagerFactoryInterface)
+    factory = mock.create_autospec(spec=ManagerInterfaceFactoryInterface)
     factory.instantiate.return_value = mock_manager_interface
     return factory
 

--- a/tests/python/openassetio/pluginSystem/test_pluginsystemmanagerinterfacefactory.py
+++ b/tests/python/openassetio/pluginSystem/test_pluginsystemmanagerinterfacefactory.py
@@ -15,7 +15,7 @@
 #
 """
 These tests check the functionality of the plugin system based
-ManagerFactoryInterface implementation.
+ManagerInterfaceFactoryInterface implementation.
 """
 
 # pylint: disable=no-self-use
@@ -29,7 +29,7 @@ from unittest import mock
 import pytest
 
 from openassetio.log import LoggerInterface
-from openassetio.pluginSystem import PluginSystemManagerFactory
+from openassetio.pluginSystem import PluginSystemManagerInterfaceFactory
 
 #
 # Plugin fixtures
@@ -82,34 +82,34 @@ def a_logger():
     return mock.create_autospec(spec=LoggerInterface)
 
 
-class Test_PluginSystemManagerFactory_init:
+class Test_PluginSystemManagerInterfaceFactory_init:
 
     def test_plugin_factory_uses_the_expected_env_var(self):
-        assert PluginSystemManagerFactory.kPluginEnvVar == "OPENASSETIO_PLUGIN_PATH"
+        assert PluginSystemManagerInterfaceFactory.kPluginEnvVar == "OPENASSETIO_PLUGIN_PATH"
 
     def test_when_env_var_not_set_then_logs_warning(self, a_logger, monkeypatch):
 
-        expected_msg = f"{PluginSystemManagerFactory.kPluginEnvVar} is not set. " \
+        expected_msg = f"{PluginSystemManagerInterfaceFactory.kPluginEnvVar} is not set. " \
                         "It is somewhat unlikely that you will find any plugins..."
         expected_severity = a_logger.kWarning
 
-        if PluginSystemManagerFactory.kPluginEnvVar in os.environ:
-            monkeypatch.delenv(PluginSystemManagerFactory.kPluginEnvVar)
+        if PluginSystemManagerInterfaceFactory.kPluginEnvVar in os.environ:
+            monkeypatch.delenv(PluginSystemManagerInterfaceFactory.kPluginEnvVar)
 
-        factory = PluginSystemManagerFactory(a_logger)
+        factory = PluginSystemManagerInterfaceFactory(a_logger)
         # Plugins are scanned lazily when first requested
         _ = factory.identifiers()
         a_logger.log.assert_called_once_with(expected_msg, expected_severity)
 
 
-class Test_PluginSystemManagerFactory_identifiers:
+class Test_PluginSystemManagerInterfaceFactory_identifiers:
 
     def test_when_env_var_not_set_then_returns_empty_list(self, a_logger, monkeypatch):
 
-        if PluginSystemManagerFactory.kPluginEnvVar in os.environ:
-            monkeypatch.delenv(PluginSystemManagerFactory.kPluginEnvVar)
+        if PluginSystemManagerInterfaceFactory.kPluginEnvVar in os.environ:
+            monkeypatch.delenv(PluginSystemManagerInterfaceFactory.kPluginEnvVar)
 
-        factory = PluginSystemManagerFactory(a_logger)
+        factory = PluginSystemManagerInterfaceFactory(a_logger)
         identifiers = factory.identifiers()
         # Check it is an empty list, not None, or any other value
         # that would satisty == [] as a boolean comparison.
@@ -119,9 +119,9 @@ class Test_PluginSystemManagerFactory_identifiers:
     def test_when_env_var_empty_then_returns_empty_list(self, a_logger, monkeypatch):
 
         plugin_paths = ""
-        monkeypatch.setenv(PluginSystemManagerFactory.kPluginEnvVar, plugin_paths)
+        monkeypatch.setenv(PluginSystemManagerInterfaceFactory.kPluginEnvVar, plugin_paths)
 
-        factory = PluginSystemManagerFactory(a_logger)
+        factory = PluginSystemManagerInterfaceFactory(a_logger)
         identifiers = factory.identifiers()
         assert isinstance(identifiers, list)
         assert len(identifiers) == 0
@@ -130,24 +130,24 @@ class Test_PluginSystemManagerFactory_identifiers:
             self, a_logger, local_plugin_path,
             local_plugin_identifiers, monkeypatch):
 
-        monkeypatch.setenv(PluginSystemManagerFactory.kPluginEnvVar, local_plugin_path)
+        monkeypatch.setenv(PluginSystemManagerInterfaceFactory.kPluginEnvVar, local_plugin_path)
 
-        factory = PluginSystemManagerFactory(a_logger)
+        factory = PluginSystemManagerInterfaceFactory(a_logger)
         assert factory.identifiers() == local_plugin_identifiers
 
     def test_when_paths_set_to_local_plugin_path_then_finds_local_plugins(
             self, a_logger, local_plugin_path, local_plugin_identifiers, monkeypatch):
 
-        if PluginSystemManagerFactory.kPluginEnvVar in os.environ:
-            monkeypatch.delenv(PluginSystemManagerFactory.kPluginEnvVar)
+        if PluginSystemManagerInterfaceFactory.kPluginEnvVar in os.environ:
+            monkeypatch.delenv(PluginSystemManagerInterfaceFactory.kPluginEnvVar)
 
-        factory = PluginSystemManagerFactory(a_logger, paths=local_plugin_path)
+        factory = PluginSystemManagerInterfaceFactory(a_logger, paths=local_plugin_path)
         assert factory.identifiers() == local_plugin_identifiers
 
     def test_when_env_var_overridden_to_local_plugin_path_then_finds_local_plugins(
             self, a_logger, local_plugin_path, local_plugin_identifiers, monkeypatch):
 
-        monkeypatch.setenv(PluginSystemManagerFactory.kPluginEnvVar, "some invalid value")
+        monkeypatch.setenv(PluginSystemManagerInterfaceFactory.kPluginEnvVar, "some invalid value")
 
-        factory = PluginSystemManagerFactory(a_logger, paths=local_plugin_path)
+        factory = PluginSystemManagerInterfaceFactory(a_logger, paths=local_plugin_path)
         assert factory.identifiers() == local_plugin_identifiers

--- a/tests/python/openassetio/test/manager/conftest.py
+++ b/tests/python/openassetio/test/manager/conftest.py
@@ -51,7 +51,8 @@ def openassetio_env_with_test_resources(resources_dir, monkeypatch):
 
 @pytest.fixture
 def mock_manager_factory():
-    return mock.create_autospec(hostApi.ManagerFactoryInterface, instance=True, spec_set=True)
+    return mock.create_autospec(
+        hostApi.ManagerInterfaceFactoryInterface, instance=True, spec_set=True)
 
 
 @pytest.fixture

--- a/tests/python/openassetio/test_imports.py
+++ b/tests/python/openassetio/test_imports.py
@@ -80,8 +80,8 @@ class Test_hostApi_imports:
     def test_importing_Manager_succeeds(self):
         from openassetio.hostApi import Manager
 
-    def test_importing_ManagerFactoryInterface_succeeds(self):
-        from openassetio.hostApi import ManagerFactoryInterface
+    def test_importing_ManagerInterfaceFactoryInterface_succeeds(self):
+        from openassetio.hostApi import ManagerInterfaceFactoryInterface
 
     def test_importing_Session_succeeds(self):
         from openassetio.hostApi import Session
@@ -110,8 +110,8 @@ class Test_pluginSystem_imports:
     def test_importing_PluginSystem_succeeds(self):
         from openassetio.pluginSystem import PluginSystem
 
-    def test_importing_PluginSystemManagerFactory_succeeds(self):
-        from openassetio.pluginSystem import PluginSystemManagerFactory
+    def test_importing_PluginSystemManagerInterfaceFactory_succeeds(self):
+        from openassetio.pluginSystem import PluginSystemManagerInterfaceFactory
 
     def test_importing_PluginSystemPlugin_succeeds(self):
         from openassetio.pluginSystem import PluginSystemPlugin


### PR DESCRIPTION
Closes #506.  Renames both `ManagerFactoryInterface` as well as the subclass `PluginSystemManagerFactory` to `ManagerInterfaceFactoryInterface` and `PluginSystemManagerInterfaceFactory`, respectively.