### PR TITLE
[Tests] Fix conan install of cpython

### DIFF
--- a/resources/build/bootstrap-ubuntu-20.04.sh
+++ b/resources/build/bootstrap-ubuntu-20.04.sh
@@ -10,13 +10,14 @@ sudo apt-get install -y build-essential pkgconf clang-format-12 clang-tidy-12 py
 # These would be installed as part of the conan package install, but
 # we're caching the conan directory via the `actions/cache` Github
 # action, so a fresh Github VM is left without these system packages.
-sudo apt-get install -y  --no-install-recommends libfontenc-dev libx11-xcb-dev libxaw7-dev \
-    libxcb-dri3-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev \
-    libxcb-render-util0-dev libxcb-shape0-dev libxcb-sync-dev libxcb-util-dev libxcb-xfixes0-dev \
-    libxcb-xinerama0-dev libxcb-xkb-dev libxcomposite-dev libxcursor-dev libxdamage-dev \
-    libxfixes-dev libxi-dev libxinerama-dev libxmu-dev libxmuu-dev libxpm-dev libxrandr-dev \
-    libxres-dev libxss-dev libxtst-dev libxv-dev libxvmc-dev libxxf86vm-dev uuid-dev \
-    libxkbfile-dev
+sudo apt-get install -y --no-install-recommends libfontenc-dev libice-dev libsm-dev libx11-dev \
+ libx11-xcb-dev libxau-dev libxaw7-dev libxcb-dri3-dev libxcb-icccm4-dev libxcb-image0-dev \
+ libxcb-keysyms1-dev libxcb-randr0-dev libxcb-render0-dev libxcb-render-util0-dev \
+ libxcb-shape0-dev libxcb-sync-dev libxcb-util-dev libxcb-xfixes0-dev libxcb-xinerama0-dev \
+ libxcb-xkb-dev libxcomposite-dev libxcursor-dev libxdamage-dev libxdmcp-dev libxext-dev \
+ libxfixes-dev libxi-dev libxinerama-dev libxkbfile-dev libxmu-dev libxmuu-dev libxpm-dev \
+ libxrandr-dev libxrender-dev libxres-dev libxss-dev libxt-dev libxtst-dev libxv-dev libxvmc-dev \
+ libxxf86vm-dev uuid-dev xkb-data xtrans-dev
 
 # Install additional build tools.
 sudo pip3 install -r "$WORKSPACE/resources/build/requirements.txt"
@@ -32,7 +33,14 @@ conan profile new default --detect --force
 conan profile update settings.compiler.libcxx=libstdc++ default
 # Install openassetio third-party dependencies from public Conan Center
 # package repo.
+# TODO(DF): conan<1.51 (not yet released) has a bug that means we have
+# to allow conan recipes to try to install system packages, even if the
+# system packages are already available. In particular, this affects
+# recent versions of the xorg/system recipe (a dependency of cpython).
+# The problem is reported and fixed in https://github.com/conan-io/conan/pull/11712
 conan install --install-folder "$CONAN_USER_HOME" --build=missing \
+    -c tools.system.package_manager:mode=install \
+    -c tools.system.package_manager:sudo=True \
     "$WORKSPACE/resources/build"
 # Ensure we have the expected version of clang-* available
 sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-12 10

--- a/resources/build/requirements.txt
+++ b/resources/build/requirements.txt
@@ -1,4 +1,4 @@
-conan==1.48.1
+conan==1.50.0
 cmake==3.21
 ninja==1.10.2.3
 cpplint==1.5.5


### PR DESCRIPTION
Due to a new [`xorg/system` recipe](https://conan.io/center/xorg?version=system&revision=7c176593b897dc32de475df95d7e506c&tab=recipe), which the cpython recipe depends on, the `conan install` step on CI (and Vagrant) fails attempting to install system packages (i.e. `apt` packages).

This failure only occurred recently due to our GitHub CI cache being busted (a separate mystery).

The primary cause of the failure is because the `xorg/system` recipe has been refactored and will now always try to install the latest version of system packages, even if they are already available.

The default conan mode in this case is to only "check" if packages are installed and throw an error if they're not found (the alternative behaviour being to "install" if not found). 

However, this has a bug (reported and hopefully fixed in https://github.com/conan-io/conan/pull/11712), whereby if the recipe has specified to `apt-get update` (or platform-specific equivalent) before installing, then conan always tries and throws an error if in "check" mode:
```
    default: xorg/system: ERROR: while executing system_requirements(): Can't update because tools.system.package_manager:mode is 'check'.Please update packages manually or set 'tools.system.package_manager:mode' to 'install' in the [conf] section of the profile, or in the command line using '-c tools.system.package_manager:mode=install'
    default: ERROR: Error in system requirements
```

So switch to "install" mode, which will cause a pointless `apt-get update` followed by
> xorg/system: System requirements:  already installed

during the conan install.

Added a TODO to revisit this once conan 1.51 is released, where this problem should be fixed.

Also extracted the list of system packages required by the latest `xorg/system` recipe and updated the package list in our bootstrap script.
