### PR TITLE
[Core] Invert log severity constant order

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,11 @@ v1.0.0-alpha.X
 
 ### Breaking changes
 
+- Reversed the order of logging severity constants, such that the
+  numerical value of the constant increases with the logical severity
+  (i.e. `kDebugApi` is now `0` and `kCritical` is now `6`).
+  [#516](https://github.com/OpenAssetIO/OpenAssetIO/issues/516)
+
 - Removed the logging abstraction in `HostSession`. The `log` method has
   been replaced with the `logger` accessor that provides the sessions
   `LoggerInterface` derived class directly.

--- a/python/openassetio/log.py
+++ b/python/openassetio/log.py
@@ -40,11 +40,11 @@ class SeverityFilter(LoggerInterface):
     def __init__(self, upstreamLogger):
         LoggerInterface.__init__(self)
 
-        self.__maxSeverity = self.kWarning
+        self.__minSeverity = self.kWarning
 
         if "OPENASSETIO_LOGGING_SEVERITY" in os.environ:
             try:
-                self.__maxSeverity = int(os.environ["OPENASSETIO_LOGGING_SEVERITY"])
+                self.__minSeverity = int(os.environ["OPENASSETIO_LOGGING_SEVERITY"])
             except ValueError:
                 pass
 
@@ -60,9 +60,6 @@ class SeverityFilter(LoggerInterface):
 
     ## @name Filter Severity
     # Messages logged with a severity greater or equal to this will be displayed.
-    # Note: Confusingly, greater severities (ie. worse consequence) have a lower
-    # numerical equivalent.
-    # @todo Revisit severity <> int mappings etc...
     ## @{
 
     def setSeverity(self, severity):
@@ -75,7 +72,7 @@ class SeverityFilter(LoggerInterface):
 
         @see @ref LoggerInterface
         """
-        self.__maxSeverity = severity
+        self.__minSeverity = severity
 
     def getSeverity(self):
         """
@@ -86,7 +83,7 @@ class SeverityFilter(LoggerInterface):
 
         @see @ref LoggerInterface
         """
-        return self.__maxSeverity
+        return self.__minSeverity
 
     ## @}
 
@@ -97,7 +94,7 @@ class SeverityFilter(LoggerInterface):
         Log only if `severity` is greater than or equal to this logger's
         configured severity level.
         """
-        if severity > self.__maxSeverity:
+        if severity < self.__minSeverity:
             return
 
         self.__upstreamLogger.log(severity, message)
@@ -141,7 +138,7 @@ class ConsoleLogger(LoggerInterface):
         """
         severityStr = "[%s]" % self.kSeverityNames[severity]
         msg = "%11s: %s\n" % (severityStr, message)
-        outStream = self.__stderr if severity < self.kInfo else self.__stdout
+        outStream = self.__stderr if severity > self.kInfo else self.__stdout
         outStream.write(self.__colorMsg(msg, severity) if self.__colorOutput else msg)
 
     @staticmethod
@@ -156,7 +153,7 @@ class ConsoleLogger(LoggerInterface):
             return "%s%s%s" % (color % 6, msg, end)
         if severity == LoggerInterface.kWarning:
             return "%s%s%s" % (color % 3, msg, end)
-        if severity < LoggerInterface.kWarning:
+        if severity > LoggerInterface.kWarning:
             return "%s%s%s" % (color % 1, msg, end)
 
         return msg

--- a/src/openassetio-core/include/openassetio/LoggerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/LoggerInterface.hpp
@@ -19,10 +19,10 @@ class OPENASSETIO_CORE_EXPORT LoggerInterface {
    * @name Log Severity
    * @{
    */
-  enum Severity : EnumIdx { kCritical = 0, kError, kWarning, kProgress, kInfo, kDebug, kDebugApi };
+  enum Severity : EnumIdx { kDebugApi = 0, kDebug, kInfo, kProgress, kWarning, kError, kCritical };
 
-  static constexpr EnumNames<7> kSeverityNames{"critical", "error", "warning", "progress",
-                                               "info",     "debug", "debugApi"};
+  static constexpr EnumNames<7> kSeverityNames{"debugApi", "debug", "info",    "progress",
+                                               "warning",  "error", "critical"};
   /// @}
 
   virtual ~LoggerInterface() = 0;

--- a/tests/python/openassetio/test/manager/test_main.py
+++ b/tests/python/openassetio/test/manager/test_main.py
@@ -54,7 +54,7 @@ class Test_CLI_exit_code:
 class Test_CLI_output:
 
     def test_api_logging_goes_to_standard_out(self, a_passing_fixtures_file, monkeypatch):
-        monkeypatch.setenv("OPENASSETIO_LOGGING_SEVERITY", "6")
+        monkeypatch.setenv("OPENASSETIO_LOGGING_SEVERITY", "0")
         assert "[debug]: PythonPluginSystem" in str(execute_cli(a_passing_fixtures_file).stdout)
 
     def test_unittest_output_written_to_stderr(self, a_passing_fixtures_file):

--- a/tests/python/openassetio/test_log.py
+++ b/tests/python/openassetio/test_log.py
@@ -41,6 +41,7 @@ def severity_filter(mock_logger):
     return lg.SeverityFilter(mock_logger)
 
 
+# Ordered by increasing severity value
 all_severities = (
     lg.LoggerInterface.kDebugApi,
     lg.LoggerInterface.kDebug,
@@ -63,6 +64,10 @@ class Test_LoggerInterface:
         assert lg.LoggerInterface.kSeverityNames[lg.LoggerInterface.kInfo] == "info"
         assert lg.LoggerInterface.kSeverityNames[lg.LoggerInterface.kDebug] == "debug"
         assert lg.LoggerInterface.kSeverityNames[lg.LoggerInterface.kDebugApi] == "debugApi"
+
+    def test_severity_index(self):
+        for index, severity in enumerate(all_severities):
+            assert severity.value == index
 
 
 class Test_SeverityFilter_init:
@@ -123,7 +128,7 @@ class Test_SeverityFilter_log:
             for message_severity in all_severities:
                 mock_logger.mock.reset_mock()
                 severity_filter.log(message_severity, msg)
-                if message_severity <= filter_severity:
+                if message_severity >= filter_severity:
                     mock_logger.mock.log.assert_called_once_with(
                         message_severity, msg)
                 else:


### PR DESCRIPTION
Reverses the order of logging severity constants, such that a logically higher severity now has a higher associated numeric value.

Closes #516

