### PR TITLE
[Docs] Decision records for entity reference validation workflow

### DIFF
--- a/decisions/DR011-Entity-reference-type-safety.md
+++ b/decisions/DR011-Entity-reference-type-safety.md
@@ -1,0 +1,360 @@
+# DR011 Entity reference type-safety
+
+- **Status:** Decided
+- **Impact:** Medium
+- **Driver:** @feltech
+- **Approver:** @foundrytom
+- **Outcome:** Use strongly-typed entity reference identifier.
+
+## Background
+
+The current API assumes a "honor agreement" in which the host will never
+pass a string to an API call that accepts an entity reference unless it
+has first run it through `isEntityReference` at least once, and that
+method has returned `True` for the manager in question.
+
+Note that this does not imply the entity reference actually corresponds
+to an entity, only that it is understood and handled by a particular
+manager.
+
+This is specifically to allow a manager implementation to assume that
+any input to a method that takes entity reference does not need
+re-validating. This reduces runtime overhead and simplifies their
+implementation.
+
+However, this trust-based system does not preclude a host passing an
+invalid identifier to a manager.
+
+So we're faced with the question, how can we enforce that an entity
+reference passed to API methods has been validated as relevant to the
+target manager?
+
+## Relevant data
+
+See issue [#532](https://github.com/OpenAssetIO/OpenAssetIO/issues/532).
+
+In some cases, managers may provide a prefix through `info()` that
+allows the API middleware to accelerate this test when a manager
+implementation is purely in Python to avoid costly GIL acquisitions.
+
+A typical production asset-centric render may reference millions of
+entity references, and each reference may well be of non-trivial length,
+so references should not use memory longer than their natural scope in
+the host codebase.
+
+In theory, a host only needs to check `isEntityReference` once for any
+given string/manager combination, and that string can then be used with
+any other API method with that manager.
+
+However, there is an obvious potential for host applications to break
+this contract, either by not validating the reference or by validating
+against the wrong manager implementation.
+
+From this we can see there are two questions that must be answered
+before we can guarantee to a manager that an entity reference is
+relevant to them:
+
+1. Is the string an entity reference?
+2. Is the entity reference relevant for the target manager?
+
+In the current API, this translates to
+
+1. Has `isEntityReference` been called on the string?
+2. Was `isEntityReference` called using the correct manager
+   implementation?
+
+The current trust-based system solves this by simply assuming the host
+application will satisfy the contract. Ideally these questions could be
+answered and enforced automatically, and cheaply.
+
+One further consideration is the possibility of entity references that
+are known to be valid. For example, they may have been validated at some
+point in the past or in a separate process. Forcing an ultimately
+pointless (if cheap) `isEntityReference` check in this case is
+undesirable. Again, the current trust-based system solves this
+trivially, if not robustly.
+
+### References
+
+#### Issues
+
+See issue [#532](https://github.com/OpenAssetIO/OpenAssetIO/issues/532).
+
+#### Projects
+
+**OpenTimelineIO** has `SerializableObject::ReferenceId`, which is
+deserialised from JSON objects with schema `SerializableObjectRef.1`. It
+simply stores a `std::string id` field. The `id` is looked up in a
+`_Resolver`'s `std::map` of `std::string` to `SerializableObject`.
+
+They also have `ExternalReference`, which is perhaps most comparable to
+an entity reference, and acts as a strong type containing a
+`target_url` field, as well as metadata fields.
+
+**USD** uses interned strings, which
+has [caused some problems](https://github.com/PixarAnimationStudios/USD/issues/1287).
+Their `TfToken` type is a globally interned string type for efficient
+comparison, assignment, and hashing. Similarly their `SdfPath` is
+analogous to entity references and, according
+to [the docs](https://graphics.pixar.com/usd/dev/api/class_sdf_path.html#details)
+> uses a global prefix tree to efficiently share representations of
+> paths
+
+They make specific mention of thread-safety of the global store, which
+comes at a cost when creating or copying paths.
+
+#### Articles
+
+FluentCpp's
+[Strong types for strong interfaces](https://www.fluentcpp.com/2016/12/08/strong-types-for-strong-interfaces/)
+and
+[Struct as strong type](https://www.fluentcpp.com/2018/04/06/strong-types-by-struct/)
+
+## Options considered
+
+### Option 1
+
+Keep the current trust-based solution expecting hosts to call
+`isEntityReference` before using a reference in any manager API call.
+
+#### Pros
+
+- Conceptually simple.
+- No changes required.
+- No global state.
+- Assuming entity references are valid when used means zero validation
+  cost in manager API methods.
+- Trivial language bindings - everything supports strings.
+- String types often have many built-in conveniences, e.g. native
+  support for hashing (dictionaries, sets) and serialisation.
+
+#### Cons
+
+- Relies on trust - easy to break.
+- A non-reference string argument for a function can be erroneously
+  given a reference (and vice versa) and compilers/linters will not
+  complain.
+
+Estimated cost: Small
+
+### Option 2
+
+Strong typing: add a custom type `EntityRef` that wraps a string
+reference, and require that type in all manager API calls that take (or
+return) an entity reference.
+
+Instances of the custom type can only be constructed by
+`Manager.createEntityReference`, which throws an exception if the
+reference is not valid.
+
+`createEntityReference` does not need to be implemented by the manager
+plugin, this is a convenience that will make use of the current API's
+`isEntityReference`.
+
+#### Pros
+
+- Compile-time enforcement that a reference was validated. Though not
+  necessarily for the appropriate manager.
+- An entity reference type can contain a reference to the manager that
+  generated it, allowing for (cheap) validation that a reference is
+  relevant to a given manager. This could be added to all middleware
+  methods as further validation.
+- If independently trivially constructible, then retains the advantage
+  of allowing optional circumvention of `isEntityReference`, for
+  references the host is already sure of.
+- No need for global state.
+- Strong typing of domain concepts, avoiding "primitive obsession", is
+  considered good coding practice. E.g. it prevents passing an entity
+  reference to the wrong argument of a function that happens to also be
+  a string.
+- Extensible, open to future modification.
+- Adds the possibility of implementation of references as a polymorphic
+  class, allowing the manager implementation the opportunity to return a
+  subclass instance bundling arbitrary additional data.
+
+#### Cons
+
+- Assuming the reference type can be trivially constructed without
+  validation, this raises similar trust issues to just using
+  strings. Mitigated by the fact that hosts must very intentionally
+  do this, so it's less likely that they simply "forgot" to validate.
+  Further mitigated if we enforce validation in the constructor, with
+  potentially an optional `dontValidate` parameter.
+- A manager may assume the string is a reference, but not that it is
+  relevant to that particular manager, without further probing.
+- Validation that a reference is relevant to a given manager, added to
+  all middleware methods, would introduce some runtime cost. Mitigated
+  by making such checks a debug-only feature, if we assume that a
+  badly-behaved host is a particularly exceptional case.
+- Maintenance burden of a custom type and its language bindings.
+- Serialisation and transfer across processes/languages is more complex
+  than using a native type that is widely understood, such as a string.
+
+Estimated cost: Medium
+
+### Option 3
+
+Use an interned string type, with a per-manager database. That is, a
+call to `createEntityReference` returns an index to an entity reference
+string in a manager-specific database, or raises an exception if the
+reference is not valid.
+
+`createEntityReference` does not need to be implemented by the manager
+plugin, this is a convenience that will make use of the current API's
+`isEntityReference` (assuming the string is not already interned).
+
+#### Pros
+
+- Conceptually simple and intuitive as "just like a string".
+- Compile-time enforcement that a reference was validated. Though not
+  necessarily for the appropriate manager.
+- Attempts by the manager to unpack a reference that is not meant for
+  it can give an explicit, easy to understand, runtime error.
+- No way to circumvent validation, removing a class of programmer error.
+- Low memory overhead within a host for storage of many references to
+  the same entity.
+
+#### Cons
+
+- Additional memory overhead of caching valid references. 1 million
+  references at 100 (UTF-8) characters each is approx 100 MB.
+- Assumes that the associated manager cache is always available, meaning
+  either global state or indefinite lifetime of manager instances.
+- No way to circumvent validation, even if the host is certain the
+  reference is valid.
+- Database state is not trivially available across processes, so
+  entity references may need pointlessly re-validating.
+- Maintenance burden of a non-native custom/third-party type and its
+  language bindings.
+
+Estimated cost: Medium
+
+## Outcome
+
+Option 2 was chosen. The combination of strong typing, extensibility
+and lack of need for a global cache, make it the clear winner.
+
+There are still workflow questions to be answered. However, it seems
+clear that we should, at least initially, mirror the
+`Manager.createContext` function with a `Manager.createEntityReference`
+function.
+
+Validation that a reference was created for the relevant manager can be
+added to the middleware (enabled/disabled by a global flag).
+
+## Appendix
+
+### Option 2 - Usage sketch
+
+**Host**
+
+```python
+# Assume constructible from a manager, which validates.
+checked_ref: EntityReference = manager.createEntityReference(
+    "ref://to.check")
+
+# Assume constructible independently, which may or may not validate.
+known_good_ref = EntityRef(manager, "ref://known.good")
+
+refs = [checked_ref, known_good_ref]
+
+
+# Resolve the refs we've got, now we're pretty sure they're all valid
+# for the manager.
+
+def success_callback(idx, traits_data):
+    process_location(
+        LocateableContentTrait(traits_data).getLocation())
+
+
+def error_callback(idx, error):
+    if error.code == kEntityResolutionError:
+        # Maybe we made a mistake...
+        if not refs[idx].isForManager(manager):
+            # We passed the wrong ref to the wrong manager.
+            # Note that this could be a check in the middleware instead.
+            # Checking it here is too late, really, since a malformed
+            # ref was sent to the manager.  We're just lucky we didn't
+            # cause a nastier exception during `resolve`.
+            raise RuntimeError(
+                "Programming error! Ref resolved with wrong manager.")
+
+    log.warn("Error resolving %s" % refs[idx])
+
+
+manager.resolve(refs, {LocateableContent.kID}, context,
+                success_callback, error_callback)
+```
+
+**Manager**
+
+We assume the strongly typed `ref` `EntityReference` instance has a
+`toString`-like method.
+
+```python
+def resolve(self, refs, traitSet, context, hostSession,
+            success_callback, error_callback):
+    for idx, ref in enumerate(refs):
+        ams_data = backend.resolve(traitSet, ref.toString())
+        if not ams_data:
+            error_callback(
+                idx, ErrorMessageAndCode("Failed to resolve",
+                                         kEntityResolutionError))
+        else:
+            success_callback(idx, convert_to_traits_data(ams_data))
+```
+
+### Option 3 - Usage sketch
+
+**Host**
+
+```python
+# Assume constructible from a manager, which validates.
+ref: EntityReference = manager.createEntityReference("ref://to.check")
+
+
+# ... Do some other work...
+
+def success_callback(idx, traits_data):
+    process_location(
+        LocateableContentTrait(traits_data).getLocation())
+
+
+def error_callback(idx, error):
+    log.warn("No location for ref %s" % refs[idx])
+
+
+try:
+    # Resolve using what we hope is the same manager just bound to a
+    # different variable name.
+    other_manager.resolve([ref], {LocateableContent.kID}, context,
+                          success_callback, error_callback)
+
+except ManagerMismatchError:
+    # Will be triggered if the manager attempts to unpack a ref that
+    # was meant for a different manager.
+    log.error("Programming error! Ref resolved with wrong manager.")
+    return False
+```
+
+**Manager**
+
+In order to extract the underlying string of the reference, the
+`toString` method must be given a manager whose database should be
+queried.
+
+```python
+def resolve(self, refs, traitSet, context, hostSession):
+    for idx, ref in enumerate(refs):
+        # Note: toString may raise an exception if a ref for another
+        # manager was given. This is an exceptional case that should
+        # never happen in a well-behaved host, so don't bother guarding
+        # against it and just let any exception propagate.
+        ams_data = backend.resolve(traitSet, ref.toString(self))
+        if not ams_data:
+            error_callback(
+                idx, ErrorMessageAndCode("Failed to resolve",
+                                         kEntityResolutionError))
+        else:
+            success_callback(idx, convert_to_traits_data(ams_data))
+```

--- a/decisions/DR012-Entity-reference-validation-workflow.md
+++ b/decisions/DR012-Entity-reference-validation-workflow.md
@@ -1,0 +1,375 @@
+# DR012 Entity reference validation workflow
+
+- **Status:** Decided
+- **Impact:** Medium
+- **Driver:** @feltech
+- **Approver:** @foundrytom
+- **Outcome:** Support all options: `isEntityReference`, and both
+  throwing and `optional`-based variants of `createEntityReference`
+
+## Background
+
+The current API's `Manager.isEntityReference` must be called by
+a host before the entity reference is used. This is a brittle mechanism
+based on trust.
+
+The result of [DR011](DR011-Entity-reference-type-safety.md) was to use
+strongly typed identifiers for entity references instead. This allows
+(some) compile-time guarantees, extensibility, and opens up additional
+validation options.
+
+However, `isEntityReference` is also useful for the host, allowing it to
+(cheaply) decide whether to use an assetized or non-assetized code path
+when given a string to process.
+
+This begs the question, with the new strong typing mechanism, what is
+the host workflow for deciding on asssetized vs. non-assetized code
+paths?
+
+## Relevant data
+
+A host may find themselves with one or more strings that must be
+checked to see whether they are an entity reference, before taking the
+appropriate code path.
+
+For example, a FileWrite widget may store a raw file path, or may store
+an entity reference. In the former case the code path would perform a
+non-assetized workflow, in the latter case the code path would typically
+need to validate the entity reference, call `preflight`, write the file,
+then call `register`.
+
+Another example could be a node graph that is optimised to prefetch
+nodes' associated scripts in a batch. In this case, each node may store
+a raw file path, or may store an entity reference. The host must iterate
+over the nodes and decide which should use a direct file load
+and which need to be `resolve`d first, then take the appropriate code
+path.
+
+We can assume that testing whether a string is an entity reference,
+relevant to a given manager, is a cheap operation. It is performed
+entirely in-process within the plugin (possibly even in the middleware
+if a prefix is given by `Manager.info()`). In an analogy to URLs,
+`isEntityReference` is like checking the URL schema. In particular, this
+means entity-specific details, e.g. whether a URL query parameter is
+relevant for the type of entity being referenced, is out of scope for
+`isEntityReference`.
+
+The sketch of the `Manager.createEntityReference` method from
+[DR011](DR011-Entity-reference-type-safety.md) assumes the method throws
+if given an invalid reference, which means the only way an `EntityRef`
+type is constructed is when a manager (not necessarily the appropriate
+manager) has deemed an entity reference to be valid. In this way we
+have a partial C++ compile-time guarantee to methods that take entity
+reference arguments, such as `resolve`, that the `EntityRef`s provided
+have been validated.
+
+### References
+
+See issue [#532](https://github.com/OpenAssetIO/OpenAssetIO/issues/532).
+
+## Options considered
+
+### Option 1
+
+Allow hosts to call `isEntityReference` as well as
+`createEntityReference` (which throws if given an invalid reference).
+
+#### Pros
+
+- No need to (try to) construct an object just for a boolean comparison.
+- Obvious self-documenting usage.
+- Clear language bindings based on existing patterns.
+- No way to construct an invalid entity reference.
+
+#### Cons
+
+- Duplicated validation effort if the code path goes on to use
+  `createEntityReference`.
+- Hosts may forget to check `isEntityReference` first, leading to
+  unexpected exceptions.
+
+### Option 2
+
+`isEntityReference` is hidden from the host. `createEntityReference` is
+the only way to construct and validate an entity reference, and
+throws if invalid.
+
+#### Pros
+
+- Only one way to accomplish validation and construction.
+- Validation and construction are performed in one operation.
+- Clear language bindings based on existing patterns.
+- No way to construct an invalid entity reference.
+
+#### Cons
+
+- Host must use exceptions to test validity, increasing boilerplate
+  and reducing performance.
+- If the host just wants to test validity (e.g. in order to choose a
+  code path), then there is no way to do this without also constructing
+  a throwaway object.
+
+### Option 3
+
+`isEntityReference` hidden from the host. `createEntityReferenceIfValid`
+is instead used to return an `optional<EntityRef>` in C++
+(`None`/`EntityRef` in Python; `NULL` (and error code)/`EntityRef_h` in
+C).
+
+#### Pros
+
+- Only one way to accomplish validation and construction.
+- Validation and construction are performed in one operation.
+- Lowest host boilerplate for many workflows, utilising modern C++.
+- If using  `optional::value()` to extract the `EntityRef` before
+  passing to API methods, then safety is guaranteed, since a
+  `bad_optional_access` will be thrown if invalid (though less
+  informative than a custom exception).
+- Pybind has built-in support for `std::optional`, translating "not set"
+  to `None`.
+
+#### Cons
+
+- Very slightly less performant than `isEntityReference` in the invalid
+  reference case (at the risk of second-guessing compiler
+  optimisations).
+- Not immediately obvious in Python that the host must test the returned
+  value is valid (not `None`).
+- Uses a different optional API to `TraitsData`, decided
+  in [DR010](DR010-TraitsData-value-retrieval-API.md).
+  Though many of the arguments do not hold for this case (e.g.
+  direct-assignment to existing variables; detailed result codes).
+- Using the dereferencing operator (`*`) on a `std::optional` is unsafe
+  and loses the compile-time guarantee that the entity reference is
+  safe before being passed to API methods.
+- Language bindings to C and Python have a different interface than C++.
+
+## Outcome
+
+Based on the sketches in the Appendix (below) and the various pros and
+cons we have decided on supporting all workflows, i.e. implementing
+Option 1 and 3 (with Option 2 supported implicitly).
+
+The number of potential host workflows, which we have little visibility
+on at present, mean that all options have enough merits to warrant
+first-class inclusion in the core API.
+
+## Appendix
+
+### Sketch - Publishing from a FileWidget
+
+We assume a `FileWidget` that may either contain a path or an entity
+reference, and the application must take a different code path for
+each case.
+
+#### Option 1
+
+```python
+file_path_or_ref = file_widget.get_value()
+
+if manager.isEntityReference(file_path_or_ref):
+    # Note: duplicated validation.
+    ref = manager.createEntityReference(file_path_or_ref)
+    assetized_publish(ref)
+else:
+    publish(file_path_or_ref)
+```
+
+#### Option 2
+
+```python
+file_path_or_ref = file_widget.get_value()
+
+try:
+    ref = manager.createEntityReference(file_path_or_ref)
+except InvalidEntityReferenceError:
+    publish(file_path_or_ref)
+else:
+    assetized_publish(ref)
+```
+
+#### Option 3
+
+```python
+file_path_or_ref = file_widget.get_value()
+
+if ref := manager.createEntityReferenceIfValid(file_path_or_ref):
+    assetized_publish(ref)
+else:
+    publish(file_path_or_ref)
+```
+
+### Sketch - Assetized workflow is unsupported
+
+We assume an application with a code path that does not support
+an assetized workflow, and so rejects strings that are entity
+references.
+
+#### Option 1
+
+```python
+file_path_or_ref = file_widget.get_value()
+
+if manager.isEntityReference(file_path_or_ref):
+    raise TypeError("Assetized workflow is not yet supported")
+
+process_file_path(file_path_or_ref)
+```
+
+#### Option 2
+
+```python
+file_path_or_ref = file_widget.get_value()
+
+try:
+    manager.createEntityReference(file_path_or_ref)
+except InvalidEntityReferenceError:
+    pass
+else:
+    raise TypeError("Assetized workflow is not yet supported")
+
+process_file_path(file_path_or_ref)
+```
+
+#### Option 3
+
+```python
+file_path_or_ref = file_widget.get_value()
+
+if manager.createEntityReferenceIfValid(file_path_or_ref):
+    raise TypeError("Assetized workflow is not yet supported")
+
+process_file_path(file_path_or_ref)
+```
+
+### Sketch - Resolving a batch of references
+
+We assume a node graph where each node is associated with a script file
+to be loaded. The script file loading process is executed for all nodes
+batched together. A node may have a raw file path or may have an
+entity reference pointing to the script. We are unsure during the
+loading process whether a node stores a raw file path or an entity
+reference.
+
+#### Option 1
+
+```python
+refs = []
+paths = []
+assetized_nodes = []
+nonassetized_nodes = []
+
+for node in node_graph:
+    file_path_or_ref = node.get_script()
+
+    if manager.isEntityReference(file_path_or_ref):
+        assetized_nodes.append(node)
+        ref = manager.createEntityReference(file_path_or_ref)
+        refs.append(ref)
+    else:
+        nonassetized_nodes.append(node)
+        paths.append(file_path_or_ref)
+
+# Process nodes whose script path is a raw file system path.
+
+for node, path in zip(nonassetized_nodes, paths):
+    node.load_from_file(path)
+
+
+# Process nodes whose script path is an assetized url.
+
+def success_callback(idx, traits_data):
+    node = assetized_nodes[idx]
+    url = LocateableContentTrait(traits_data).getLocation()
+    node.load_from_url(url)
+
+
+def error_callback(idx, error):
+    log.error(error.message)
+
+
+manager.resolve(refs, {LocateableContentTrait.kID}, context,
+                success_callback, error_callback)
+```
+
+#### Option 2
+
+```python
+refs = []
+paths = []
+assetized_nodes = []
+nonassetized_nodes = []
+
+for node in node_graph:
+    file_path_or_ref = node.get_script()
+
+    try:
+        ref = manager.createEntityReference(file_path_or_ref)
+    except InvalidEntityReferenceError:
+        nonassetized_nodes.append(node)
+        paths.append(file_path_or_ref)
+    else:
+        assetized_nodes.append(node)
+        refs.append(ref)
+
+# ... Remainder is identical to option 1 ...
+```
+
+#### Option 3
+
+```python
+refs = []
+paths = []
+assetized_nodes = []
+nonassetized_nodes = []
+
+for node in node_graph:
+    file_path_or_ref = node.get_script()
+
+    if ref := manager.createEntityReferenceIfValid(file_path_or_ref):
+        assetized_nodes.append(node)
+        refs.append(ref)
+    else:
+        nonassetized_nodes.append(node)
+        paths.append(file_path_or_ref)
+
+# ... Remainder is identical to option 1 ...
+```
+
+### Sketch - Processing references from an AssetWidget
+
+We assume a widget that has prior knowledge that the strings it stores
+are pre-validated asset references (perhaps coming from UI delegation to
+a manager plugin) against a known manager.
+
+We further assume that switching to a different manager plugin and
+attempting to use a now-incorrect entity reference from the
+`AssetWidget` is a rare exceptional case.
+
+#### Option 1 / 2
+
+We're already certain that the paths are valid for the current manager,
+and so do not need to check `isEntityReference`.
+
+```c++
+auto ref_str = asset_widget->getValue();
+// We assume the ref is relevant to the selected manager, i.e. it's
+// exceptional if not, and expected that this call will throw in that
+// case.
+auto ref = manager.createEntityReference(ref_str);
+process_entity_reference(ref);
+```
+
+#### Option 3
+
+Although we're certain that the paths are valid, we must nevertheless
+unpack an `optional`.
+
+```c++
+auto ref_str = asset_widget->getValue();
+std::optional<EntityRef> ref = manager.createEntityReferenceIfValid(ref_str);
+// Unsafe! We must _really_ be sure.
+process_entity_reference(*ref);
+// Alternatively, much safer - throws `bad_optional_access` if ref is invalid.
+process_entity_reference(ref.value());
+```


### PR DESCRIPTION
Closes #532.

Add two decision records. Firstly decide on and justify the type-safety of entity references, with respect to the entity reference string validation workflow. Secondly, decide on and justify the host API  for the validation workflow, assuming strongly typed entity references will be used.