### PR TITLE
Migrate Python loggers to C++

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -183,8 +183,8 @@ v1.0.0-alpha.X
 
 - Migrated the following classes to C++: `Context`, `Host`,
   `HostInterface`, `HostSession` and `LoggerInterface`, `ConsoleLogger`
-  and `ManagerImplementationFactoryInterface`. Debug and audit
-  functionality is left for future work.
+  `SeverityFilter` and `ManagerImplementationFactoryInterface`. Debug
+  and audit functionality is left for future work.
   [#291](https://github.com/OpenAssetIO/OpenAssetIO/issues/291)
   [#331](https://github.com/OpenAssetIO/OpenAssetIO/issues/331)
   [#455](https://github.com/OpenAssetIO/OpenAssetIO/issues/455)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -182,9 +182,9 @@ v1.0.0-alpha.X
   [#370](https://github.com/OpenAssetIO/OpenAssetIO/issues/370)
 
 - Migrated the following classes to C++: `Context`, `Host`,
-  `HostInterface`, `HostSession` and `LoggerInterface`,
-  `ManagerImplementationFactoryInterface`. Debug and audit functionality
-  is left for future work.
+  `HostInterface`, `HostSession` and `LoggerInterface`, `ConsoleLogger`
+  and `ManagerImplementationFactoryInterface`. Debug and audit
+  functionality is left for future work.
   [#291](https://github.com/OpenAssetIO/OpenAssetIO/issues/291)
   [#331](https://github.com/OpenAssetIO/OpenAssetIO/issues/331)
   [#455](https://github.com/OpenAssetIO/OpenAssetIO/issues/455)

--- a/python/openassetio/_core/debug.py
+++ b/python/openassetio/_core/debug.py
@@ -24,7 +24,7 @@ kDebug and kDebugApi logging severity displays
 
 In order to use these decorators the target class must derive from
 Debuggable, and have its `_debugLogFn` set to an callable that matches
-the @fqref{LoggerInterface.log} "LoggerInterface.log" signature. This
+the @fqref{log.LoggerInterface.log} "LoggerInterface.log" signature. This
 callback will be used to output debug information. If no callback is
 set, no debug output will be produced.
 

--- a/python/openassetio/log.py
+++ b/python/openassetio/log.py
@@ -18,84 +18,9 @@
 Provides the core classes that facilitate message and progress logging.
 """
 
-import os
-
 from . import _openassetio  # pylint: disable=no-name-in-module
 
 
 LoggerInterface = _openassetio.log.LoggerInterface
 ConsoleLogger = _openassetio.log.ConsoleLogger
-
-
-
-class SeverityFilter(LoggerInterface):
-    """
-    The SeverityFilter is a wrapper for a logger that drops messages
-    below a requested severity. More severe messages are relayed.
-
-    @envvar **OPENASSETIO_LOGGING_SEVERITY** *[int]* If set, the
-    default displaySeverity for the filter is set to the value of the
-    env var.
-    """
-
-    def __init__(self, upstreamLogger):
-        LoggerInterface.__init__(self)
-
-        self.__minSeverity = self.kWarning
-
-        if "OPENASSETIO_LOGGING_SEVERITY" in os.environ:
-            try:
-                self.__minSeverity = int(os.environ["OPENASSETIO_LOGGING_SEVERITY"])
-            except ValueError:
-                pass
-
-        self.__upstreamLogger = upstreamLogger
-
-    def upstreamLogger(self):
-        """
-        Returns the logger wrapped by the filter.
-
-        @return LoggerInterface
-        """
-        return self.__upstreamLogger
-
-    ## @name Filter Severity
-    # Messages logged with a severity greater or equal to this will be displayed.
-    ## @{
-
-    def setSeverity(self, severity):
-        """
-        Sets the minimum severity of message that will be passed on to
-        the @ref upstreamLogger.
-
-        @param severity `int` One of the LoggerInterface severity
-        constants.
-
-        @see @ref LoggerInterface
-        """
-        self.__minSeverity = severity
-
-    def getSeverity(self):
-        """
-        Returns the minimum seveirty of message that will be passed on
-        to the @ref upstreamLogger by the filter.
-
-        @return `int`
-
-        @see @ref LoggerInterface
-        """
-        return self.__minSeverity
-
-    ## @}
-
-    # LoggerInterface methods
-
-    def log(self, severity, message):
-        """
-        Log only if `severity` is greater than or equal to this logger's
-        configured severity level.
-        """
-        if severity < self.__minSeverity:
-            return
-
-        self.__upstreamLogger.log(severity, message)
+SeverityFilter = _openassetio.log.SeverityFilter

--- a/python/openassetio/log.py
+++ b/python/openassetio/log.py
@@ -19,12 +19,13 @@ Provides the core classes that facilitate message and progress logging.
 """
 
 import os
-import sys
 
 from . import _openassetio  # pylint: disable=no-name-in-module
 
 
 LoggerInterface = _openassetio.log.LoggerInterface
+ConsoleLogger = _openassetio.log.ConsoleLogger
+
 
 
 class SeverityFilter(LoggerInterface):
@@ -98,62 +99,3 @@ class SeverityFilter(LoggerInterface):
             return
 
         self.__upstreamLogger.log(severity, message)
-
-
-class ConsoleLogger(LoggerInterface):
-    """
-    A simple logger that prints messages to stdout/stderr.
-    """
-
-    def __init__(self, colorOutput=True, forceDefaultStreams=False):
-        """
-        @param colorOutput bool [True] Make a vague attempt to color
-        the output using terminal escape codes.
-
-        @param forceDefaultStreams bool [False] Some applications remap
-        the std outputs. When set, logging will attempt to write to the
-        'real' sys.stderr and sys.stdout instead of the remapped
-        outputs. If these have been closed, it will fall back to the
-        remapped outputs.
-        """
-        LoggerInterface.__init__(self)
-        self.__colorOutput = colorOutput
-
-        self.__stdout = sys.stdout
-        self.__stderr = sys.stderr
-
-        if forceDefaultStreams:
-            # In some occasions, the real std outs may have been closed (for example in
-            # osx somewhere, when an app is launched in the GUI and uses something like
-            # py2app. So, we try to fall back on the facaded outs instead.
-            if not sys.__stdout__.closed:
-                self.__stdout = sys.__stdout__
-            if not sys.__stderr__.closed:
-                self.__stderr = sys.__stderr__
-
-    def log(self, severity, message):
-        """
-        Log to stderr for severity greater than `kInfo`, stdout
-        otherwise.
-        """
-        severityStr = "[%s]" % self.kSeverityNames[severity]
-        msg = "%11s: %s\n" % (severityStr, message)
-        outStream = self.__stderr if severity > self.kInfo else self.__stdout
-        outStream.write(self.__colorMsg(msg, severity) if self.__colorOutput else msg)
-
-    @staticmethod
-    def __colorMsg(msg, severity):
-
-        end = '\033[0m'
-        color = '\033[0;3%dm'
-
-        if severity == LoggerInterface.kDebug:
-            return "%s%s%s" % (color % 2, msg, end)
-        if severity == LoggerInterface.kDebugApi:
-            return "%s%s%s" % (color % 6, msg, end)
-        if severity == LoggerInterface.kWarning:
-            return "%s%s%s" % (color % 3, msg, end)
-        if severity > LoggerInterface.kWarning:
-            return "%s%s%s" % (color % 1, msg, end)
-
-        return msg

--- a/python/openassetio/log.py
+++ b/python/openassetio/log.py
@@ -24,7 +24,7 @@ import sys
 from . import _openassetio  # pylint: disable=no-name-in-module
 
 
-LoggerInterface = _openassetio.LoggerInterface
+LoggerInterface = _openassetio.log.LoggerInterface
 
 
 class SeverityFilter(LoggerInterface):

--- a/python/openassetio/managerApi/ManagerInterface.py
+++ b/python/openassetio/managerApi/ManagerInterface.py
@@ -87,7 +87,7 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
     result in output being lost.
 
     @see @fqref{managerApi.HostSession.logger} "HostSession.logger"
-    @see @fqref{LoggerInterface} "LoggerInterface"
+    @see @fqref{log.LoggerInterface} "LoggerInterface"
 
     Exceptions should be thrown to handle any in-flight errors that
     occur.  The error should be mapped to a derived class of

--- a/resources/perftest/perftest.cpp
+++ b/resources/perftest/perftest.cpp
@@ -7,9 +7,9 @@
 #include <unordered_map>
 
 #include <openassetio/Context.hpp>
-#include <openassetio/LoggerInterface.hpp>
 #include <openassetio/TraitsData.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/managerApi/Host.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 
@@ -68,8 +68,8 @@ struct Fixture {
     [[nodiscard]] openassetio::Str displayName() const override { return {}; }
   };
   /// A dummy LoggerInterface implementation
-  struct LoggerImpl : openassetio::LoggerInterface {
-    void log([[maybe_unused]] openassetio::LoggerInterface::Severity severity,
+  struct LoggerImpl : openassetio::log::LoggerInterface {
+    void log([[maybe_unused]] openassetio::log::LoggerInterface::Severity severity,
              [[maybe_unused]] const openassetio::Str& message) override {}
   };
 

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -65,6 +65,7 @@ target_sources(
     hostApi/ManagerImplementationFactoryInterface.cpp
     log/ConsoleLogger.cpp
     log/LoggerInterface.cpp
+    log/SeverityFilter.cpp
     managerApi/Host.cpp
     managerApi/HostSession.cpp
     managerApi/ManagerInterface.cpp

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -58,12 +58,12 @@ target_sources(
     openassetio-core
     PRIVATE
     Context.cpp
-    LoggerInterface.cpp
     TraitsData.cpp
     hostApi/HostInterface.cpp
     hostApi/Manager.cpp
     hostApi/ManagerFactory.cpp
     hostApi/ManagerImplementationFactoryInterface.cpp
+    log/LoggerInterface.cpp
     managerApi/Host.cpp
     managerApi/HostSession.cpp
     managerApi/ManagerInterface.cpp

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -63,6 +63,7 @@ target_sources(
     hostApi/Manager.cpp
     hostApi/ManagerFactory.cpp
     hostApi/ManagerImplementationFactoryInterface.cpp
+    log/ConsoleLogger.cpp
     log/LoggerInterface.cpp
     managerApi/Host.cpp
     managerApi/HostSession.cpp

--- a/src/openassetio-core/hostApi/ManagerFactory.cpp
+++ b/src/openassetio-core/hostApi/ManagerFactory.cpp
@@ -61,7 +61,7 @@ ManagerPtr ManagerFactory::createManager(const Identifier& identifier) const {
 ManagerPtr ManagerFactory::createManagerForInterface(
     const Identifier& identifier, const HostInterfacePtr& hostInterface,
     const ManagerImplementationFactoryInterfacePtr& managerImplementationFactory,
-    [[maybe_unused]] const log::LoggerInterfacePtr& logger) {
+    const log::LoggerInterfacePtr& logger) {
   return Manager::make(
       managerImplementationFactory->instantiate(identifier),
       managerApi::HostSession::make(managerApi::Host::make(hostInterface), logger));

--- a/src/openassetio-core/hostApi/ManagerFactory.cpp
+++ b/src/openassetio-core/hostApi/ManagerFactory.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 The Foundry Visionmongers Ltd
-#include <openassetio/LoggerInterface.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/hostApi/Manager.hpp>
 #include <openassetio/hostApi/ManagerFactory.hpp>
 #include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/managerApi/Host.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
@@ -17,7 +17,7 @@ namespace hostApi {
 ManagerFactoryPtr ManagerFactory::make(
     HostInterfacePtr hostInterface,
     ManagerImplementationFactoryInterfacePtr managerImplementationFactory,
-    LoggerInterfacePtr logger) {
+    log::LoggerInterfacePtr logger) {
   return openassetio::hostApi::ManagerFactoryPtr{new ManagerFactory{
       std::move(hostInterface), std::move(managerImplementationFactory), std::move(logger)}};
 }
@@ -25,7 +25,7 @@ ManagerFactoryPtr ManagerFactory::make(
 ManagerFactory::ManagerFactory(
     HostInterfacePtr hostInterface,
     ManagerImplementationFactoryInterfacePtr managerImplementationFactory,
-    LoggerInterfacePtr logger)
+    log::LoggerInterfacePtr logger)
     : hostInterface_{std::move(hostInterface)},
       managerImplementationFactory_{std::move(managerImplementationFactory)},
       logger_{std::move(logger)} {}
@@ -61,7 +61,7 @@ ManagerPtr ManagerFactory::createManager(const Identifier& identifier) const {
 ManagerPtr ManagerFactory::createManagerForInterface(
     const Identifier& identifier, const HostInterfacePtr& hostInterface,
     const ManagerImplementationFactoryInterfacePtr& managerImplementationFactory,
-    [[maybe_unused]] const LoggerInterfacePtr& logger) {
+    [[maybe_unused]] const log::LoggerInterfacePtr& logger) {
   return Manager::make(
       managerImplementationFactory->instantiate(identifier),
       managerApi::HostSession::make(managerApi::Host::make(hostInterface), logger));

--- a/src/openassetio-core/hostApi/ManagerImplementationFactoryInterface.cpp
+++ b/src/openassetio-core/hostApi/ManagerImplementationFactoryInterface.cpp
@@ -9,7 +9,7 @@ namespace hostApi {
 ManagerImplementationFactoryInterface::~ManagerImplementationFactoryInterface() = default;
 
 ManagerImplementationFactoryInterface::ManagerImplementationFactoryInterface(
-    LoggerInterfacePtr logger)
+    log::LoggerInterfacePtr logger)
     : logger_{std::move(logger)} {}
 }  // namespace hostApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-core/include/openassetio/hostApi/ManagerFactory.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/ManagerFactory.hpp
@@ -13,8 +13,8 @@
 OPENASSETIO_FWD_DECLARE(hostApi, HostInterface)
 OPENASSETIO_FWD_DECLARE(hostApi, Manager)
 OPENASSETIO_FWD_DECLARE(hostApi, ManagerImplementationFactoryInterface)
+OPENASSETIO_FWD_DECLARE(log, LoggerInterface)
 OPENASSETIO_FWD_DECLARE(managerApi, ManagerInterface)
-OPENASSETIO_FWD_DECLARE(LoggerInterface)
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -96,7 +96,7 @@ class OPENASSETIO_CORE_EXPORT ManagerFactory final {
   static ManagerFactoryPtr make(
       HostInterfacePtr hostInterface,
       ManagerImplementationFactoryInterfacePtr managerImplementationFactory,
-      LoggerInterfacePtr logger);
+      log::LoggerInterfacePtr logger);
 
   /**
    * All identifiers known to the factory.
@@ -168,16 +168,16 @@ class OPENASSETIO_CORE_EXPORT ManagerFactory final {
   [[nodiscard]] static ManagerPtr createManagerForInterface(
       const Identifier& identifier, const HostInterfacePtr& hostInterface,
       const ManagerImplementationFactoryInterfacePtr& managerImplementationFactory,
-      const LoggerInterfacePtr& logger);
+      const log::LoggerInterfacePtr& logger);
 
  private:
   ManagerFactory(HostInterfacePtr hostInterface,
                  ManagerImplementationFactoryInterfacePtr managerImplementationFactory,
-                 LoggerInterfacePtr logger);
+                 log::LoggerInterfacePtr logger);
 
   const HostInterfacePtr hostInterface_;
   const ManagerImplementationFactoryInterfacePtr managerImplementationFactory_;
-  const LoggerInterfacePtr logger_;
+  const log::LoggerInterfacePtr logger_;
 };
 
 }  // namespace hostApi

--- a/src/openassetio-core/include/openassetio/hostApi/ManagerImplementationFactoryInterface.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/ManagerImplementationFactoryInterface.hpp
@@ -8,7 +8,7 @@
 #include <openassetio/export.h>
 #include <openassetio/typedefs.hpp>
 
-OPENASSETIO_FWD_DECLARE(LoggerInterface)
+OPENASSETIO_FWD_DECLARE(log, LoggerInterface)
 OPENASSETIO_FWD_DECLARE(managerApi, ManagerInterface)
 
 namespace openassetio {
@@ -46,7 +46,7 @@ class OPENASSETIO_CORE_EXPORT ManagerImplementationFactoryInterface {
    * @param logger Logger object that should be used for all logging
    * by the factory. Obtainable in subclasses through @ref logger_.
    */
-  explicit ManagerImplementationFactoryInterface(LoggerInterfacePtr logger);
+  explicit ManagerImplementationFactoryInterface(log::LoggerInterfacePtr logger);
 
   virtual ~ManagerImplementationFactoryInterface() = 0;
 
@@ -75,7 +75,7 @@ class OPENASSETIO_CORE_EXPORT ManagerImplementationFactoryInterface {
   // Allow violation of no protected members, since this is const and
   // within an abstract interface.
   // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-  const LoggerInterfacePtr logger_;
+  const log::LoggerInterfacePtr logger_;
 };
 }  // namespace hostApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-core/include/openassetio/log/ConsoleLogger.hpp
+++ b/src/openassetio-core/include/openassetio/log/ConsoleLogger.hpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+
+#include <openassetio/export.h>
+#include <openassetio/log/LoggerInterface.hpp>
+
+#pragma once
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace log {
+OPENASSETIO_DECLARE_PTR(ConsoleLogger)
+/**
+ * A logger that sends messages to the console (stderr).
+ */
+class OPENASSETIO_CORE_EXPORT ConsoleLogger final : public LoggerInterface {
+ public:
+  /**
+   * Creates a new instance of the ConsoleLogger
+   *
+   * @param shouldColorOutput When true, messages will be colored based on
+   * their severity.
+   */
+  [[nodiscard]] ConsoleLoggerPtr static make(bool shouldColorOutput = true);
+
+  /**
+   */
+  void log(Severity severity, const Str& message) override;
+
+ private:
+  explicit ConsoleLogger(bool shouldColorOutput);
+
+  bool shouldColorOutput_;
+};
+}  // namespace log
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/log/LoggerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/log/LoggerInterface.hpp
@@ -8,6 +8,16 @@
 #pragma once
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
+/**
+ This namespace contains code relevant to message logging within the
+ API.
+
+ @ref host "Host" authors provide an implementation of @ref
+ LoggerInterface to a @ref manager to channel its messages. The API
+ middleware also makes use of this logger to provide debugging
+ information about use of the API at runtime.
+*/
+namespace log {
 OPENASSETIO_DECLARE_PTR(LoggerInterface)
 /**
  * An abstract base class that defines the receiving interface for
@@ -40,5 +50,6 @@ class OPENASSETIO_CORE_EXPORT LoggerInterface {
    */
   virtual void log(Severity severity, const Str& message) = 0;
 };
+}  // namespace log
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/log/SeverityFilter.hpp
+++ b/src/openassetio-core/include/openassetio/log/SeverityFilter.hpp
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+
+#include <openassetio/export.h>
+#include <openassetio/log/LoggerInterface.hpp>
+
+#pragma once
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace log {
+OPENASSETIO_DECLARE_PTR(SeverityFilter)
+/**
+ * The SeverityFilter is a wrapper for a logger that drops messages
+ * below a requested severity. More severe messages are relayed.
+ *
+ * @envvar **OPENASSETIO_LOGGING_SEVERITY** *[int]* If set, the default
+ * displaySeverity for the filter is set to the value of the env var.
+ */
+class OPENASSETIO_CORE_EXPORT SeverityFilter final : public LoggerInterface {
+ public:
+  /**
+   * Creates a new instance of the SeverityFilter
+   *
+   * The filter defaults to the @ref kWarning severity.
+   *
+   * @param upstreamLogger A logger that will receive messages of the
+   * requested severity or above.
+   *
+   * @see @fqref{log.LoggerInterface.Severity} "LoggerInterface.Severity"
+   */
+  [[nodiscard]] SeverityFilterPtr static make(LoggerInterfacePtr upstreamLogger);
+
+  /**
+   * Returns the logger wrapped by the filter.
+   */
+  [[nodiscard]] LoggerInterfacePtr upstreamLogger() const;
+
+  /**
+   * @name Filter Severity
+   * Messages logged with a severity greater or equal to this will be displayed.
+   * @{
+   */
+
+  /**
+   * Sets the minimum severity of message that will be passed on to the
+   * @ref upstreamLogger.
+   *
+   * @param severity The minimum severity.
+   *
+   * @see @fqref{log.LoggerInterface.Severity} "LoggerInterface.Severity"
+   */
+  void setSeverity(LoggerInterface::Severity severity);
+
+  /**
+   * Returns the minimum severity of message that will be passed on to the
+   * @ref upstreamLogger.
+   *
+   * @see @fqref{log.LoggerInterface.Severity} "LoggerInterface.Severity"
+   */
+  [[nodiscard]] LoggerInterface::Severity getSeverity() const;
+
+  /**
+   * @}
+   */
+
+  void log(Severity severity, const Str& message) override;
+
+ private:
+  explicit SeverityFilter(LoggerInterfacePtr upstreamLogger);
+
+  LoggerInterface::Severity minSeverity_ = kWarning;
+  LoggerInterfacePtr upstreamLogger_;
+};
+}  // namespace log
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/managerApi/HostSession.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/HostSession.hpp
@@ -7,7 +7,7 @@
 #include <openassetio/export.h>
 #include <openassetio/typedefs.hpp>
 
-OPENASSETIO_FWD_DECLARE(LoggerInterface)
+OPENASSETIO_FWD_DECLARE(log, LoggerInterface)
 OPENASSETIO_FWD_DECLARE(managerApi, Host)
 
 namespace openassetio {
@@ -30,18 +30,18 @@ OPENASSETIO_DECLARE_PTR(HostSession)
  *   - A concrete instance of the @fqref{managerApi.Host} "Host",
  *     implemented by the tool or application that initiated the API
  *     session.
- *   - A concrete instance of the @fqref{LoggerInterface}
+ *   - A concrete instance of the @fqref{log.LoggerInterface}
  *     "LoggerInterface", to be used for all message reporting.
  *
  * @see @fqref{managerApi.Host} "Host"
- * @see @fqref{LoggerInterface} "LoggerInterface"
+ * @see @fqref{log.LoggerInterface} "LoggerInterface"
  */
 class OPENASSETIO_CORE_EXPORT HostSession final {
  public:
   /**
    * Constructs a new HostSession holding the supplied host.
    */
-  static HostSessionPtr make(HostPtr host, LoggerInterfacePtr logger);
+  static HostSessionPtr make(HostPtr host, log::LoggerInterfacePtr logger);
 
   /**
    * @return The host that initiated the API session.
@@ -51,12 +51,12 @@ class OPENASSETIO_CORE_EXPORT HostSession final {
   /**
    * @return The logger associated with this session
    */
-  [[nodiscard]] LoggerInterfacePtr logger() const;
+  [[nodiscard]] log::LoggerInterfacePtr logger() const;
 
  private:
-  explicit HostSession(HostPtr host, LoggerInterfacePtr logger);
+  explicit HostSession(HostPtr host, log::LoggerInterfacePtr logger);
   HostPtr host_;
-  LoggerInterfacePtr logger_;
+  log::LoggerInterfacePtr logger_;
 };
 }  // namespace managerApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -78,7 +78,7 @@ OPENASSETIO_DECLARE_PTR(ManagerInterface)
  * result in output being lost.
  *
  * @see @fqref{managerApi.HostSession.logger} "HostSession.logger"
- * @see @fqref{LoggerInterface} "LoggerInterface"
+ * @see @fqref{log.LoggerInterface} "LoggerInterface"
  *
  * Exceptions should be thrown to handle any in-flight errors that
  * occur. The error should be mapped to a derived class of

--- a/src/openassetio-core/log/ConsoleLogger.cpp
+++ b/src/openassetio-core/log/ConsoleLogger.cpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#include <iomanip>
+#include <iostream>
+
+#include <openassetio/log/ConsoleLogger.hpp>
+
+// Foreground ANSI color codes (combined with \033[<color>m)
+constexpr const int kSeverityColors[] = {36, 32, 32, 0, 33, 31, 31};
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace log {
+ConsoleLoggerPtr ConsoleLogger::make(bool shouldColorOutput) {
+  return std::shared_ptr<ConsoleLogger>(new ConsoleLogger(shouldColorOutput));
+}
+
+ConsoleLogger::ConsoleLogger(bool shouldColorOutput) : shouldColorOutput_(shouldColorOutput) {}
+
+void ConsoleLogger::log(Severity severity, const Str& message) {
+  if (shouldColorOutput_) {
+    std::cerr << "\033[0;" << kSeverityColors[severity] << "m";
+  }
+
+  // NOLINTNEXTLINE(readability-magic-numbers)
+  std::cerr << std::setw(11) << kSeverityNames[severity] << ": " << message;
+
+  if (shouldColorOutput_) {
+    std::cerr << "\033[0m";
+  }
+
+  std::cerr << "\n";
+}
+}  // namespace log
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/log/LoggerInterface.cpp
+++ b/src/openassetio-core/log/LoggerInterface.cpp
@@ -3,10 +3,12 @@
 #include <iomanip>
 #include <sstream>
 
-#include <openassetio/LoggerInterface.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace log {
 LoggerInterface::~LoggerInterface() = default;
+}  // namespace log
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/log/SeverityFilter.cpp
+++ b/src/openassetio-core/log/SeverityFilter.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#include <cstdlib>
+#include <iostream>
+
+#include <openassetio/log/SeverityFilter.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace log {
+SeverityFilterPtr SeverityFilter::make(LoggerInterfacePtr upstreamLogger) {
+  return std::shared_ptr<SeverityFilter>(new SeverityFilter(std::move(upstreamLogger)));
+}
+
+SeverityFilter::SeverityFilter(LoggerInterfacePtr upstreamLogger)
+    : upstreamLogger_(std::move(upstreamLogger)) {
+  /// @todo [#546] Redesign and improve env var handling and associated logging.
+
+  // If the env var is set to a suitable int, attempt to extract a valid
+  // severity from it, and use as minSeverity_.
+  if (const char* envSeverityStr = std::getenv("OPENASSETIO_LOGGING_SEVERITY")) {
+    const int envSeverity = std::atoi(envSeverityStr);
+    const bool exactConversion = std::to_string(envSeverity) == envSeverityStr;
+    if (!exactConversion || envSeverity < int(kDebugApi) || envSeverity > int(kCritical)) {
+      std::string msg = "SeverityFilter: Invalid OPENASSETIO_LOGGING_SEVERITY value '";
+      msg += envSeverityStr;
+      msg += "' - ignoring.";
+      upstreamLogger_->log(kError, msg);
+    } else {
+      minSeverity_ = static_cast<Severity>(envSeverity);
+    }
+  }
+}
+
+void SeverityFilter::log(Severity severity, const Str& message) {
+  if (severity < minSeverity_) {
+    return;
+  }
+  upstreamLogger_->log(severity, message);
+}
+
+void SeverityFilter::setSeverity(LoggerInterface::Severity severity) { minSeverity_ = severity; }
+
+LoggerInterface::Severity SeverityFilter::getSeverity() const { return minSeverity_; }
+
+LoggerInterfacePtr SeverityFilter::upstreamLogger() const { return upstreamLogger_; }
+}  // namespace log
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/managerApi/HostSession.cpp
+++ b/src/openassetio-core/managerApi/HostSession.cpp
@@ -2,22 +2,22 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #include <openassetio/managerApi/HostSession.hpp>
 
-#include <openassetio/LoggerInterface.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/managerApi/Host.hpp>
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace managerApi {
 
-HostSessionPtr HostSession::make(HostPtr host, LoggerInterfacePtr logger) {
+HostSessionPtr HostSession::make(HostPtr host, log::LoggerInterfacePtr logger) {
   return std::shared_ptr<HostSession>(new HostSession(std::move(host), std::move(logger)));
 }
 
-HostSession::HostSession(HostPtr host, LoggerInterfacePtr logger)
+HostSession::HostSession(HostPtr host, log::LoggerInterfacePtr logger)
     : host_{std::move(host)}, logger_{std::move(logger)} {}
 
 HostPtr HostSession::host() const { return host_; }
-LoggerInterfacePtr HostSession::logger() const { return logger_; }
+log::LoggerInterfacePtr HostSession::logger() const { return logger_; }
 
 }  // namespace managerApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-python/bridge/include/openassetio/python/hostApi.hpp
+++ b/src/openassetio-python/bridge/include/openassetio/python/hostApi.hpp
@@ -6,7 +6,7 @@
 #include <openassetio/typedefs.hpp>
 
 OPENASSETIO_FWD_DECLARE(hostApi, ManagerImplementationFactoryInterface)
-OPENASSETIO_FWD_DECLARE(LoggerInterface)
+OPENASSETIO_FWD_DECLARE(log, LoggerInterface)
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -22,7 +22,7 @@ namespace hostApi {
  * @return Python plugin system.
  */
 OPENASSETIO_PYTHON_BRIDGE_EXPORT openassetio::hostApi::ManagerImplementationFactoryInterfacePtr
-createPythonPluginSystemManagerImplementationFactory(LoggerInterfacePtr logger);
+createPythonPluginSystemManagerImplementationFactory(log::LoggerInterfacePtr logger);
 }  // namespace hostApi
 }  // namespace python
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-python/bridge/python/hostApi.cpp
+++ b/src/openassetio-python/bridge/python/hostApi.cpp
@@ -6,8 +6,8 @@
 
 #include <pybind11/embed.h>
 
-#include <openassetio/LoggerInterface.hpp>
 #include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
 // Private headers
 #include <openassetio/private/python/pointers.hpp>
 
@@ -21,7 +21,7 @@ using openassetio::hostApi::ManagerImplementationFactoryInterface;
 using openassetio::hostApi::ManagerImplementationFactoryInterfacePtr;
 
 ManagerImplementationFactoryInterfacePtr createPythonPluginSystemManagerImplementationFactory(
-    LoggerInterfacePtr logger) {  // NOLINT(performance-unnecessary-value-param)
+    log::LoggerInterfacePtr logger) {  // NOLINT(performance-unnecessary-value-param)
   // Get Python class.
   py::object pyClass =
       py::module_::import(

--- a/src/openassetio-python/module/CMakeLists.txt
+++ b/src/openassetio-python/module/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(
     hostApi/HostInterfaceBinding.cpp
     hostApi/ManagerFactoryBinding.cpp
     hostApi/ManagerImplementationFactoryInterfaceBinding.cpp
+    log/ConsoleLoggerBinding.cpp
     log/LoggerInterfaceBinding.cpp
     managerApi/HostBinding.cpp
     managerApi/HostSessionBinding.cpp

--- a/src/openassetio-python/module/CMakeLists.txt
+++ b/src/openassetio-python/module/CMakeLists.txt
@@ -42,12 +42,12 @@ target_sources(
     PRIVATE
     _openassetio.cpp
     ContextBinding.cpp
-    LoggerInterfaceBinding.cpp
     TraitsDataBinding.cpp
     hostApi/ManagerBinding.cpp
     hostApi/HostInterfaceBinding.cpp
     hostApi/ManagerFactoryBinding.cpp
     hostApi/ManagerImplementationFactoryInterfaceBinding.cpp
+    log/LoggerInterfaceBinding.cpp
     managerApi/HostBinding.cpp
     managerApi/HostSessionBinding.cpp
     managerApi/ManagerInterfaceBinding.cpp

--- a/src/openassetio-python/module/CMakeLists.txt
+++ b/src/openassetio-python/module/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(
     hostApi/ManagerImplementationFactoryInterfaceBinding.cpp
     log/ConsoleLoggerBinding.cpp
     log/LoggerInterfaceBinding.cpp
+    log/SeverityFilterBinding.cpp
     managerApi/HostBinding.cpp
     managerApi/HostSessionBinding.cpp
     managerApi/ManagerInterfaceBinding.cpp

--- a/src/openassetio-python/module/_openassetio.cpp
+++ b/src/openassetio-python/module/_openassetio.cpp
@@ -17,6 +17,7 @@ PYBIND11_MODULE(_openassetio, mod) {
   py::module log = mod.def_submodule("log");
 
   registerLoggerInterface(log);
+  registerConsoleLogger(log);
   registerTraitsData(mod);
   registerManagerStateBase(managerApi);
   registerContext(mod);

--- a/src/openassetio-python/module/_openassetio.cpp
+++ b/src/openassetio-python/module/_openassetio.cpp
@@ -18,6 +18,7 @@ PYBIND11_MODULE(_openassetio, mod) {
 
   registerLoggerInterface(log);
   registerConsoleLogger(log);
+  registerSeverityFilter(log);
   registerTraitsData(mod);
   registerManagerStateBase(managerApi);
   registerContext(mod);

--- a/src/openassetio-python/module/_openassetio.cpp
+++ b/src/openassetio-python/module/_openassetio.cpp
@@ -14,8 +14,9 @@ PYBIND11_MODULE(_openassetio, mod) {
 
   py::module managerApi = mod.def_submodule("managerApi");
   py::module hostApi = mod.def_submodule("hostApi");
+  py::module log = mod.def_submodule("log");
 
-  registerLoggerInterface(mod);
+  registerLoggerInterface(log);
   registerTraitsData(mod);
   registerManagerStateBase(managerApi);
   registerContext(mod);

--- a/src/openassetio-python/module/_openassetio.hpp
+++ b/src/openassetio-python/module/_openassetio.hpp
@@ -13,9 +13,9 @@
 
 #include "PyRetainingSharedPtr.hpp"
 
-OPENASSETIO_FWD_DECLARE(LoggerInterface)
 OPENASSETIO_FWD_DECLARE(ManagerStateBase)
 OPENASSETIO_FWD_DECLARE(managerApi, ManagerInterface)
+OPENASSETIO_FWD_DECLARE(log, LoggerInterface)
 OPENASSETIO_FWD_DECLARE(hostApi, HostInterface)
 OPENASSETIO_FWD_DECLARE(hostApi, ManagerImplementationFactoryInterface)
 
@@ -33,11 +33,10 @@ OPENASSETIO_FWD_DECLARE(hostApi, ManagerImplementationFactoryInterface)
  * @see PyRetainingSharedPtr
  * @see RetainPyArgs
  */
-using RetainCommonPyArgs =
-    openassetio::RetainPyArgs<openassetio::LoggerInterfacePtr, openassetio::ManagerStateBasePtr,
-                              openassetio::managerApi::ManagerInterfacePtr,
-                              openassetio::hostApi::HostInterfacePtr,
-                              openassetio::hostApi::ManagerImplementationFactoryInterfacePtr>;
+using RetainCommonPyArgs = openassetio::RetainPyArgs<
+    openassetio::log::LoggerInterfacePtr, openassetio::ManagerStateBasePtr,
+    openassetio::managerApi::ManagerInterfacePtr, openassetio::hostApi::HostInterfacePtr,
+    openassetio::hostApi::ManagerImplementationFactoryInterfacePtr>;
 
 /// Concise pybind alias.
 namespace py = pybind11;

--- a/src/openassetio-python/module/_openassetio.hpp
+++ b/src/openassetio-python/module/_openassetio.hpp
@@ -47,6 +47,9 @@ void registerLoggerInterface(const py::module& mod);
 /// Register the ConsoleLogger class with Python.
 void registerConsoleLogger(const py::module& mod);
 
+/// Register the SeverityFilter class with Python.
+void registerSeverityFilter(const py::module& mod);
+
 /// Register the Context class with Python.
 void registerContext(const py::module& mod);
 

--- a/src/openassetio-python/module/_openassetio.hpp
+++ b/src/openassetio-python/module/_openassetio.hpp
@@ -44,6 +44,9 @@ namespace py = pybind11;
 /// Register the LoggerInterface class with Python.
 void registerLoggerInterface(const py::module& mod);
 
+/// Register the ConsoleLogger class with Python.
+void registerConsoleLogger(const py::module& mod);
+
 /// Register the Context class with Python.
 void registerContext(const py::module& mod);
 

--- a/src/openassetio-python/module/hostApi/ManagerFactoryBinding.cpp
+++ b/src/openassetio-python/module/hostApi/ManagerFactoryBinding.cpp
@@ -3,11 +3,11 @@
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
-#include <openassetio/LoggerInterface.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/hostApi/Manager.hpp>
 #include <openassetio/hostApi/ManagerFactory.hpp>
 #include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
 
 #include "../_openassetio.hpp"
 

--- a/src/openassetio-python/module/hostApi/ManagerImplementationFactoryInterfaceBinding.cpp
+++ b/src/openassetio-python/module/hostApi/ManagerImplementationFactoryInterfaceBinding.cpp
@@ -2,8 +2,8 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #include <pybind11/stl.h>
 
-#include <openassetio/LoggerInterface.hpp>
 #include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/typedefs.hpp>
 
@@ -44,7 +44,7 @@ void registerManagerImplementationFactoryInterface(const py::module& mod) {
   using openassetio::hostApi::ManagerImplementationFactoryInterfacePtr;
   using openassetio::hostApi::PyManagerImplementationFactoryInterface;
   using PyRetainingLoggerInterfacePtr =
-      openassetio::PyRetainingSharedPtr<openassetio::LoggerInterface>;
+      openassetio::PyRetainingSharedPtr<openassetio::log::LoggerInterface>;
 
   py::class_<ManagerImplementationFactoryInterface, PyManagerImplementationFactoryInterface,
              ManagerImplementationFactoryInterfacePtr>(mod,

--- a/src/openassetio-python/module/log/ConsoleLoggerBinding.cpp
+++ b/src/openassetio-python/module/log/ConsoleLoggerBinding.cpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <openassetio/log/ConsoleLogger.hpp>
+
+#include "../_openassetio.hpp"
+
+void registerConsoleLogger(const py::module& mod) {
+  using openassetio::log::ConsoleLogger;
+  using openassetio::log::ConsoleLoggerPtr;
+  using openassetio::log::LoggerInterface;
+
+  py::class_<ConsoleLogger, LoggerInterface, ConsoleLoggerPtr>(mod, "ConsoleLogger",
+                                                               py::is_final())
+      .def(py::init(&ConsoleLogger::make), py::arg("shouldColorOutput") = true);
+}

--- a/src/openassetio-python/module/log/LoggerInterfaceBinding.cpp
+++ b/src/openassetio-python/module/log/LoggerInterfaceBinding.cpp
@@ -3,11 +3,12 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include <openassetio/LoggerInterface.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
 
-#include "_openassetio.hpp"
+#include "../_openassetio.hpp"
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace log {
 /**
  * Trampoline class required for pybind to bind pure virtual methods
  * and allow C++ -> Python calls via a C++ instance.
@@ -19,15 +20,16 @@ struct PyLoggerInterface : LoggerInterface {
     PYBIND11_OVERRIDE_PURE(void, LoggerInterface, log, severity, message);
   }
 };
+}  // namespace log
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio
 
 void registerLoggerInterface(const py::module& mod) {
   using openassetio::Float;
-  using openassetio::LoggerInterface;
-  using openassetio::LoggerInterfacePtr;
-  using openassetio::PyLoggerInterface;
   using openassetio::Str;
+  using openassetio::log::LoggerInterface;
+  using openassetio::log::LoggerInterfacePtr;
+  using openassetio::log::PyLoggerInterface;
 
   py::class_<LoggerInterface, PyLoggerInterface, LoggerInterfacePtr> loggerInterface{
       mod, "LoggerInterface"};

--- a/src/openassetio-python/module/log/SeverityFilterBinding.cpp
+++ b/src/openassetio-python/module/log/SeverityFilterBinding.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <openassetio/log/SeverityFilter.hpp>
+
+#include "../PyRetainingSharedPtr.hpp"
+#include "../_openassetio.hpp"
+
+void registerSeverityFilter(const py::module& mod) {
+  using openassetio::log::LoggerInterface;
+  using openassetio::log::SeverityFilter;
+  using openassetio::log::SeverityFilterPtr;
+
+  py::class_<SeverityFilter, LoggerInterface, SeverityFilterPtr>(mod, "SeverityFilter",
+                                                                 py::is_final())
+      .def(py::init(RetainCommonPyArgs::forFn<&SeverityFilter::make>()),
+           py::arg("upstreamLogger").none(false))
+      .def("getSeverity", &SeverityFilter::getSeverity)
+      .def("setSeverity", &SeverityFilter::setSeverity)
+      .def("upstreamLogger", &SeverityFilter::upstreamLogger);
+}

--- a/src/openassetio-python/module/managerApi/HostSessionBinding.cpp
+++ b/src/openassetio-python/module/managerApi/HostSessionBinding.cpp
@@ -2,7 +2,7 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #include <pybind11/stl.h>
 
-#include <openassetio/LoggerInterface.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/managerApi/Host.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 

--- a/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
+++ b/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
@@ -9,9 +9,9 @@
 #include <catch2/catch.hpp>
 #include <catch2/trompeloeil.hpp>
 
-#include <openassetio/LoggerInterface.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/hostApi/Manager.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/managerApi/Host.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
@@ -29,8 +29,8 @@ namespace managerApi = openassetio::managerApi;
 namespace hostApi = openassetio::hostApi;
 namespace handles = openassetio::handles;
 
-using openassetio::LoggerInterface;
-using openassetio::LoggerInterfacePtr;
+using openassetio::log::LoggerInterface;
+using openassetio::log::LoggerInterfacePtr;
 
 namespace {
 constexpr size_t kStringBufferSize = 500;

--- a/tests/openassetio-core/managerApi/HostSessionTest.cpp
+++ b/tests/openassetio-core/managerApi/HostSessionTest.cpp
@@ -10,7 +10,7 @@ OPENASSETIO_FWD_DECLARE(LoggerInterface)
 OPENASSETIO_FWD_DECLARE(managerApi, Host)
 
 SCENARIO("HostSession constructor is private") {
-  STATIC_REQUIRE_FALSE(
-      std::is_constructible_v<openassetio::managerApi::HostSession,
-                              openassetio::managerApi::HostPtr, openassetio::LoggerInterfacePtr>);
+  STATIC_REQUIRE_FALSE(std::is_constructible_v<openassetio::managerApi::HostSession,
+                                               openassetio::managerApi::HostPtr,
+                                               openassetio::log::LoggerInterfacePtr>);
 }

--- a/tests/openassetio-python/CMakeLists.txt
+++ b/tests/openassetio-python/CMakeLists.txt
@@ -175,7 +175,8 @@ if (Python_Interpreter_FOUND)
     add_custom_target(
         openassetio-python-test-pytest
         COMMAND cmake -E echo -- Running pytest
-        COMMAND ${venv_activate} && ${pytest_env} ${venv_python_exe} -m pytest -v -s tests/python
+        COMMAND ${venv_activate} && ${pytest_env} ${venv_python_exe} -m pytest -v --capture=tee-sys
+        tests/python
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
         USES_TERMINAL
     )
@@ -187,7 +188,7 @@ if (Python_Interpreter_FOUND)
     add_custom_target(
         openassetio-resources-examples-test-pytest
         COMMAND cmake -E echo -- Running pytest
-        COMMAND ${venv_activate} && ${pytest_env} ${venv_python_exe} -m pytest -v
+        COMMAND ${venv_activate} && ${pytest_env} ${venv_python_exe} -m pytest -v --capture=tee-sys
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/resources/examples"
         USES_TERMINAL
     )
@@ -199,7 +200,7 @@ if (Python_Interpreter_FOUND)
     add_custom_target(
         openassetio-resources-codegen-test-pytest
         COMMAND cmake -E echo -- Running pytest
-        COMMAND ${venv_activate} && ${pytest_env} ${venv_python_exe} -m pytest -v
+        COMMAND ${venv_activate} && ${pytest_env} ${venv_python_exe} -m pytest -v --capture=tee-sys
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/resources/codegen"
         USES_TERMINAL
     )

--- a/tests/openassetio-python/hostApiTest.cpp
+++ b/tests/openassetio-python/hostApiTest.cpp
@@ -4,15 +4,15 @@
  * Bindings used for testing the C++ Python bridge hostApi helpers.
  */
 #include <pybind11/pybind11.h>
-#include <openassetio/LoggerInterface.hpp>
 #include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/python/hostApi.hpp>
 
 namespace py = pybind11;
 
 void registerHostApiTestTypes(py::module_& mod) {
   mod.def("callCreatePythonPluginSystemManagerImplementationFactory",
-          [](openassetio::LoggerInterfacePtr logger) {
+          [](openassetio::log::LoggerInterfacePtr logger) {
             openassetio::hostApi::ManagerImplementationFactoryInterfacePtr pluginSystem =
                 openassetio::python::hostApi::createPythonPluginSystemManagerImplementationFactory(
                     std::move(logger));

--- a/tests/python/openassetio/test/manager/test_main.py
+++ b/tests/python/openassetio/test/manager/test_main.py
@@ -55,7 +55,7 @@ class Test_CLI_output:
 
     def test_api_logging_goes_to_standard_out(self, a_passing_fixtures_file, monkeypatch):
         monkeypatch.setenv("OPENASSETIO_LOGGING_SEVERITY", "0")
-        assert "[debug]: PythonPluginSystem" in str(execute_cli(a_passing_fixtures_file).stdout)
+        assert "debug: PythonPluginSystem" in str(execute_cli(a_passing_fixtures_file).stderr)
 
     def test_unittest_output_written_to_stderr(self, a_passing_fixtures_file):
         assert "Ran" in str(execute_cli(a_passing_fixtures_file).stderr)

--- a/tests/python/openassetio/test_log.py
+++ b/tests/python/openassetio/test_log.py
@@ -55,6 +55,55 @@ all_severities = (
 severity_control_envvar = "OPENASSETIO_LOGGING_SEVERITY"
 
 
+class Test_ConsoleLogger_inheritance:
+    def test_class_is_final(self):
+        with pytest.raises(TypeError):
+
+            class _(lg.ConsoleLogger):
+                pass
+
+
+class Test_ConsoleLogger:
+    def test_when_logging_then_messages_are_written_to_stderr(self, capfd):
+        # Clear the capture so we don't get swamped by any output from
+        # previous tests.
+        _ = capfd.readouterr()
+
+        logger = lg.ConsoleLogger(shouldColorOutput=False)
+        for severity in all_severities:
+            logger.log(severity, "A message")
+        output = capfd.readouterr()
+
+        assert output.out == ""
+        assert output.err == "\n".join(
+            [f"{lg.LoggerInterface.kSeverityNames[s] : >11}: A message" for s in all_severities]
+        ) + "\n"
+
+    def test_when_shouldColorOutput_not_set_then_messages_are_colored(self, capfd):
+        _ = capfd.readouterr()
+        logger = lg.ConsoleLogger(shouldColorOutput=True)
+        logger.log(lg.LoggerInterface.kCritical, "A message")
+        output = capfd.readouterr()
+
+        assert "\033[0m" in output.err
+
+    def test_when_shouldColorOutput_set_true_then_messages_are_colored(self, capfd):
+        _ = capfd.readouterr()
+        logger = lg.ConsoleLogger(shouldColorOutput=True)
+        logger.log(lg.LoggerInterface.kCritical, "A message")
+        output = capfd.readouterr()
+
+        assert "\033[0m" in output.err
+
+    def test_when_shouldColorOutput_set_false_then_messages_are_not_colored(self, capfd):
+        _ = capfd.readouterr()
+        logger = lg.ConsoleLogger(shouldColorOutput=False)
+        logger.log(lg.LoggerInterface.kCritical, "A message")
+        output = capfd.readouterr()
+
+        assert "\033[0m" not in output.err
+
+
 class Test_LoggerInterface:
     def test_severity_names(self):
         assert lg.LoggerInterface.kSeverityNames[lg.LoggerInterface.kCritical] == "critical"


### PR DESCRIPTION
Migrates the current (fairly minimal) logger implementations (`ConsoleLogger` and `SeverityFilter`) over to C++ so we can leave the GIL out of messaging.

It is a fairly literal port that takes the path of least resistance to get us going, and we have #546 to address some of the more questionable aspects of the current implementation.