### PR TITLE
`isEntityReference` refactor

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,10 @@ v1.0.0-alpha.X
   ambiguity when also working with the new `EntityReference` type.
   [#549](https://github.com/OpenAssetIO/OpenAssetIO/issues/549)
 
+- Made `isEntityReferenceString` a non-batch method to simplify common
+  usage, as it is always in-process.
+  [#549](https://github.com/OpenAssetIO/OpenAssetIO/issues/549)
+
 - Reversed the order of logging severity constants, such that the
   numerical value of the constant increases with the logical severity
   (i.e. `kDebugApi` is now `0` and `kCritical` is now `6`).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,10 @@ v1.0.0-alpha.X
 
 ### Breaking changes
 
+- Renamed `isEntityReference` to `isEntityReferenceString` to avoid
+  ambiguity when also working with the new `EntityReference` type.
+  [#549](https://github.com/OpenAssetIO/OpenAssetIO/issues/549)
+
 - Reversed the order of logging severity constants, such that the
   numerical value of the constant increases with the logical severity
   (i.e. `kDebugApi` is now `0` and `kCritical` is now `6`).

--- a/decisions/DR011-Entity-reference-type-safety.md
+++ b/decisions/DR011-Entity-reference-type-safety.md
@@ -10,8 +10,8 @@
 
 The current API assumes a "honor agreement" in which the host will never
 pass a string to an API call that accepts an entity reference unless it
-has first run it through `isEntityReference` at least once, and that
-method has returned `True` for the manager in question.
+has first run it through `isEntityReferenceString` at least once, and
+that method has returned `True` for the manager in question.
 
 Note that this does not imply the entity reference actually corresponds
 to an entity, only that it is understood and handled by a particular
@@ -42,9 +42,9 @@ entity references, and each reference may well be of non-trivial length,
 so references should not use memory longer than their natural scope in
 the host codebase.
 
-In theory, a host only needs to check `isEntityReference` once for any
-given string/manager combination, and that string can then be used with
-any other API method with that manager.
+In theory, a host only needs to check `isEntityReferenceString` once for
+any given string/manager combination, and that string can then be used
+with any other API method with that manager.
 
 However, there is an obvious potential for host applications to break
 this contract, either by not validating the reference or by validating
@@ -59,8 +59,8 @@ relevant to them:
 
 In the current API, this translates to
 
-1. Has `isEntityReference` been called on the string?
-2. Was `isEntityReference` called using the correct manager
+1. Has `isEntityReferenceString` been called on the string?
+2. Was `isEntityReferenceString` called using the correct manager
    implementation?
 
 The current trust-based system solves this by simply assuming the host
@@ -70,7 +70,7 @@ answered and enforced automatically, and cheaply.
 One further consideration is the possibility of entity references that
 are known to be valid. For example, they may have been validated at some
 point in the past or in a separate process. Forcing an ultimately
-pointless (if cheap) `isEntityReference` check in this case is
+pointless (if cheap) `isEntityReferenceString` check in this case is
 undesirable. Again, the current trust-based system solves this
 trivially, if not robustly.
 
@@ -115,10 +115,10 @@ and
 ### Option 1
 
 Keep the current trust-based solution expecting hosts to call
-`isEntityReference` before using a reference in any manager API call.
+`isEntityReferenceString` before using a reference in any manager API
+call.
 
 #### Pros
-
 - Conceptually simple.
 - No changes required.
 - No global state.
@@ -149,7 +149,7 @@ reference is not valid.
 
 `createEntityReference` does not need to be implemented by the manager
 plugin, this is a convenience that will make use of the current API's
-`isEntityReference`.
+`isEntityReferenceString`.
 
 #### Pros
 
@@ -160,7 +160,7 @@ plugin, this is a convenience that will make use of the current API's
   relevant to a given manager. This could be added to all middleware
   methods as further validation.
 - If independently trivially constructible, then retains the advantage
-  of allowing optional circumvention of `isEntityReference`, for
+  of allowing optional circumvention of `isEntityReferenceString`, for
   references the host is already sure of.
 - No need for global state.
 - Strong typing of domain concepts, avoiding "primitive obsession", is
@@ -201,7 +201,7 @@ reference is not valid.
 
 `createEntityReference` does not need to be implemented by the manager
 plugin, this is a convenience that will make use of the current API's
-`isEntityReference` (assuming the string is not already interned).
+`isEntityReferenceString` (assuming the string is not already interned).
 
 #### Pros
 

--- a/doc/src/Examples.dox
+++ b/doc/src/Examples.dox
@@ -134,7 +134,7 @@
  *
  * # We must **ALWAYS** validate that a string is an entity reference
  * # before passing it to any other manager API call.
- * if not manager.isEntityReferenceString([some_string])[0]:
+ * if not manager.isEntityReferenceString(some_string):
  *    raise ValueError(f'"{some_string}" isn't an entity reference.')
  *
  * # All calls to the manager must have a Context, these should always

--- a/doc/src/Examples.dox
+++ b/doc/src/Examples.dox
@@ -134,7 +134,7 @@
  *
  * # We must **ALWAYS** validate that a string is an entity reference
  * # before passing it to any other manager API call.
- * if not manager.isEntityReference([some_string])[0]:
+ * if not manager.isEntityReferenceString([some_string])[0]:
  *    raise ValueError(f'"{some_string}" isn't an entity reference.')
  *
  * # All calls to the manager must have a Context, these should always

--- a/doc/src/ForHosts.dox
+++ b/doc/src/ForHosts.dox
@@ -102,8 +102,9 @@
  *   traits.
  *
  * - Always check any suspected entity references with @ref
- *   openassetio.hostApi.Manager.Manager.isEntityReference
- *   "Manager.isEntityReference" before passing to any other API calls.
+ *   openassetio.hostApi.Manager.Manager.isEntityReferenceString
+ *   "Manager.isEntityReferenceString" before passing to any other API
+ *   calls.
  *
  * @see @ref examples_api_initialization
  * @see @ref examples_picking_a_manager
@@ -136,9 +137,9 @@
  *   manager to use to interact with an @ref asset_management_system,
  *   storing applicable options, etc...
  *
- * - @ref openassetio.hostApi.Manager.Manager.isEntityReference "Test"
- *   and resolve any strings that may represent file system locations
- *   (@ref openassetio.hostApi.Manager.Manager.resolve
+ * - @ref openassetio.hostApi.Manager.Manager.isEntityReferenceString
+ *   "Test" and resolve any strings that may represent file system
+ *   locations (@ref openassetio.hostApi.Manager.Manager.resolve
  *   "Manager.resolve")
  *
  * - Ensure the use of a correctly configured @ref Context for all
@@ -148,9 +149,9 @@
  *   "managementPolicy" sets the @needsref WantsThumbnail trait, where
  *   possible, generate thumbnails as requested during publishing.
  *
- * - Allow the @needsref ManagerUIDelegate to participate in browsing/etc...
- *   for any data types they have expressed an interest in managing via
- *   @fqref{hostApi.Manager.managementPolicy}
+ * - Allow the @needsref ManagerUIDelegate to participate in
+ *   browsing/etc... for any data types they have expressed an interest
+ *   in managing via @fqref{hostApi.Manager.managementPolicy}
  *   "Manager.managementPolicy".
  *
  * - Make the drawing of any parameters that may hold an @ref

--- a/doc/src/Glossary.dox
+++ b/doc/src/Glossary.dox
@@ -110,12 +110,12 @@
  *
  * 1. Discoverability
  * ------------------
- * It is essential that any given string can be readily identified
- * identified as being an entity reference or not. The @ref
- * openassetio.managerApi.ManagerInterface.ManagerInterface.isEntityReference
- * "isEntityReference" method will be called frequently by a @ref host
- * to determine if the arbitrary user input is a reference to a managed
- * entity.
+ * It is essential that any given string can be readily identified as
+ * being an entity reference or not. The @ref
+ * openassetio.managerApi.ManagerInterface.ManagerInterface.isEntityReferenceString
+ * "isEntityReferenceString" method will be called frequently by a @ref
+ * host to determine if the arbitrary user input is a reference to a
+ * managed entity.
  *
  * 2. Uniform Resource Location
  * ----------------------------

--- a/doc/src/Testing.dox
+++ b/doc/src/Testing.dox
@@ -28,9 +28,9 @@
  *
  * Consequently the test harness needs to be supplied with valid
  * values to pass to methods such as
- * @ref openassetio.managerApi.ManagerInterface.ManagerInterface.isEntityReference
- * "isEntityReference", and the expected values from methods such as
- * @fqref{managerApi.ManagerInterface.identifier} "identifier"
+ * @ref openassetio.managerApi.ManagerInterface.ManagerInterface.isEntityReferenceString
+ * "isEntityReferenceString", and the expected values from methods such
+ * as @fqref{managerApi.ManagerInterface.identifier} "identifier"
  *
  * The file should set a top level variable called `fixtures`, holding
  * a dict structured as-per the `fixtures` parameter documented

--- a/python/openassetio/constants.py
+++ b/python/openassetio/constants.py
@@ -45,7 +45,7 @@ kField_Icon = 'icon'
 # Entity Reference Properties
 
 ## This field may be used by the API to optimize queries to
-## isEntityReference in situations where bridging languages, etc.
+## isEntityReferenceString in situations where bridging languages, etc.
 ## can be expensive (particularly in the case of python plug-ins
 ## called from multi-threaded C++).
 kField_EntityReferencesMatchPrefix = "entityReferencesMatchPrefix"

--- a/python/openassetio/hostApi/Manager.py
+++ b/python/openassetio/hostApi/Manager.py
@@ -194,7 +194,7 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def isEntityReference(self, tokens):
+    def isEntityReferenceString(self, tokens):
         """
         @warning It is essential, as a host, that only valid
         references are supplied to Manager API calls. Before any
@@ -234,7 +234,7 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         # We need to add support here for using the supplied prefix match string,
         # or regex, if supplied, instead of calling the manager, this is less
         # relevant in python though, more in C, but the note is here to remind us.
-        return self.__impl.isEntityReference(tokens, self.__hostSession)
+        return self.__impl.isEntityReferenceString(tokens, self.__hostSession)
 
     @debugApiCall
     @auditApiCall("Manager methods")
@@ -647,9 +647,9 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         caller to handle requested data being missing in a fashion
         appropriate to its intended use.
 
-        @note You should always call @ref isEntityReference first if
-        there is any doubt as to whether or not a string you have is a
-        valid reference for the manager, and only call resolve, or any
+        @note You should always call @ref isEntityReferenceString first
+        if there is any doubt as to whether or not a string you have is
+        a valid reference for the manager, and only call resolve, or any
         other methods, if it is a reference recognised by the manager.
 
         The API defines that all file paths passed though the API that

--- a/python/openassetio/hostApi/Manager.py
+++ b/python/openassetio/hostApi/Manager.py
@@ -194,30 +194,30 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def isEntityReferenceString(self, tokens):
+    def isEntityReferenceString(self, someString):
         """
         @warning It is essential, as a host, that only valid
         references are supplied to Manager API calls. Before any
         reference is passed to any other methods of this class, they
         must first be validated through this method.
 
-        Determines if each supplied token (in its entirety) matches the
+        Determines if the supplied string (in its entirety) matches the
         pattern of an @ref entity_reference.  It does not verify that it
         points to a valid entity in the system, simply that the pattern
-        of the token is recognised by the manager.
+        of the string is recognised by the manager.
 
-        If it returns `True`, the token is an @ref entity_reference and
+        If it returns `True`, the string is an @ref entity_reference and
         should be considered as a managed entity (or a future one).
         Consequently, it should be resolved before use. It also confirms
         that it can be passed to any other method that requires an @ref
         entity_reference.
 
         If `False`, this manager should no longer be involved in actions
-        relating to the token.
+        relating to the string.
 
-        @param tokens `List[str]` The strings to be inspected.
+        @param someString `str` The string to be inspected.
 
-        @return `List[bool]` `True` if a supplied token should be
+        @return `bool` `True` if the supplied token should be
         considered as an @ref entity_reference, `False` if the pattern
         is not recognised.
 
@@ -234,7 +234,7 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         # We need to add support here for using the supplied prefix match string,
         # or regex, if supplied, instead of calling the manager, this is less
         # relevant in python though, more in C, but the note is here to remind us.
-        return self.__impl.isEntityReferenceString(tokens, self.__hostSession)
+        return self.__impl.isEntityReferenceString(someString, self.__hostSession)
 
     @debugApiCall
     @auditApiCall("Manager methods")

--- a/python/openassetio/managerApi/ManagerInterface.py
+++ b/python/openassetio/managerApi/ManagerInterface.py
@@ -246,7 +246,7 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
     # @{
 
     @abc.abstractmethod
-    def isEntityReference(self, tokens, hostSession):
+    def isEntityReferenceString(self, tokens, hostSession):
         """
         Determines if each supplied token (in its entirety) matches the
         pattern of a valid @ref entity_reference in your system.  It
@@ -369,8 +369,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         any rules of the system - for example, resolving an existing
         entity reference for write.
 
-        The caller will have first called isEntityReference() on the
-        supplied strings.
+        The caller will have first called isEntityReferenceString() on
+        the supplied strings.
 
         @param entityRefs `List[str]` Entity references to query.
 
@@ -393,7 +393,7 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         access is `kWrite` and the entity is an existing version.
 
         @see @ref entityExists
-        @see @ref isEntityReference
+        @see @ref isEntityReferenceString
         """
         raise NotImplementedError
 

--- a/python/openassetio/managerApi/ManagerInterface.py
+++ b/python/openassetio/managerApi/ManagerInterface.py
@@ -246,29 +246,29 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
     # @{
 
     @abc.abstractmethod
-    def isEntityReferenceString(self, tokens, hostSession):
+    def isEntityReferenceString(self, someString, hostSession):
         """
-        Determines if each supplied token (in its entirety) matches the
-        pattern of a valid @ref entity_reference in your system.  It
+        Determines if the supplied string (in its entirety) matches the
+        pattern of a valid @ref entity_reference in your system. It
         does not need to verify that it points to a valid entity in the
-        system, simply that the pattern of the token is recognised by
+        system, simply that the pattern of the string is recognised by
         this implementation.
 
-        If this returns `True`, the token is an @ref entity_reference
+        If this returns `True`, the string is an @ref entity_reference
         and should be considered usable with the other methods of this
         interface.
 
         If `False`, this manager should no longer be involved in actions
-        relating to the token.
+        relating to the string.
 
         @warning The result of this call should not depend on the
         context Locale.
 
-        @param tokens `List[str]` The strings to be inspected.
+        @param someString str The string to be inspected.
 
         @param hostSession HostSession The API session.
 
-        @return `List[bool]` `True` if the supplied token should be
+        @return `bool` `True` if the supplied string should be
         considered as an @ref entity_reference, `False` if the pattern is
         not recognised.
 

--- a/python/openassetio/test/manager/apiComplianceSuite.py
+++ b/python/openassetio/test/manager/apiComplianceSuite.py
@@ -221,24 +221,18 @@ class Test_isEntityReferenceString(FixtureAugmentedTestCase):
         self.collectRequiredFixture("a_malformed_reference")
 
     def test_valid_reference_returns_true(self):
-        assert self._manager.isEntityReferenceString([self.a_valid_reference]) == [True]
+        assert self._manager.isEntityReferenceString(self.a_valid_reference) is True
 
     def test_non_reference_returns_false(self):
         assert self.a_malformed_reference != ""
-        assert self._manager.isEntityReferenceString([self.a_malformed_reference]) == [False]
+        assert self._manager.isEntityReferenceString(self.a_malformed_reference) is False
 
     def test_empty_string_returns_false(self):
-        assert self._manager.isEntityReferenceString([""]) == [False]
-
-    def test_mixed_inputs_returns_mixed_output(self):
-        reference = self.a_valid_reference
-        non_reference = self.a_malformed_reference
-        expected = [True, False]
-        assert self._manager.isEntityReferenceString([reference, non_reference]) == expected
+        assert self._manager.isEntityReferenceString("") is False
 
     def test_random_unicode_input_returns_false(self):
         unicode_reference = "🦆🦆🦑"
-        assert self._manager.isEntityReferenceString([unicode_reference]) == [False]
+        assert self._manager.isEntityReferenceString(unicode_reference) is False
 
 
 class Test_entityExists(FixtureAugmentedTestCase):

--- a/python/openassetio/test/manager/apiComplianceSuite.py
+++ b/python/openassetio/test/manager/apiComplianceSuite.py
@@ -74,8 +74,8 @@ class Test_info(FixtureAugmentedTestCase):
     """
     Check plugin's implementation of managerApi.ManagerInterface.info.
     """
-    # TODO(DF): Once `isEntityReference` tests are added, check that
-    #   `kField_EntityReferencesMatchPrefix` in info dict is used.
+    # TODO(DF): Once `isEntityReferenceString` tests are added, check
+    # that `kField_EntityReferencesMatchPrefix` in info dict is used.
     def test_is_correct_type(self):
         self.assertIsStringKeyPrimitiveValueDict(self._manager.info())
 
@@ -210,10 +210,10 @@ class Test_managementPolicy(FixtureAugmentedTestCase):
         self.assertEqual(len(policies), numTraitSets)
 
 
-class Test_isEntityReference(FixtureAugmentedTestCase):
+class Test_isEntityReferenceString(FixtureAugmentedTestCase):
     """
     Check plugin's implementation of
-    managerApi.ManagerInterface.isEntityReference.
+    managerApi.ManagerInterface.isEntityReferenceString.
     """
 
     def setUp(self):
@@ -221,24 +221,24 @@ class Test_isEntityReference(FixtureAugmentedTestCase):
         self.collectRequiredFixture("a_malformed_reference")
 
     def test_valid_reference_returns_true(self):
-        assert self._manager.isEntityReference([self.a_valid_reference]) == [True]
+        assert self._manager.isEntityReferenceString([self.a_valid_reference]) == [True]
 
     def test_non_reference_returns_false(self):
         assert self.a_malformed_reference != ""
-        assert self._manager.isEntityReference([self.a_malformed_reference]) == [False]
+        assert self._manager.isEntityReferenceString([self.a_malformed_reference]) == [False]
 
     def test_empty_string_returns_false(self):
-        assert self._manager.isEntityReference([""]) == [False]
+        assert self._manager.isEntityReferenceString([""]) == [False]
 
     def test_mixed_inputs_returns_mixed_output(self):
         reference = self.a_valid_reference
         non_reference = self.a_malformed_reference
         expected = [True, False]
-        assert self._manager.isEntityReference([reference, non_reference]) == expected
+        assert self._manager.isEntityReferenceString([reference, non_reference]) == expected
 
     def test_random_unicode_input_returns_false(self):
         unicode_reference = "🦆🦆🦑"
-        assert self._manager.isEntityReference([unicode_reference]) == [False]
+        assert self._manager.isEntityReferenceString([unicode_reference]) == [False]
 
 
 class Test_entityExists(FixtureAugmentedTestCase):

--- a/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
+++ b/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
@@ -95,9 +95,9 @@ class BasicAssetLibraryInterface(ManagerInterface):
             for trait_set in traitSets
         ]
 
-    def isEntityReferenceString(self, tokens, hostSession):
+    def isEntityReferenceString(self, someString, hostSession):
         # pylint: disable=unused-argument
-        return [token.startswith(self.__reference_prefix) for token in tokens]
+        return someString.startswith(self.__reference_prefix)
 
     def entityExists(self, entityRefs, context, hostSession):
         results = []

--- a/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
+++ b/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
@@ -95,7 +95,7 @@ class BasicAssetLibraryInterface(ManagerInterface):
             for trait_set in traitSets
         ]
 
-    def isEntityReference(self, tokens, hostSession):
+    def isEntityReferenceString(self, tokens, hostSession):
         # pylint: disable=unused-argument
         return [token.startswith(self.__reference_prefix) for token in tokens]
 

--- a/resources/examples/manager/SampleAssetManager/python/SampleAssetManager/SampleAssetManagerInterface.py
+++ b/resources/examples/manager/SampleAssetManager/python/SampleAssetManager/SampleAssetManagerInterface.py
@@ -52,10 +52,12 @@ class SampleAssetManagerInterface(ManagerInterface):
         return "Sample Asset Manager (SAM)"
 
     def info(self):
-        # This hint allows the API middleware to short-circuit calls to `isEntityReference`
-        # using string prefix comparisons. If your implementation's entity reference format
-        # supports this kind of matching, you should set this key. It allows for multi-threaded
-        # reference testing in C++ as it avoids the need to acquire the GIL and enter Python.
+        # This hint allows the API middleware to short-circuit calls to
+        # `isEntityReferenceString` using string prefix comparisons. If
+        # your implementation's entity reference format supports this
+        # kind of matching, you should set this key. It allows for
+        # multi-threaded reference testing in C++ as it avoids the need
+        # to acquire the GIL and enter Python.
         return {
             constants.kField_EntityReferencesMatchPrefix: "sam:///"
         }

--- a/src/openassetio-core/include/openassetio/EntityReference.hpp
+++ b/src/openassetio-core/include/openassetio/EntityReference.hpp
@@ -16,8 +16,8 @@ inline namespace OPENASSETIO_CORE_ABI_VERSION {
  * related API calls.
  *
  * It can be assumed that if @ref
- * openassetio.hostApi.Manager.Manager.isEntityReference
- * "isEntityReference" is true for a given string, then an
+ * openassetio.hostApi.Manager.Manager.isEntityReferenceString
+ * "isEntityReferenceString" is true for a given string, then an
  * EntityReference can be constructed from that string.
  *
  * @warning EntityReferences should not be constructed directly by the

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -217,11 +217,11 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * info can also contain an additional field - a prefix that
    * identifies a string as a valid entity reference. If supplied,
    * this will be used by the API to optimize calls to
-   * isEntityReference when bridging between C/Python etc.
-   * If this isn't supplied, then isEntityReference will always be
+   * isEntityReferenceString when bridging between C/Python etc.
+   * If this isn't supplied, then isEntityReferenceString will always be
    * called to determine if a string is an @ref entity_reference or
    * not. Note, not all invocations require this optimization, so
-   * @needsref isEntityReference should be implemented regardless.
+   * @needsref isEntityReferenceString should be implemented regardless.
    *
    *   @li openassetio.constants.kField_EntityReferencesMatchPrefix
    *

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -214,10 +214,10 @@ class ValidatingMockManagerInterface(ManagerInterface):
 
         return self.mock.managementPolicy(traitSets, context, hostSession)
 
-    def isEntityReferenceString(self, tokens, hostSession):
-        self.__assertIsIterableOf(tokens, str)
+    def isEntityReferenceString(self, someString, hostSession):
+        assert isinstance(someString, str)
         assert isinstance(hostSession, HostSession)
-        return self.mock.isEntityReferenceString(tokens, hostSession)
+        return self.mock.isEntityReferenceString(someString, hostSession)
 
     def entityExists(self, entityRefs, context, hostSession):
         self.__assertIsIterableOf(entityRefs, str)

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -214,10 +214,10 @@ class ValidatingMockManagerInterface(ManagerInterface):
 
         return self.mock.managementPolicy(traitSets, context, hostSession)
 
-    def isEntityReference(self, tokens, hostSession):
+    def isEntityReferenceString(self, tokens, hostSession):
         self.__assertIsIterableOf(tokens, str)
         assert isinstance(hostSession, HostSession)
-        return self.mock.isEntityReference(tokens, hostSession)
+        return self.mock.isEntityReferenceString(tokens, hostSession)
 
     def entityExists(self, entityRefs, context, hostSession):
         self.__assertIsIterableOf(entityRefs, str)

--- a/tests/python/openassetio/hostApi/test_manager.py
+++ b/tests/python/openassetio/hostApi/test_manager.py
@@ -231,13 +231,13 @@ class Test_Manager_flushCaches:
         method.assert_called_once_with(a_host_session)
 
 
-class Test_Manager_isEntityReference:
+class Test_Manager_isEntityReferenceString:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session, some_refs):
 
-        method = mock_manager_interface.mock.isEntityReference
-        assert manager.isEntityReference(some_refs) == method.return_value
+        method = mock_manager_interface.mock.isEntityReferenceString
+        assert manager.isEntityReferenceString(some_refs) == method.return_value
         method.assert_called_once_with(some_refs, a_host_session)
 
 

--- a/tests/python/openassetio/hostApi/test_manager.py
+++ b/tests/python/openassetio/hostApi/test_manager.py
@@ -234,11 +234,11 @@ class Test_Manager_flushCaches:
 class Test_Manager_isEntityReferenceString:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, a_host_session, some_refs):
+            self, manager, mock_manager_interface, a_host_session, a_ref):
 
         method = mock_manager_interface.mock.isEntityReferenceString
-        assert manager.isEntityReferenceString(some_refs) == method.return_value
-        method.assert_called_once_with(some_refs, a_host_session)
+        assert manager.isEntityReferenceString(a_ref) == method.return_value
+        method.assert_called_once_with(a_ref, a_host_session)
 
 
 class Test_Manager_entityExists:


### PR DESCRIPTION
Part of #549, refactors `isEntityReference` to the non-batch `isEntityReferenceString`, see the individual commit messages for more details.