### PR TITLE
[Core] Migrate `isEntityReferenceString` to C++

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -205,17 +205,21 @@ v1.0.0-alpha.X
 
 - Migrated the following `ManagerInterface` methods to C++
   `initialize`, `managementPolicy`, `createState`, `createChildState`,
-  `persistenceTokenForState`, `stateFromPersistenceToken`.
+  `persistenceTokenForState`, `stateFromPersistenceToken`,
+  `isEntityReferenceString`.
   [#455](https://github.com/OpenAssetIO/OpenAssetIO/issues/455)
   [#458](https://github.com/OpenAssetIO/OpenAssetIO/issues/458)
   [#445](https://github.com/OpenAssetIO/OpenAssetIO/issues/445)
+  [#549](https://github.com/OpenAssetIO/OpenAssetIO/issues/549)
 
 - Migrated the following `Manager` methods to C++ `initialize`
   `managementPolicy`, `createContext`, `createChildContext`,
-  `persistenceTokenForContext`, `contextFromPersistenceToken`.
+  `persistenceTokenForContext`, `contextFromPersistenceToken`,
+  `isEntityReferenceString`.
   [#455](https://github.com/OpenAssetIO/OpenAssetIO/issues/455)
   [#458](https://github.com/OpenAssetIO/OpenAssetIO/issues/458)
   [#445](https://github.com/OpenAssetIO/OpenAssetIO/issues/445)
+  [#549](https://github.com/OpenAssetIO/OpenAssetIO/issues/549)
 
 - Switched to preferring un-versioned `clang-tidy` executables when
   the `OPENASSETIO_ENABLE_CLANG_TIDY` build option is enabled. We

--- a/doc/src/ForHosts.dox
+++ b/doc/src/ForHosts.dox
@@ -101,8 +101,8 @@
  *   with a @ref Context with `kRead` access, respecting the returned
  *   traits.
  *
- * - Always check any suspected entity references with @ref
- *   openassetio.hostApi.Manager.Manager.isEntityReferenceString
+ * - Always check any suspected entity references with
+ *   @fqref{hostApi.Manager.isEntityReferenceString}
  *   "Manager.isEntityReferenceString" before passing to any other API
  *   calls.
  *
@@ -137,10 +137,9 @@
  *   manager to use to interact with an @ref asset_management_system,
  *   storing applicable options, etc...
  *
- * - @ref openassetio.hostApi.Manager.Manager.isEntityReferenceString
- *   "Test" and resolve any strings that may represent file system
- *   locations (@ref openassetio.hostApi.Manager.Manager.resolve
- *   "Manager.resolve")
+ * - @fqref{hostApi.Manager.isEntityReferenceString} "Test" and resolve
+ *   any strings that may represent file system locations (@ref
+ *   openassetio.hostApi.Manager.Manager.resolve "Manager.resolve")
  *
  * - Ensure the use of a correctly configured @ref Context for all
  *   calls to the API.

--- a/doc/src/Glossary.dox
+++ b/doc/src/Glossary.dox
@@ -111,8 +111,8 @@
  * 1. Discoverability
  * ------------------
  * It is essential that any given string can be readily identified as
- * being an entity reference or not. The @ref
- * openassetio.managerApi.ManagerInterface.ManagerInterface.isEntityReferenceString
+ * being an entity reference or not. The
+ * @fqref{hostApi.Manager.isEntityReferenceString}
  * "isEntityReferenceString" method will be called frequently by a @ref
  * host to determine if the arbitrary user input is a reference to a
  * managed entity.

--- a/doc/src/Testing.dox
+++ b/doc/src/Testing.dox
@@ -28,7 +28,7 @@
  *
  * Consequently the test harness needs to be supplied with valid
  * values to pass to methods such as
- * @ref openassetio.managerApi.ManagerInterface.ManagerInterface.isEntityReferenceString
+ * @fqref{hostApi.Manager.isEntityReferenceString}
  * "isEntityReferenceString", and the expected values from methods such
  * as @fqref{managerApi.ManagerInterface.identifier} "identifier"
  *

--- a/python/openassetio/hostApi/Manager.py
+++ b/python/openassetio/hostApi/Manager.py
@@ -186,55 +186,7 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
     ##
     # @name Entity Reference inspection
     #
-    # Because of the nature of an @ref entity_reference, it is often
-    # necessary to determine if some working string is actually an @ref
-    # entity_reference or not, to ensure it is handled correctly.
-    #
     # @{
-
-    @debugApiCall
-    @auditApiCall("Manager methods")
-    def isEntityReferenceString(self, someString):
-        """
-        @warning It is essential, as a host, that only valid
-        references are supplied to Manager API calls. Before any
-        reference is passed to any other methods of this class, they
-        must first be validated through this method.
-
-        Determines if the supplied string (in its entirety) matches the
-        pattern of an @ref entity_reference.  It does not verify that it
-        points to a valid entity in the system, simply that the pattern
-        of the string is recognised by the manager.
-
-        If it returns `True`, the string is an @ref entity_reference and
-        should be considered as a managed entity (or a future one).
-        Consequently, it should be resolved before use. It also confirms
-        that it can be passed to any other method that requires an @ref
-        entity_reference.
-
-        If `False`, this manager should no longer be involved in actions
-        relating to the string.
-
-        @param someString `str` The string to be inspected.
-
-        @return `bool` `True` if the supplied token should be
-        considered as an @ref entity_reference, `False` if the pattern
-        is not recognised.
-
-        @note This call does not verify an entity exits, just that the
-        format of the string is recognised.
-
-        @see @ref entityExists
-        @see @ref resolve
-
-        @todo Make use of
-        openassetio.constants.kField_EntityReferencesMatchPrefix if
-        supplied, especially when bridging between C/python.
-        """
-        # We need to add support here for using the supplied prefix match string,
-        # or regex, if supplied, instead of calling the manager, this is less
-        # relevant in python though, more in C, but the note is here to remind us.
-        return self.__impl.isEntityReferenceString(someString, self.__hostSession)
 
     @debugApiCall
     @auditApiCall("Manager methods")
@@ -647,10 +599,12 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         caller to handle requested data being missing in a fashion
         appropriate to its intended use.
 
-        @note You should always call @ref isEntityReferenceString first
-        if there is any doubt as to whether or not a string you have is
-        a valid reference for the manager, and only call resolve, or any
-        other methods, if it is a reference recognised by the manager.
+        @note You should always call
+        @fqref{hostApi.Manager.isEntityReferenceString}
+        "isEntityReferenceString" first if there is any doubt as to
+        whether or not a string you have is a valid reference for the
+        manager, and only call resolve, or any other methods, if it is a
+        reference recognised by the manager.
 
         The API defines that all file paths passed though the API that
         represent file sequences should retain the frame token, and

--- a/python/openassetio/managerApi/ManagerInterface.py
+++ b/python/openassetio/managerApi/ManagerInterface.py
@@ -239,46 +239,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
     ##
     # @name Entity Reference inspection
     #
-    # Because of the nature of an @ref entity_reference, it is often
-    # necessary to determine if some working string is actually an @ref
-    # entity_reference or not, to ensure it is handled correctly.
     #
     # @{
-
-    @abc.abstractmethod
-    def isEntityReferenceString(self, someString, hostSession):
-        """
-        Determines if the supplied string (in its entirety) matches the
-        pattern of a valid @ref entity_reference in your system. It
-        does not need to verify that it points to a valid entity in the
-        system, simply that the pattern of the string is recognised by
-        this implementation.
-
-        If this returns `True`, the string is an @ref entity_reference
-        and should be considered usable with the other methods of this
-        interface.
-
-        If `False`, this manager should no longer be involved in actions
-        relating to the string.
-
-        @warning The result of this call should not depend on the
-        context Locale.
-
-        @param someString str The string to be inspected.
-
-        @param hostSession HostSession The API session.
-
-        @return `bool` `True` if the supplied string should be
-        considered as an @ref entity_reference, `False` if the pattern is
-        not recognised.
-
-        @note This call should not verify an entity exits, just that
-        the format of the string is recognised.
-
-        @see @ref entityExists
-        @see @ref resolve
-        """
-        raise NotImplementedError
 
     @abc.abstractmethod
     def entityExists(self, entityRefs, context, hostSession):
@@ -393,7 +355,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         access is `kWrite` and the entity is an existing version.
 
         @see @ref entityExists
-        @see @ref isEntityReferenceString
+        @see @fqref{hostApi.Manager.isEntityReferenceString}
+        "isEntityReferenceString"
         """
         raise NotImplementedError
 

--- a/src/openassetio-core-c/private/managerApi/CManagerInterfaceAdapter.cpp
+++ b/src/openassetio-core-c/private/managerApi/CManagerInterfaceAdapter.cpp
@@ -2,6 +2,7 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 
 #include <stdexcept>
+#include <string>
 
 #include "CManagerInterfaceAdapter.hpp"
 
@@ -87,6 +88,12 @@ void CManagerInterfaceAdapter::initialize([[maybe_unused]] InfoDictionary manage
 trait::TraitsDatas CManagerInterfaceAdapter::managementPolicy(
     [[maybe_unused]] const trait::TraitSets& traitSets,
     [[maybe_unused]] const ContextConstPtr& context,
+    [[maybe_unused]] const HostSessionPtr& hostSession) const {
+  throw std::runtime_error{"Not implemented"};
+}
+
+bool CManagerInterfaceAdapter::isEntityReferenceString(
+    [[maybe_unused]] const std::string& someString,
     [[maybe_unused]] const HostSessionPtr& hostSession) const {
   throw std::runtime_error{"Not implemented"};
 }

--- a/src/openassetio-core-c/private/managerApi/CManagerInterfaceAdapter.hpp
+++ b/src/openassetio-core-c/private/managerApi/CManagerInterfaceAdapter.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #pragma once
+#include <string>
 
 #include <openassetio/c/export.h>
 #include <openassetio/export.h>
@@ -45,14 +46,19 @@ class OPENASSETIO_CORE_C_EXPORT CManagerInterfaceAdapter : ManagerInterface {
   [[nodiscard]] InfoDictionary info() const override;
 
   /// Wrap the C suite's `initialize` function.
-  /// @todo Implement C API. Currently a no-op.
+  /// @todo Implement C API. Currently throws `runtime_error`.
   void initialize(InfoDictionary managerSettings, const HostSessionPtr& hostSession) override;
 
   /// Wrap the C suite's `managementPolicy` function.
-  /// @todo Implement C API. Currently a no-op.
+  /// @todo Implement C API. Currently throws `runtime_error`.
   [[nodiscard]] trait::TraitsDatas managementPolicy(
       const trait::TraitSets& traitSets, const ContextConstPtr& context,
       const HostSessionPtr& hostSession) const override;
+
+  /// Wrap the C suite's `isEntityReferenceString` function.
+  /// @todo Implement C API. Currently throws `runtime_error`.
+  [[nodiscard]] bool isEntityReferenceString(const std::string& someString,
+                                             const HostSessionPtr& hostSession) const override;
 
  private:
   /// Opaque handle representing a ManagerInterface for the C API.

--- a/src/openassetio-core/hostApi/Manager.cpp
+++ b/src/openassetio-core/hostApi/Manager.cpp
@@ -68,6 +68,10 @@ ContextPtr Manager::contextFromPersistenceToken(const std::string &token) {
   return context;
 }
 
+bool Manager::isEntityReferenceString(const std::string &someString) const {
+  return managerInterface_->isEntityReferenceString(someString, hostSession_);
+}
+
 }  // namespace hostApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/EntityReference.hpp
+++ b/src/openassetio-core/include/openassetio/EntityReference.hpp
@@ -15,8 +15,8 @@ inline namespace OPENASSETIO_CORE_ABI_VERSION {
  * before being used as an @ref entity_reference in the various entity
  * related API calls.
  *
- * It can be assumed that if @ref
- * openassetio.hostApi.Manager.Manager.isEntityReferenceString
+ * It can be assumed that if
+ * @fqref{hostApi.Manager.isEntityReferenceString}
  * "isEntityReferenceString" is true for a given string, then an
  * EntityReference can be constructed from that string.
  *

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -34,7 +34,7 @@ OPENASSETIO_DECLARE_PTR(Manager)
  * @fqref{hostApi.ManagerFactory} "ManagerFactory", using the
  * @fqref{hostApi.ManagerFactory.createManager}
  * "ManagerFactory.createManager()" method with an appropriate manager
- * @needsref identifier.
+ * @ref identifier.
  *
  * @code
  * factory = openassetio.hostApi.ManagerFactory(
@@ -319,6 +319,60 @@ class OPENASSETIO_CORE_EXPORT Manager {
   /**
    * @}
    */
+
+  /**
+   * @name Entity Reference inspection
+   *
+   * Because of the nature of an @ref entity_reference, it is often
+   * necessary to determine if some working string is actually an @ref
+   * entity_reference or not, to ensure it is handled correctly.
+   *
+   * @{
+   */
+
+  /**
+   * @warning It is essential, as a host, that only valid references are
+   * supplied to Manager API calls. Before any reference is passed to
+   * any other methods of this class, they must first be validated
+   * through this method.
+   *
+   * Determines if the supplied string (in its entirety) matches the
+   * pattern of an @ref entity_reference.  It does not verify that it
+   * points to a valid entity in the system, simply that the pattern of
+   * the string is recognised by the manager.
+   *
+   * If it returns `true`, the string is an @ref entity_reference and
+   * should be considered as a managed entity (or a future one).
+   * Consequently, it should be resolved before use. It also confirms
+   * that it can be passed to any other method that requires an @ref
+   * entity_reference.
+   *
+   * If `false`, this manager should no longer be involved in actions
+   * relating to the string.
+   *
+   * @param someString `str` The string to be inspected.
+   *
+   * @return `bool` `True` if the supplied token should be
+   * considered as an @ref entity_reference, `False` if the pattern
+   * is not recognised.
+   *
+   * @note This call does not verify an entity exits, just that the
+   * format of the string is recognised. The call is notionally trivial
+   * and does not involve back-end system queries.
+   *
+   * @see @needsref entityExists
+   * @see @needsref resolve
+   *
+   * @todo Make use of
+   * openassetio.constants.kField_EntityReferencesMatchPrefix if
+   * supplied, especially when bridging between C/python.
+   */
+  [[nodiscard]] bool isEntityReferenceString(const std::string& someString) const;
+
+  /**
+   * @}
+   */
+
  private:
   explicit Manager(managerApi::ManagerInterfacePtr managerInterface,
                    managerApi::HostSessionPtr hostSession);

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -221,7 +221,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * If this isn't supplied, then isEntityReferenceString will always be
    * called to determine if a string is an @ref entity_reference or
    * not. Note, not all invocations require this optimization, so
-   * @needsref isEntityReferenceString should be implemented regardless.
+   * @ref isEntityReferenceString should be implemented regardless.
    *
    *   @li openassetio.constants.kField_EntityReferencesMatchPrefix
    *
@@ -500,6 +500,60 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    */
   [[nodiscard]] virtual ManagerStateBasePtr stateFromPersistenceToken(
       const std::string& token, const HostSessionPtr& hostSession);
+  /**
+   * @}
+   */
+
+  /**
+   * @name Entity Reference inspection
+   *
+   * Because of the nature of an @ref entity_reference, it is often
+   * necessary to determine if some working string is actually an @ref
+   * entity_reference or not, to ensure it is handled correctly.
+   *
+   * @{
+   */
+
+  /**
+   * Determines if the supplied string (in its entirety) matches the
+   * pattern of a valid @ref entity_reference in your system. It
+   * does not need to verify that it points to a valid entity in the
+   * system, simply that the pattern of the string is recognised by
+   * this implementation.
+   *
+   * Return `True` if the string is an @ref entity_reference
+   * and should be considered usable with the other methods of this
+   * interface.
+   *
+   * Return `False`, if this should no longer be involved in actions
+   * relating to the string as it is not recognised.
+   *
+   * @warning The result of this call should not depend on the context
+   * Locale, and should be trivial to compute. If for example, a manager
+   * makes use of URL-based entity references, then it is sufficient to
+   * check that the string's schema is that owned by the manager. This
+   * method should not validate the correctness of all supplied host,
+   * path or query components. The API middleware may cache or
+   * short-circuit calls to this method when bridging between languages.
+   *
+   * @param someString str The string to be inspected.
+   *
+   * @param hostSession HostSession The API session.
+   *
+   * @return `bool` `True` if the supplied string should be
+   * considered as an @ref entity_reference, `False` if the pattern is
+   * not recognised.
+   *
+   * @note This call should not verify an entity exits, just that the
+   * format of the string is recognised as a potential entity reference
+   * by the manager.
+   *
+   * @see @needsref entityExists
+   * @see @needsref resolve
+   */
+  [[nodiscard]] virtual bool isEntityReferenceString(const std::string& someString,
+                                                     const HostSessionPtr& hostSession) const = 0;
+
   /**
    * @}
    */

--- a/src/openassetio-python/module/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/module/hostApi/ManagerBinding.cpp
@@ -30,5 +30,6 @@ void registerManager(const py::module& mod) {
            py::arg("parentContext").none(false))
       .def("persistenceTokenForContext", &Manager::persistenceTokenForContext,
            py::arg("context").none(false))
-      .def("contextFromPersistenceToken", &Manager::contextFromPersistenceToken, py::arg("token"));
+      .def("contextFromPersistenceToken", &Manager::contextFromPersistenceToken, py::arg("token"))
+      .def("isEntityReferenceString", &Manager::isEntityReferenceString, py::arg("someString"));
 }

--- a/src/openassetio-python/module/managerApi/ManagerInterfaceBinding.cpp
+++ b/src/openassetio-python/module/managerApi/ManagerInterfaceBinding.cpp
@@ -75,6 +75,12 @@ struct PyManagerInterface : ManagerInterface {
     PYBIND11_OVERRIDE(PyRetainingManagerStateBasePtr, ManagerInterface, stateFromPersistenceToken,
                       token, hostSession);
   }
+
+  [[nodiscard]] bool isEntityReferenceString(const std::string& someString,
+                                             const HostSessionPtr& hostSession) const override {
+    PYBIND11_OVERRIDE_PURE(bool, ManagerInterface, isEntityReferenceString, someString,
+                           hostSession);
+  }
 };
 
 }  // namespace managerApi
@@ -104,5 +110,7 @@ void registerManagerInterface(const py::module& mod) {
            RetainCommonPyArgs::forFn<&ManagerInterface::persistenceTokenForState>(),
            py::arg("state").none(false), py::arg("hostSession").none(false))
       .def("stateFromPersistenceToken", &ManagerInterface::stateFromPersistenceToken,
-           py::arg("token"), py::arg("hostSession").none(false));
+           py::arg("token"), py::arg("hostSession").none(false))
+      .def("isEntityReferenceString", &ManagerInterface::isEntityReferenceString,
+           py::arg("someString"), py::arg("hostSession").none(false));
 }

--- a/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
+++ b/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
@@ -45,6 +45,7 @@ struct MockManagerInterface : trompeloeil::mock_interface<managerApi::ManagerInt
   IMPLEMENT_CONST_MOCK0(info);
   IMPLEMENT_MOCK2(initialize);
   IMPLEMENT_CONST_MOCK3(managementPolicy);
+  IMPLEMENT_CONST_MOCK2(isEntityReferenceString);
 };
 /**
  * Mock implementation of a HostInterface.

--- a/tests/python/openassetio/hostApi/test_manager.py
+++ b/tests/python/openassetio/hostApi/test_manager.py
@@ -232,12 +232,13 @@ class Test_Manager_flushCaches:
 
 
 class Test_Manager_isEntityReferenceString:
-
+    @pytest.mark.parametrize("expected", (True, False))
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, a_host_session, a_ref):
-
+            self, manager, mock_manager_interface, a_host_session, a_ref, expected):
         method = mock_manager_interface.mock.isEntityReferenceString
-        assert manager.isEntityReferenceString(a_ref) == method.return_value
+        method.return_value = expected
+
+        assert manager.isEntityReferenceString(a_ref) == expected
         method.assert_called_once_with(a_ref, a_host_session)
 
 


### PR DESCRIPTION
Part of #549. In order for a C++ host to use an entity reference string as a parameter to manager API methods, the host is required to validate that it is relevant to the target manager.

Currently, this is expected to be an explicit validation by the host application, but in upcoming work this will also be performed by entity reference factory functions.

So as a prerequisite step toward C++ migration of manager API methods that use entity references, migrate `isEntityReferenceString` to C++, so that entity reference strings can be validated before use.