### PR TITLE
[Core] Add `Manager.createEntityReference`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -168,7 +168,8 @@ v1.0.0-alpha.X
 ### Improvements
 
 - Added `EntityReference` type to encapsulate a validated string
-  so it can be used with entity-related API methods.
+  so it can be used with entity-related API methods. These should
+  always be created with `Manager.createEntityReference`.
   [#549](https://github.com/OpenAssetIO/OpenAssetIO/issues/549)
 
 - Added `openassetio-python` C++-to-Python bridge library, providing

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -169,7 +169,8 @@ v1.0.0-alpha.X
 
 - Added `EntityReference` type to encapsulate a validated string
   so it can be used with entity-related API methods. These should
-  always be created with `Manager.createEntityReference`.
+  always be created with either `Manager.createEntityReference` or
+  `Manager.createEntityReferenceIfValid`.
   [#549](https://github.com/OpenAssetIO/OpenAssetIO/issues/549)
 
 - Added `openassetio-python` C++-to-Python bridge library, providing

--- a/src/openassetio-core/hostApi/Manager.cpp
+++ b/src/openassetio-core/hostApi/Manager.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <stdexcept>
+
 #include <openassetio/Context.hpp>
 #include <openassetio/hostApi/Manager.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
@@ -70,6 +72,15 @@ ContextPtr Manager::contextFromPersistenceToken(const std::string &token) {
 
 bool Manager::isEntityReferenceString(const std::string &someString) const {
   return managerInterface_->isEntityReferenceString(someString, hostSession_);
+}
+
+const Str kCreateEntityReferenceErrorMessage = "Invalid entity reference: ";
+
+EntityReference Manager::createEntityReference(Str entityReferenceString) const {
+  if (!isEntityReferenceString(entityReferenceString)) {
+    throw std::domain_error{kCreateEntityReferenceErrorMessage + entityReferenceString};
+  }
+  return EntityReference{std::move(entityReferenceString)};
 }
 
 }  // namespace hostApi

--- a/src/openassetio-core/hostApi/Manager.cpp
+++ b/src/openassetio-core/hostApi/Manager.cpp
@@ -83,6 +83,14 @@ EntityReference Manager::createEntityReference(Str entityReferenceString) const 
   return EntityReference{std::move(entityReferenceString)};
 }
 
+std::optional<EntityReference> Manager::createEntityReferenceIfValid(
+    Str entityReferenceString) const {
+  if (!isEntityReferenceString(entityReferenceString)) {
+    return {};
+  }
+  return EntityReference{std::move(entityReferenceString)};
+}
+
 }  // namespace hostApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <openassetio/export.h>
@@ -390,6 +391,23 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * @todo Use a custom exception type rather than std::domain_error.
    */
   [[nodiscard]] EntityReference createEntityReference(Str entityReferenceString) const;
+
+  /**
+   * Create an @ref EntityReference object wrapping a given
+   * @ref entity_reference string, if it is valid according to
+   * @ref isEntityReferenceString.
+   *
+   * @see @ref createEntityReference
+   *
+   * @param entityReferenceString Raw string representation of the
+   * entity reference. Taken by value to enable move semantics, on the
+   * assumption that an invalid entity reference is a rare case.
+   *
+   * @return `std::optional` containing an `EntityReference` value if
+   * valid, not containing a value otherwise.
+   */
+  [[nodiscard]] std::optional<EntityReference> createEntityReferenceIfValid(
+      Str entityReferenceString) const;
 
   /**
    * @}

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include <openassetio/export.h>
+#include <openassetio/EntityReference.hpp>
 #include <openassetio/InfoDictionary.hpp>
 #include <openassetio/trait/collection.hpp>
 #include <openassetio/typedefs.hpp>
@@ -368,6 +369,27 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * supplied, especially when bridging between C/python.
    */
   [[nodiscard]] bool isEntityReferenceString(const std::string& someString) const;
+
+  /**
+   * Create an @ref EntityReference object wrapping a given
+   * @ref entity_reference string.
+   *
+   * First validates that the given entity reference string is
+   * meaningful for this manager via @ref isEntityReferenceString,
+   * throwing a `std::domain_error` if not.
+   *
+   * @param entityReferenceString Raw string representation of the
+   * entity reference. Taken by value to enable move semantics, on the
+   * assumption that an invalid entity reference is a rare case.
+   *
+   * @return Validated entity reference object.
+   *
+   * @throw std::domain_error If the given string is not recognized as
+   * an entity reference by this manager.
+   *
+   * @todo Use a custom exception type rather than std::domain_error.
+   */
+  [[nodiscard]] EntityReference createEntityReference(Str entityReferenceString) const;
 
   /**
    * @}

--- a/src/openassetio-python/module/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/module/hostApi/ManagerBinding.cpp
@@ -33,5 +33,7 @@ void registerManager(const py::module& mod) {
       .def("contextFromPersistenceToken", &Manager::contextFromPersistenceToken, py::arg("token"))
       .def("isEntityReferenceString", &Manager::isEntityReferenceString, py::arg("someString"))
       .def("createEntityReference", &Manager::createEntityReference,
+           py::arg("entityReferenceString"))
+      .def("createEntityReferenceIfValid", &Manager::createEntityReferenceIfValid,
            py::arg("entityReferenceString"));
 }

--- a/src/openassetio-python/module/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/module/hostApi/ManagerBinding.cpp
@@ -31,5 +31,7 @@ void registerManager(const py::module& mod) {
       .def("persistenceTokenForContext", &Manager::persistenceTokenForContext,
            py::arg("context").none(false))
       .def("contextFromPersistenceToken", &Manager::contextFromPersistenceToken, py::arg("token"))
-      .def("isEntityReferenceString", &Manager::isEntityReferenceString, py::arg("someString"));
+      .def("isEntityReferenceString", &Manager::isEntityReferenceString, py::arg("someString"))
+      .def("createEntityReference", &Manager::createEntityReference,
+           py::arg("entityReferenceString"));
 }

--- a/tests/python/openassetio/hostApi/test_manager.py
+++ b/tests/python/openassetio/hostApi/test_manager.py
@@ -266,6 +266,29 @@ class Test_Manager_createEntityReference:
         assert entity_reference.toString() == a_ref_string
 
 
+class Test_Manager_createEntityReferenceIfValid:
+    def test_when_invalid_then_returns_None(
+            self, manager, mock_manager_interface, a_ref_string, a_host_session):
+        mock_manager_interface.mock.isEntityReferenceString.return_value = False
+
+        entity_reference = manager.createEntityReferenceIfValid(a_ref_string)
+
+        mock_manager_interface.mock.isEntityReferenceString.assert_called_once_with(
+            a_ref_string, a_host_session)
+        assert entity_reference is None
+
+    def test_when_valid_then_returns_configured_EntityReference(
+            self, manager, mock_manager_interface, a_ref_string, a_host_session):
+        mock_manager_interface.mock.isEntityReferenceString.return_value = True
+
+        entity_reference = manager.createEntityReferenceIfValid(a_ref_string)
+
+        mock_manager_interface.mock.isEntityReferenceString.assert_called_once_with(
+            a_ref_string, a_host_session)
+        assert isinstance(entity_reference, EntityReference)
+        assert entity_reference.toString() == a_ref_string
+
+
 class Test_Manager_entityExists:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(

--- a/tests/python/openassetio/hostApi/test_manager.py
+++ b/tests/python/openassetio/hostApi/test_manager.py
@@ -23,7 +23,7 @@ Tests that cover the openassetio.hostApi.Manager wrapper class.
 
 import pytest
 
-from openassetio import Context, TraitsData, managerApi
+from openassetio import Context, EntityReference, TraitsData, managerApi
 from openassetio.hostApi import Manager
 
 
@@ -64,7 +64,7 @@ def a_context():
 
 
 @pytest.fixture
-def a_ref():
+def a_ref_string():
     return "asset://a"
 
 
@@ -234,12 +234,36 @@ class Test_Manager_flushCaches:
 class Test_Manager_isEntityReferenceString:
     @pytest.mark.parametrize("expected", (True, False))
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, a_host_session, a_ref, expected):
+            self, manager, mock_manager_interface, a_host_session, a_ref_string, expected):
         method = mock_manager_interface.mock.isEntityReferenceString
         method.return_value = expected
 
-        assert manager.isEntityReferenceString(a_ref) == expected
-        method.assert_called_once_with(a_ref, a_host_session)
+        assert manager.isEntityReferenceString(a_ref_string) == expected
+        method.assert_called_once_with(a_ref_string, a_host_session)
+
+
+class Test_Manager_createEntityReference:
+    def test_when_invalid_then_raises_ValueError(
+            self, manager, mock_manager_interface, a_ref_string, a_host_session):
+        mock_manager_interface.mock.isEntityReferenceString.return_value = False
+
+        with pytest.raises(ValueError) as err:
+            manager.createEntityReference(a_ref_string)
+
+        mock_manager_interface.mock.isEntityReferenceString.assert_called_once_with(
+            a_ref_string, a_host_session)
+        assert str(err.value) == f"Invalid entity reference: {a_ref_string}"
+
+    def test_when_valid_then_returns_configured_EntityReference(
+            self, manager, mock_manager_interface, a_ref_string, a_host_session):
+        mock_manager_interface.mock.isEntityReferenceString.return_value = True
+
+        entity_reference = manager.createEntityReference(a_ref_string)
+
+        mock_manager_interface.mock.isEntityReferenceString.assert_called_once_with(
+            a_ref_string, a_host_session)
+        assert isinstance(entity_reference, EntityReference)
+        assert entity_reference.toString() == a_ref_string
 
 
 class Test_Manager_entityExists:
@@ -345,16 +369,16 @@ class Test_Manager_finalizedEntityVersion:
 class Test_Manager_getRelatedReferences:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, a_host_session, a_ref, an_empty_traitsdata,
-            an_entity_trait_set, a_context):
+            self, manager, mock_manager_interface, a_host_session, a_ref_string,
+            an_empty_traitsdata, an_entity_trait_set, a_context):
 
         # pylint: disable=too-many-locals
 
         method = mock_manager_interface.mock.getRelatedReferences
 
-        one_ref = a_ref
-        two_refs = [a_ref, a_ref]
-        three_refs = [a_ref, a_ref, a_ref]
+        one_ref = a_ref_string
+        two_refs = [a_ref_string, a_ref_string]
+        three_refs = [a_ref_string, a_ref_string, a_ref_string]
         one_data = an_empty_traitsdata
         two_datas = [an_empty_traitsdata, an_empty_traitsdata]
         three_datas = [an_empty_traitsdata, an_empty_traitsdata, an_empty_traitsdata]


### PR DESCRIPTION
Part of #549. Added the `createEntityReference` method to C++ and Python, which should always be used to create `EntityReference` objects.

The method will validate that the provided entity reference string is relevant to the manager and throw a `std::domain_error` if it isn't (exception type to be migrated to a custom type in future work).
