### PR TITLE
[Core] Update Manager to expect EntityReference

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,14 @@ v1.0.0-alpha.X
 
 ### Breaking changes
 
+- Added `EntityReference` type to encapsulate a validated string
+  so it can be used with entity-related API methods. These should always
+  be created with either `Manager.createEntityReference` or
+  `Manager.createEntityReferenceIfValid`. Updated the signature of
+  `Manager` and `ManagerInterface` methods to take `EntityReference`
+  object arguments, rather than entity reference strings.
+  [#549](https://github.com/OpenAssetIO/OpenAssetIO/issues/549)
+
 - Renamed `isEntityReference` to `isEntityReferenceString` to avoid
   ambiguity when also working with the new `EntityReference` type.
   [#549](https://github.com/OpenAssetIO/OpenAssetIO/issues/549)
@@ -166,12 +174,6 @@ v1.0.0-alpha.X
 
 
 ### Improvements
-
-- Added `EntityReference` type to encapsulate a validated string
-  so it can be used with entity-related API methods. These should
-  always be created with either `Manager.createEntityReference` or
-  `Manager.createEntityReferenceIfValid`.
-  [#549](https://github.com/OpenAssetIO/OpenAssetIO/issues/549)
 
 - Added `openassetio-python` C++-to-Python bridge library, providing
   a `createPythonPluginSystemManagerImplementationFactory` function,

--- a/doc/src/Examples.dox
+++ b/doc/src/Examples.dox
@@ -103,15 +103,21 @@
  * @section examples_resolving_a_reference Resolving a Reference
  *
  * This example shows how to use the instantiated manager to resolve a
- * string (`some_string`) that may be an entity reference to an entity
- * with the 'file' @ref trait - covering use of the correct context
- * and a custom @ref locale to describe the call site.
+ * string (`some_string`) that is assumed to be an entity reference to
+ * an entity with the 'file' @ref trait - covering use of the correct
+ * context and a custom @ref locale to describe the call site.
  *
- * @note Note how it is the callers responsibility to validate
- * that a string is a @ref entity_reference before passing it to any
- * other OpenAssetIO API that expects one.
+ * @note The caller must convert a string to an @fqref{EntityReference}
+ * "EntityReference" object in order to use any OpenAssetIO API that
+ * expects an @ref entity_reference. There is more than one approach to
+ * this. Below we rely on the exception thrown by
+ * @fqref{hostApi.Manager.createEntityReference} "createEntityReference"
+ * when given an invalid reference. Alternatively, we could use
+ * @fqref{hostApi.Manager.createEntityReferenceIfValid}
+ * "createEntityReferenceIfValid" and test if the result is falsey.
  *
- * This is to reduce the validation overhead in the manager's
+ * @note Ensuring that an entity reference is valid before handing it
+ * to the manager reduces the validation overhead in the manager's
  * implementation of the API. This affords significant gains in
  * real-world production use cases where thousands of references
  * may be operated upon in time-critical scenarios.
@@ -132,10 +138,11 @@
  *     """
  *     kTraitSet = {"documentation", "example"}
  *
- * # We must **ALWAYS** validate that a string is an entity reference
- * # before passing it to any other manager API call.
- * if not manager.isEntityReferenceString(some_string):
- *    raise ValueError(f'"{some_string}" isn't an entity reference.')
+ * # Note: this will raise an exception if given a string that is not
+ * # recognized by this manager as a valid entity reference (ValueError
+ * # in Python, std::domain_error in C++). Consider
+ * # createEntityReferenceIfValid, if unsure of the string.
+ * entity_reference = manager.createEntityReference(some_string)
  *
  * # All calls to the manager must have a Context, these should always
  * # be created by the target manager. The Context expresses the host's
@@ -157,7 +164,7 @@
  * # We can now resolve a token we may have if it is a reference. In
  * # this example, we'll attempt to resolve the asset with the
  * # file trait.
- * [resolved_asset] = manager.resolve([some_string], {FileTrait.id}, context)
+ * [resolved_asset] = manager.resolve([entity_reference], {FileTrait.id}, context)
  * if resolved_asset.hasTrait(FileTrait.id):
  *    path = FileTrait(resolved_asset).getPath()
  * @endcode

--- a/python/openassetio/exceptions.py
+++ b/python/openassetio/exceptions.py
@@ -83,11 +83,12 @@ class BaseEntityException(ManagerException):
         """
         @param message str, The message of the exception.
 
-        @param entityReference str, The entity reference associated with
-        the error. This should be provided wherever known, and will be
-        printed along with the message in any traceback/etc... As such,
-        there is no need to embedded the entity reference in the message
-        when using this exception type.
+        @param entityReference @fqref{EntityReference} "EntityReference"
+        The entity reference associated with the error. This should be
+        provided wherever known, and will be printed along with the
+        message in any traceback/etc... As such, there is no need to
+        embedded the entity reference in the message when using this
+        exception type.
         """
         super(BaseEntityException, self).__init__(message)
         self.ref = entityReference

--- a/python/openassetio/hostApi/Manager.py
+++ b/python/openassetio/hostApi/Manager.py
@@ -214,7 +214,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         definition of 'exists' in some cases too, as it better explains
         the use-case of the call.
 
-        @param entityRefs `List[str]` Entity references to query.
+        @param entityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` Entity references to query.
 
         @param context Context The calling context.
 
@@ -282,7 +283,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
          @li `"Cuttlefish v1"` - for a versioned asset
          @li `"seq003"` - for a sequence in a hierarchy
 
-        @param entityRefs `List[str]` Entity references to query.
+        @param entityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` Entity references to query.
 
         @param context Context The calling context.
 
@@ -308,7 +310,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
          @li `"Sequence 003 [ Dive / Episode 1 ]"` - for a sequence in
          an hierarchy as a window title.
 
-        @param entityRefs `List[str]` Entity references to query.
+        @param entityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` Entity references to query.
 
         @param context Context The calling context.
 
@@ -340,7 +343,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         Retrieves the identifier of the version pointed to by each
         supplied @ref entity_reference.
 
-        @param entityRefs `List[str]` Entity references to query.
+        @param entityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` Entity references to query.
 
         @param context Context The calling context.
 
@@ -365,7 +369,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         entity_reference (including the supplied ref, if it points to a
         specific version).
 
-        @param entityRefs `List[str]` Entity references to query.
+        @param entityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` Entity references to query.
 
         @param context Context The calling context.
 
@@ -408,7 +413,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         If versioning is unsupported for a given @ref
         entity_reference, then the input reference will be returned.
 
-        @param entityRefs `List[str]` Entity references to query.
+        @param entityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` Entity references to query.
 
         @param context Context The calling context.
 
@@ -599,18 +605,19 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         caller to handle requested data being missing in a fashion
         appropriate to its intended use.
 
-        @note You should always call
-        @fqref{hostApi.Manager.isEntityReferenceString}
-        "isEntityReferenceString" first if there is any doubt as to
-        whether or not a string you have is a valid reference for the
-        manager, and only call resolve, or any other methods, if it is a
-        reference recognised by the manager.
+        @note @fqref{EntityReference} "EntityReference" objects _must_
+        be constructed using either
+        @fqref{hostApi.Manager.createEntityReference}
+        "createEntityReference" or
+        @fqref{hostApi.Manager.createEntityReferenceIfValid}
+        "createEntityReferenceIfValid".
 
         The API defines that all file paths passed though the API that
         represent file sequences should retain the frame token, and
         use the 'format' syntax, compatible with sprintf (eg.  %04d").
 
-        @param entityRefs `List[str]` Entity references to query.
+        @param entityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` Entity references to query.
 
         @param context Context The calling context.
 
@@ -752,8 +759,9 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         registration, and for the final call to @ref
         register itself. See @ref example_publishing_a_file.
 
-        @param targetEntityRefs `List[str]` The entity references to
-        preflight prior to registration.
+        @param targetEntityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` The entity references to preflight prior
+        to registration.
 
         @param traitSet `Set[str]` The @ref trait_set of the
         entites that are being published.
@@ -831,8 +839,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         same path. Managers may freely relocate, copy, move or rename
         files as part of registration.
 
-        @param targetEntityRefs `List[str]` Entity references to publish
-        to.
+        @param targetEntityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` Entity references to publish to.
 
         @param entityTraitsDatas `List[` @fqref{TraitsData}
         "TraitsData" `]` The data to register for each entity.

--- a/python/openassetio/managerApi/ManagerInterface.py
+++ b/python/openassetio/managerApi/ManagerInterface.py
@@ -208,7 +208,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         designated thread safe, it is important to implement any
         pre-fetch mechanism with suitable locks/etc... if required.
 
-        @param entityRefs `List[str]` The entities whose data should be
+        @param entityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` The entities whose data should be
         prefetched.
 
         @param context openassetio.Context You may wish to make use of
@@ -266,7 +267,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         to disambiguating this subtle definition of 'exists' in some
         cases too, as it better explains the use-case of the call.
 
-        @param entityRefs `List[str]` Entity references to query.
+        @param entityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` Entity references to query.
 
         @param context Context The calling context.
 
@@ -331,10 +333,13 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         any rules of the system - for example, resolving an existing
         entity reference for write.
 
-        The caller will have first called isEntityReferenceString() on
-        the supplied strings.
+        The supplied entity references will have already been validated
+        as relevant to this manager (via
+        @fqref{hostApi.Manager.isEntityReferenceString}
+        "isEntityReferenceString").
 
-        @param entityRefs `List[str]` Entity references to query.
+        @param entityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` Entity references to query.
 
         @param traitSet `Set[str]` The traits to resolve for the
         supplied list of entity references.
@@ -421,7 +426,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
          @li `"Cuttlefish v1"` - for a version of an asset
          @li `"seq003"` - for a sequence in a hierarchy
 
-        @param entityRefs `List[str]` Entity references to query.
+        @param entityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` Entity references to query.
 
         @param context Context The calling context.
 
@@ -451,7 +457,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
          @li `"Sequence 003 [ Dive / Episode 1 ]"` - for a sequence in
          an hierarchy as a window title.
 
-        @param entityRefs `List[str]` Entity references to query.
+        @param entityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` Entity references to query.
 
         @param context Context The calling context.
 
@@ -486,7 +493,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         Retrieves the identifier of the version pointed to by each
         supplied @ref entity_reference.
 
-        @param entityRefs `List[str]` Entity references to query.
+        @param entityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` Entity references to query.
 
         @param context Context The calling context.
 
@@ -514,7 +522,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         entity_reference (including the supplied ref, if it points to a
         specific version).
 
-        @param entityRefs `List[str]` Entity references to query.
+        @param entityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` Entity references to query.
 
         @param context Context The calling context.
 
@@ -558,7 +567,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         If versioning is unsupported for a given @ref
         entity_reference, then the input reference should be returned.
 
-        @param entityRefs `List[str]` The entity references to finalize.
+        @param entityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` The entity references to finalize.
 
         @param context Context The calling context.
 
@@ -677,7 +687,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         should be returned for that relationship, and no errors should
         be raised.
 
-        @param entityRefs List[str]
+        @param entityRefs List[` @fqref{EntityReference}
+        "EntityReference" `]
 
         @param relationshipTraitsDatas `List[`
         @fqref{TraitsData} "TraitsData" `]`
@@ -728,8 +739,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         In systems that don't support post-creation adjustment of
         relationships, this can simply be a no-op.
 
-        @param entityRef `str` The entity to which the relationship
-        should be established.
+        @param entityRef @fqref{EntityReference} "EntityReference" The
+        entity to which the relationship should be established.
 
         @param relationshipTraitsData @fqref{TraitsData} "TraitsData",
         The type of relationship to establish.
@@ -843,10 +854,10 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         openassetio.traits.managementPolicy.WillManagePathTrait
         "WillManagePathTrait" set.
 
-        @param targetEntityRefs `List[str]` An @ref entity_reference
-        for each entity that it is desired to publish the forthcoming
-        data to. See the notes in the API documentation for the
-        specifics of this.
+        @param targetEntityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` An @ref entity_reference for each entity
+        that it is desired to publish the forthcoming data to. See the
+        notes in the API documentation for the specifics of this.
 
         @param traitSet `Set(str)` The @ref trait_set of the
         entities that are being published.
@@ -902,15 +913,15 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         information or schedule additional processes to produce
         derivative data.
 
-        @param targetEntityRefs `List[str]` The @ref entity_reference
-        of each entity to publish. It is up to the manager to ensure
-        that this is meaningful, as it is most likely implementation
-        specific. For example, if an entity with the traits of a 'Shot'
-        specification is requested to be published to a reference that
-        points to a 'Sequence' it makes sense to interpret this as a
-        'add a shot of this spec to the sequence'. For other types of
-        entity, there may be
-        different constraints on what makes sense.
+        @param targetEntityRefs `List[` @fqref{EntityReference}
+        "EntityReference" `]` The @ref entity_reference of each entity
+        to publish. It is up to the manager to ensure that this is
+        meaningful, as it is most likely implementation specific. For
+        example, if an entity with the traits of a 'Shot' specification
+        is requested to be published to a reference that points to a
+        'Sequence' it makes sense to interpret this as a 'add a shot of
+        this spec to the sequence'. For other types of entity, there may
+        be different constraints on what makes sense.
 
         @param entityTraitsDatas `List[` @fqref{TraitsData} "TraitsData"
         `]` The data for each entity (or 'asset') that is being

--- a/python/openassetio/test/manager/apiComplianceSuite.py
+++ b/python/openassetio/test/manager/apiComplianceSuite.py
@@ -242,8 +242,10 @@ class Test_entityExists(FixtureAugmentedTestCase):
     """
 
     def setUp(self):
-        self.collectRequiredFixture("a_reference_to_an_existing_entity", skipTestIfMissing=True)
-        self.collectRequiredFixture("a_reference_to_a_nonexisting_entity")
+        self.a_reference_to_an_existing_entity = self._manager.createEntityReference(
+            self.requireFixture("a_reference_to_an_existing_entity", skipTestIfMissing=True))
+        self.a_reference_to_a_nonexisting_entity = self._manager.createEntityReference(
+            self.requireFixture("a_reference_to_a_nonexisting_entity"))
 
     def test_existing_reference_returns_true(self):
         context = self.createTestContext()
@@ -268,7 +270,8 @@ class Test_resolve(FixtureAugmentedTestCase):
     managerApi.ManagerInterface.resolve.
     """
     def setUp(self):
-        self.collectRequiredFixture("a_reference_to_a_readable_entity", skipTestIfMissing=True)
+        self.a_reference_to_a_readable_entity = self._manager.createEntityReference(
+            self.requireFixture("a_reference_to_a_readable_entity", skipTestIfMissing=True))
         self.collectRequiredFixture("a_set_of_valid_traits")
 
     def test_when_no_traits_then_returned_specification_is_empty(self):
@@ -310,7 +313,8 @@ class Test_resolve(FixtureAugmentedTestCase):
             self.assertEqual(result.traitSet(), expected_traits)
 
     def __testResolutionError(self, fixture_name, access):
-        reference = self.requireFixture(fixture_name, skipTestIfMissing=True)
+        reference = self._manager.createEntityReference(
+            self.requireFixture(fixture_name, skipTestIfMissing=True))
         expected_msg = self.requireFixture(f"the_error_string_for_{fixture_name}")
         expected_error = EntityResolutionError(expected_msg, reference)
         context = self.createTestContext()

--- a/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
+++ b/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
@@ -103,7 +103,7 @@ class BasicAssetLibraryInterface(ManagerInterface):
         results = []
         for ref in entityRefs:
             try:
-                entity_info = bal.parse_entity_ref(ref)
+                entity_info = bal.parse_entity_ref(ref.toString())
                 result = bal.exists(entity_info, self.__library)
             except InvalidEntityReference as exc:
                 result = exc
@@ -116,7 +116,7 @@ class BasicAssetLibraryInterface(ManagerInterface):
         results = []
         for ref in entityRefs:
             try:
-                entity_info = bal.parse_entity_ref(ref)
+                entity_info = bal.parse_entity_ref(ref.toString())
                 entity = bal.entity(entity_info, self.__library)
                 result = TraitsData()
                 for trait in traitSet:

--- a/resources/examples/manager/BasicAssetLibrary/tests/bal_business_logic_suite.py
+++ b/resources/examples/manager/BasicAssetLibrary/tests/bal_business_logic_suite.py
@@ -124,7 +124,9 @@ class Test_resolve(FixtureAugmentedTestCase):
     }
 
     def test_matches_expected_values(self):
-        entity_references = self.__entities.keys()
+        entity_references = [
+            self._manager.createEntityReference(ref_str) for ref_str in self.__entities.keys()
+        ]
         trait_set = {"string", "number", "test-data"}
         context = self.createTestContext(access=Context.kRead)
         results = self._manager.resolve(list(entity_references), trait_set, context)
@@ -132,7 +134,7 @@ class Test_resolve(FixtureAugmentedTestCase):
             # Check all traits are present, and their properties.
             # TODO(tc): When we have a better introspection API in
             # TraitsData, we can assert there aren't any bonus values.
-            for trait in self.__entities[ref].keys():
+            for trait in self.__entities[ref.toString()].keys():
                 self.assertTrue(result.hasTrait(trait))
-                for property_, value in self.__entities[ref][trait].items():
+                for property_, value in self.__entities[ref.toString()][trait].items():
                     self.assertEqual(result.getTraitProperty(trait, property_), value)

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -352,6 +352,12 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * If `false`, this manager should no longer be involved in actions
    * relating to the string.
    *
+   * This function is useful for control flow where constructing an
+   * @fqref{EntityReference} "EntityReference" object is not (yet)
+   * needed. For other situations, consider using @ref
+   * createEntityReferenceIfValid instead, to validate and (potentially)
+   * return an `EntityReference` in a single call.
+   *
    * @param someString `str` The string to be inspected.
    *
    * @return `bool` `True` if the supplied token should be

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -22,7 +22,7 @@ import sys
 
 import pytest
 
-from openassetio import Context, TraitsData
+from openassetio import Context, EntityReference, TraitsData
 from openassetio.log import LoggerInterface
 from openassetio.managerApi import ManagerInterface, Host, HostSession
 from openassetio.hostApi import HostInterface
@@ -154,13 +154,13 @@ class ValidatingMockManagerInterface(ManagerInterface):
         return self.mock.defaultEntityReference(traitSets, context, hostSession)
 
     def entityVersion(self, entityRefs, context, hostSession):
-        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertIsIterableOf(entityRefs, EntityReference)
         self.__assertCallingContext(context, hostSession)
         return self.mock.entityVersion(entityRefs, context, hostSession)
 
     def entityVersions(
             self, entityRefs, context, hostSession, includeMetaVersions=False, maxNumVersions=-1):
-        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertIsIterableOf(entityRefs, EntityReference)
         self.__assertCallingContext(context, hostSession)
         assert isinstance(includeMetaVersions, bool)
         assert isinstance(maxNumVersions, int)
@@ -168,7 +168,7 @@ class ValidatingMockManagerInterface(ManagerInterface):
             entityRefs, context, hostSession, includeMetaVersions, maxNumVersions)
 
     def finalizedEntityVersion(self, entityRefs, context, hostSession, overrideVersionName=None):
-        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertIsIterableOf(entityRefs, EntityReference)
         self.__assertCallingContext(context, hostSession)
         assert isinstance(overrideVersionName, str) or overrideVersionName is None
         return self.mock.finalizedEntityVersion(
@@ -176,11 +176,13 @@ class ValidatingMockManagerInterface(ManagerInterface):
 
     def setRelatedReferences(self, entityRef, relationshipTraitsData, relatedRefs, context,
                 hostSession, append=True):
+        assert isinstance(entityRef, EntityReference)
+        self.__assertIsIterableOf(relatedRefs, EntityReference)
         return self.mock.setRelatedReferences(
             entityRef, relationshipTraitsData, relatedRefs, context, hostSession, append=append)
 
     def preflight(self, targetEntityRefs, traitSet, context, hostSession):
-        self.__assertIsIterableOf(targetEntityRefs, str)
+        self.__assertIsIterableOf(targetEntityRefs, EntityReference)
         self.__assertIsIterableOf(traitSet, str)
         self.__assertCallingContext(context, hostSession)
         return self.mock.preflight(targetEntityRefs, traitSet, context, hostSession)
@@ -220,29 +222,29 @@ class ValidatingMockManagerInterface(ManagerInterface):
         return self.mock.isEntityReferenceString(someString, hostSession)
 
     def entityExists(self, entityRefs, context, hostSession):
-        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertIsIterableOf(entityRefs, EntityReference)
         self.__assertCallingContext(context, hostSession)
         return self.mock.entityExists(entityRefs, context, hostSession)
 
     def resolve(self, entityRefs, traitSet, context, hostSession):
-        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertIsIterableOf(entityRefs, EntityReference)
         self.__assertIsIterableOf(traitSet, str)
         self.__assertCallingContext(context, hostSession)
         return self.mock.resolve(entityRefs, traitSet, context, hostSession)
 
     def entityName(self, entityRefs, context, hostSession):
-        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertIsIterableOf(entityRefs, EntityReference)
         self.__assertCallingContext(context, hostSession)
         return self.mock.entityName(entityRefs, context, hostSession)
 
     def entityDisplayName(self, entityRefs, context, hostSession):
-        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertIsIterableOf(entityRefs, EntityReference)
         self.__assertCallingContext(context, hostSession)
         return self.mock.entityDisplayName(entityRefs, context, hostSession)
 
     def getRelatedReferences(
             self, entityRefs, relationshipTraitsDatas, context, hostSession, resultTraitSet=None):
-        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertIsIterableOf(entityRefs, EntityReference)
         self.__assertIsIterableOf(relationshipTraitsDatas, TraitsData)
         self.__assertCallingContext(context, hostSession)
         if resultTraitSet is not None:
@@ -252,7 +254,7 @@ class ValidatingMockManagerInterface(ManagerInterface):
             entityRefs, relationshipTraitsDatas, context, hostSession, resultTraitSet)
 
     def register(self, targetEntityRefs, entityTraitsDatas, context, hostSession):
-        self.__assertIsIterableOf(targetEntityRefs, str)
+        self.__assertIsIterableOf(targetEntityRefs, EntityReference)
         self.__assertIsIterableOf(entityTraitsDatas, TraitsData)
         self.__assertCallingContext(context, hostSession)
         assert len(targetEntityRefs) == len(entityTraitsDatas)

--- a/tests/python/openassetio/hostApi/test_manager.py
+++ b/tests/python/openassetio/hostApi/test_manager.py
@@ -31,6 +31,9 @@ from openassetio.hostApi import Manager
 
 @pytest.fixture
 def manager(mock_manager_interface, a_host_session):
+    # Default to accepting anything as an entity reference string, to
+    # make constructing EntityReference objects a bit easier.
+    mock_manager_interface.mock.isEntityReferenceString.return_value = True
     return Manager(mock_manager_interface, a_host_session)
 
 
@@ -69,8 +72,13 @@ def a_ref_string():
 
 
 @pytest.fixture
-def some_refs():
-    return ["asset://a", "asset://b"]
+def a_ref(manager):
+    return manager.createEntityReference("asset://a")
+
+
+@pytest.fixture
+def some_refs(manager):
+    return [manager.createEntityReference("asset://a"), manager.createEntityReference("asset://b")]
 
 # __str__ and __repr__ aren't tested as they're debug tricks that need
 # assessing when this is ported to cpp
@@ -392,16 +400,16 @@ class Test_Manager_finalizedEntityVersion:
 class Test_Manager_getRelatedReferences:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, a_host_session, a_ref_string,
+            self, manager, mock_manager_interface, a_host_session, a_ref,
             an_empty_traitsdata, an_entity_trait_set, a_context):
 
         # pylint: disable=too-many-locals
 
         method = mock_manager_interface.mock.getRelatedReferences
 
-        one_ref = a_ref_string
-        two_refs = [a_ref_string, a_ref_string]
-        three_refs = [a_ref_string, a_ref_string, a_ref_string]
+        one_ref = a_ref
+        two_refs = [a_ref, a_ref]
+        three_refs = [a_ref, a_ref, a_ref]
         one_data = an_empty_traitsdata
         two_datas = [an_empty_traitsdata, an_empty_traitsdata]
         three_datas = [an_empty_traitsdata, an_empty_traitsdata, an_empty_traitsdata]


### PR DESCRIPTION
Update tests and docs to use `EntityReference` object workflows.

Since most of the implementation is still in weakly-typed Python, there isn't much in the way of core code changes.

Though I can't help the nagging feeling I've missed something :thinking: 