### PR TITLE
[Core] Add BatchElementError

### DIFF
--- a/python/openassetio/__init__.py
+++ b/python/openassetio/__init__.py
@@ -71,9 +71,12 @@ The documentation for OpenAssetIO can be found here:
    https://openassetio.github.io/OpenAssetIO.
 """
 # TODO(DF): @pylint
-from ._openassetio import TraitsData  # pylint: disable=import-error
-from ._openassetio import Context  # pylint: disable=import-error
-from ._openassetio import EntityReference  # pylint: disable=import-error
+from ._openassetio import (  # pylint: disable=import-error
+    TraitsData,
+    Context,
+    EntityReference,
+    BatchElementError,
+)
 
 # pylint: disable=wrong-import-position
 from .SpecificationBase import SpecificationBase

--- a/src/openassetio-core-c/include/openassetio/c/errors.h
+++ b/src/openassetio-core-c/include/openassetio/c/errors.h
@@ -2,6 +2,8 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #pragma once
 
+#include <openassetio/errors.h>
+
 #include "./namespace.h"
 
 #ifdef __cplusplus
@@ -41,7 +43,7 @@ typedef enum {
   /// Error code indicating an OK result from a C API function.
   oa_ErrorCode_kOK = 0,
   /// Error code representing a generic non-exception type thrown.
-  oa_ErrorCode_kUnknown,
+  oa_ErrorCode_kUnknown = OPENASSETIO_ErrorCode_BEGIN,
   /// Error code representing a generic C++ exception.
   oa_ErrorCode_kException,
   /// Error code representing a C++ std::bad_variant_access exception.

--- a/src/openassetio-core/include/openassetio/BatchElementError.hpp
+++ b/src/openassetio-core/include/openassetio/BatchElementError.hpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include <openassetio/errors.h>
+#include <openassetio/export.h>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+/**
+ * Structure representing per-element batch operation errors.
+ *
+ * Many OpenAssetIO API functions take multiple inputs, i.e. a batch of
+ * elements, in order to allow the @ref manager backend to optimise bulk
+ * queries. The results of such queries are usually returned
+ * element-by-element via a callback.
+ *
+ * It is possible for the whole batch to fail due to some catastrophic
+ * error, in which case a standard exception workflow is expected. Using
+ * HTTP status codes as an analogy, a client error (4xx) would likely
+ * correspond to a `BatchElementError`, whereas a server error (5xx)
+ * would likely cause the whole batch to fail with an exception.
+ *
+ * However, it is also possible for a subset of elements in the batch to
+ * fail, whilst the remainder succeed. An exception workflow doesn't
+ * work so well here, and so every success callback is paired with an
+ * error callback, allowing per-element errors to be communicated back
+ * to the original caller (i.e. the @ref host application).
+ *
+ * The information for these per-element errors is bundled in instances
+ * of this simple BatchElementError structure for passing to error
+ * callbacks.
+ *
+ * This structure provides an error code, for control flow, and an
+ * error message, for more (human-readable) detail.
+ */
+class BatchElementError final {
+ public:
+  /// Possible classes of error.
+  enum class ErrorCode {
+    /// Fallback for uncommon errors.
+    kUnknown = OPENASSETIO_BatchErrorCode_kUnknown
+  };
+
+  /// Error code indicating the class of error.
+  const ErrorCode code;
+  /// Human-readable error message.
+  const std::string message;
+};
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/errors.h
+++ b/src/openassetio-core/include/openassetio/errors.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#pragma once
+/**
+ * @file
+ *
+ * Defines core error code constants shared between C and C++.
+ *
+ * To remove any ambiguity in error codes, we want to ensure codes of
+ * different error types (i.e. exceptions vs. batch element errors) do
+ * not overlap.
+ */
+
+/**
+ * First error code used for representing a C++ exception.
+ *
+ * This macro defines the starting error code that should be used for
+ * exception-like errors.
+ */
+#define OPENASSETIO_ErrorCode_BEGIN 1
+
+/**
+ * First error code used for representing a batch element error.
+ *
+ * Assumes a maximum of 128 exception-like error codes before these.
+ */
+#define OPENASSETIO_BatchErrorCode_BEGIN (OPENASSETIO_ErrorCode_BEGIN + 127)
+
+/// Unknown error when processing a batch element.
+#define OPENASSETIO_BatchErrorCode_kUnknown (OPENASSETIO_BatchErrorCode_BEGIN + 0)

--- a/src/openassetio-python/module/BatchElementErrorBinding.cpp
+++ b/src/openassetio-python/module/BatchElementErrorBinding.cpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <pybind11/pybind11.h>
+
+#include <openassetio/BatchElementError.hpp>
+
+#include "_openassetio.hpp"
+
+void registerBatchElementError(const py::module &mod) {
+  using openassetio::BatchElementError;
+
+  py::class_<BatchElementError> batchElementError{mod, "BatchElementError", py::is_final()};
+
+  py::enum_<BatchElementError::ErrorCode>{batchElementError, "ErrorCode"}.value(
+      "kUnknown", BatchElementError::ErrorCode::kUnknown);
+
+  batchElementError
+      .def(py::init<BatchElementError::ErrorCode, openassetio::Str>(), py::arg("code"),
+           py::arg("message"))
+      .def_readonly("code", &BatchElementError::code)
+      .def_readonly("message", &BatchElementError::message);
+}

--- a/src/openassetio-python/module/CMakeLists.txt
+++ b/src/openassetio-python/module/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(
     openassetio-python-module
     PRIVATE
     _openassetio.cpp
+    BatchElementErrorBinding.cpp
     ContextBinding.cpp
     EntityReferenceBinding.cpp
     TraitsDataBinding.cpp

--- a/src/openassetio-python/module/_openassetio.cpp
+++ b/src/openassetio-python/module/_openassetio.cpp
@@ -22,6 +22,7 @@ PYBIND11_MODULE(_openassetio, mod) {
   registerTraitsData(mod);
   registerManagerStateBase(managerApi);
   registerContext(mod);
+  registerBatchElementError(mod);
   registerEntityReference(mod);
   registerHostInterface(hostApi);
   registerHost(managerApi);

--- a/src/openassetio-python/module/_openassetio.hpp
+++ b/src/openassetio-python/module/_openassetio.hpp
@@ -82,3 +82,6 @@ void registerManagerStateBase(const py::module& mod);
 
 /// Register the EntityReference type with Python.
 void registerEntityReference(const py::module& mod);
+
+/// Register the BatchElementError type with Python.
+void registerBatchElementError(const py::module& mod);

--- a/tests/openassetio-core/BatchElementErrorTest.cpp
+++ b/tests/openassetio-core/BatchElementErrorTest.cpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#include <string>
+#include <type_traits>
+
+#include <catch2/catch.hpp>
+
+#include <openassetio/BatchElementError.hpp>
+
+using openassetio::BatchElementError;
+
+SCENARIO("BatchElementError usage") {
+  GIVEN("an error code and message") {
+    const auto code = BatchElementError::ErrorCode::kUnknown;
+    const std::string message = "some message";
+
+    WHEN("a BatchElementError is constructed wrapping the code and message") {
+      BatchElementError error{code, message};
+
+      THEN("code and message cannot be modified") {
+        STATIC_REQUIRE(std::is_const_v<decltype(error.code)>);
+        STATIC_REQUIRE(std::is_const_v<decltype(error.message)>);
+      }
+
+      THEN("code and message are available for querying") {
+        CHECK(error.code == BatchElementError::ErrorCode::kUnknown);
+        CHECK(error.message == "some message");
+      }
+    }
+  }
+}

--- a/tests/openassetio-core/CMakeLists.txt
+++ b/tests/openassetio-core/CMakeLists.txt
@@ -17,6 +17,7 @@ install(
 target_sources(openassetio-core-cpp-test-exe
     PRIVATE
     main.cpp
+    BatchElementErrorTest.cpp
     ContextTest.cpp
     TraitsDataTest.cpp
     hostApi/ManagerTest.cpp

--- a/tests/python/openassetio/test_batchelementerror.py
+++ b/tests/python/openassetio/test_batchelementerror.py
@@ -1,0 +1,68 @@
+#
+#   Copyright 2022 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Tests for the BatchElementError type.
+"""
+
+# pylint: disable=no-self-use, too-few-public-methods
+# pylint: disable=invalid-name,redefined-outer-name
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+import pytest
+
+from openassetio import BatchElementError
+
+
+class Test_BatchElementError_ErrorCode:
+    def test_code_values(self):
+        assert int(BatchElementError.ErrorCode.kUnknown) == 128
+
+
+class Test_BatchElementError_inheritance:
+    def test_class_is_final(self):
+        with pytest.raises(TypeError):
+
+            class _(BatchElementError):
+                pass
+
+
+class Test_BatchElementError_init:
+    def test_when_invalid_code_then_raises_TypeError(self):
+        expected_error = r"incompatible constructor arguments.*\n.*BatchElementError.ErrorCode"
+
+        with pytest.raises(TypeError, match=expected_error):
+            BatchElementError(-123, "whatever")
+
+    def test_when_valid_code_then_contains_given_error_code_and_message(self):
+        expected_code = BatchElementError.ErrorCode.kUnknown
+        expected_message = "An error: 🐈"
+
+        a_batch_element_error = BatchElementError(expected_code, expected_message)
+
+        assert a_batch_element_error.code == expected_code
+        assert a_batch_element_error.message == expected_message
+
+    def test_when_code_modified_then_raises_AttributeError(self):
+        a_batch_element_error = BatchElementError(BatchElementError.ErrorCode.kUnknown, "whatever")
+
+        with pytest.raises(AttributeError, match="can't set attribute"):
+            a_batch_element_error.code = BatchElementError.ErrorCode.kUnknown
+
+    def test_when_message_modified_then_raises_AttributeError(self):
+        a_batch_element_error = BatchElementError(BatchElementError.ErrorCode.kUnknown, "whatever")
+
+        with pytest.raises(AttributeError, match="can't set attribute"):
+            a_batch_element_error.message = "whatever"


### PR DESCRIPTION
Closes #557.

Add a simple `BatchElementError` aggregate class, initially containing just an error code and string message. The error code is a strongly typed enumeration, currently only supporting a fallback code of `kUnknown`.

To prevent ambiguity of these error codes with the C API's exception error codes, and to allow reuse of the error codes between C++ and C, add a new C-compatible header the core library, with `#define`s computing the new error codes as offset from the C API's exception error codes.