### PR TITLE
[Core] Remove `Manager.prefetch`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,10 @@ v1.0.0-alpha.X
 
 ### Breaking changes
 
+- Removed the `Manager`/`ManagerInterface` `prefetch` method, which
+  is redundant now the API is batch-first.
+  [#511](https://github.com/OpenAssetIO/OpenAssetIO/issues/511)
+
 - Added `EntityReference` type to encapsulate a validated string
   so it can be used with entity-related API methods. These should always
   be created with either `Manager.createEntityReference` or

--- a/python/openassetio/hostApi/Manager.py
+++ b/python/openassetio/hostApi/Manager.py
@@ -138,40 +138,6 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def prefetch(self, references, context):
-        """
-        Because query latency may be high with certain managers, it is
-        often desirable to 'batch' requests. However, in many cases, it
-        is not always practical or desirable to adjust the flow of your
-        application in order to facilitate this. The preflight call is
-        designed for these situations. It should be called wherever
-        possible before you make a series of calls to query information
-        about multiple entities in close proximity. It gives the manager
-        a chance to retrieve information in advance.
-
-        The prefetch calls instructs the manager to retrieve any
-        information needed to resolve the supplied list of entities.
-
-        The lifetime of the data is managed by the manager, as it may
-        have mechanisms to auto-dirty any caches. It is *highly*
-        recommended to supply a suitably managed @ref Context to this
-        call, as it can be used as a cache key, so that the cache
-        lifetime is inherently well-managed by your persistence (or not)
-        of the context.
-
-        @param references `List[` @ref entity_reference `]` A list of
-        references to prefetch data for.
-
-        @param context Context
-
-        @return `None`
-        """
-        if not isinstance(references, (list, tuple)):
-            references = [references, ]
-        return self.__impl.prefetch(references, context, self.__hostSession)
-
-    @debugApiCall
-    @auditApiCall("Manager methods")
     def flushCaches(self):
         """
         Clears any internal caches.  Only applicable if the manager

--- a/python/openassetio/managerApi/ManagerInterface.py
+++ b/python/openassetio/managerApi/ManagerInterface.py
@@ -193,40 +193,6 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
     #
     ## @{
 
-    def prefetch(self, entityRefs, context, hostSession):
-        """
-        Called by a host to express interest in the supplied @ref
-        entity_reference list. This usually means that the host is about
-        to make multiple queries to the same references.  This can be
-        left unimplemented, but it is advisable to batch request the
-        data for resolve here if possible.
-
-        The implementation should ignore any entities to which no action
-        is applicable (maybe as they don't exist yet).
-
-        @warning Because the majority of the resolution API itself is
-        designated thread safe, it is important to implement any
-        pre-fetch mechanism with suitable locks/etc... if required.
-
-        @param entityRefs `List[` @fqref{EntityReference}
-        "EntityReference" `]` The entities whose data should be
-        prefetched.
-
-        @param context openassetio.Context You may wish to make use of
-        the managerState object (if you supplied one on
-        construction of the context), to simplify scoping any caching of
-        data. Otherwise, it's up to you how to manage the lifetime of
-        the data to avoid inconsistencies, but the @ref flushCaches
-        method should clear any otherwise sorted data for this call.
-
-        @param hostSession HostSession The host
-        session that maps to the caller, this should be used for all
-        logging and provides access to the openassetio.managerApi.Host
-        object representing the process that initiated the API session.
-
-        @return `None`
-        """
-
     def flushCaches(self, hostSession):
         """
         Clears any internal caches.  Only applicable if the

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -140,9 +140,6 @@ class ValidatingMockManagerInterface(ManagerInterface):
     def settings(self, hostSession):
         return self.mock.settings(hostSession)
 
-    def prefetch(self, entityRefs, context, hostSession):
-        return self.mock.prefetch(entityRefs, context, hostSession)
-
     def flushCaches(self, hostSession):
         return self.mock.flushCaches(hostSession)
 

--- a/tests/python/openassetio/hostApi/test_manager.py
+++ b/tests/python/openassetio/hostApi/test_manager.py
@@ -219,16 +219,6 @@ class Test_Manager_initialize:
         mock_manager_interface.mock.initialize.assert_called_once_with(a_dict, a_host_session)
 
 
-class Test_Manager_prefetch:
-
-    def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, a_host_session, some_refs, a_context):
-
-        method = mock_manager_interface.mock.prefetch
-        assert manager.prefetch(some_refs, a_context) == method.return_value
-        method.assert_called_once_with(some_refs, a_context, a_host_session)
-
-
 class Test_Manager_flushCaches:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(


### PR DESCRIPTION
Removes the `prefetch` method as the new batch-first architecture makes this redundant.

Closes #511