### PR TITLE
[Docs] Ensure consistent use of reverse-dns identifiers

### DIFF
--- a/python/openassetio/hostApi/Manager.py
+++ b/python/openassetio/hostApi/Manager.py
@@ -47,7 +47,7 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
     @code
     factory = openassetio.hostApi.ManagerFactory(
         hostImpl, consoleLogger, pluginFactory)
-    manager = factory.createManager("org.openassetio.test")
+    manager = factory.createManager("org.openassetio.test.manager")
     @endcode
 
     A Manager instance is the single point of interaction with an asset

--- a/python/openassetio/pluginSystem/PythonPluginSystemManagerPlugin.py
+++ b/python/openassetio/pluginSystem/PythonPluginSystemManagerPlugin.py
@@ -59,7 +59,7 @@ class PythonPluginSystemManagerPlugin(PythonPluginSystemPlugin):
         The identifier should use only alpha-numeric characters and '.',
         '_' or '-'. For example:
 
-            "uk.co.foundry.asset.testManager"
+            "org.openassetio.test.manager"
 
         @return str
 

--- a/src/openassetio-core/include/openassetio/hostApi/HostInterface.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/HostInterface.hpp
@@ -61,7 +61,7 @@ class OPENASSETIO_CORE_EXPORT HostInterface {
    * '_' or '-'. We suggest using the "reverse DNS" style, for
    * example:
    *
-   *    "org.openassetio.host.test"
+   *    "org.openassetio.test.host"
    *
    * @return host identifier.
    */

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -41,7 +41,7 @@ OPENASSETIO_DECLARE_PTR(Manager)
  * @code
  * factory = openassetio.hostApi.ManagerFactory(
  *     hostImpl, consoleLogger, pluginFactory)
- * manager = factory.createManager("org.openassetio.test")
+ * manager = factory.createManager("org.openassetio.test.manager")
  * @endcode
  *
  * A Manager instance is the single point of interaction with an asset
@@ -80,7 +80,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * identifier will use only alpha-numeric characters and '.', '_' or
    * '-'. They generally follow the 'reverse-DNS' style, for example:
    *
-   *     "org.openassetio.manager.test"
+   *     "org.openassetio.test.manager"
    */
   [[nodiscard]] Identifier identifier() const;
 

--- a/src/openassetio-core/include/openassetio/managerApi/Host.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/Host.hpp
@@ -55,7 +55,7 @@ class OPENASSETIO_CORE_EXPORT Host final {
    * only alpha-numeric characters and '.', '_' or '-', commonly in
    * the form of a 'reverse-DNS' style string, for example:
    *
-   *     "org.openassetio.host.test"
+   *     "org.openassetio.test.host"
    */
   [[nodiscard]] Identifier identifier() const;
 

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -181,7 +181,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * characters and '.', '_' or '-'.  Generally speaking, we recommend
    * using the 'reverse-DNS' convention, for example:
    *
-   *     "org.openassetio.manager.test"
+   *     "org.openassetio.test.manager"
    *
    * @return Unique identifier of the manager.
    */


### PR DESCRIPTION
Conforms the use of reverse-dns style identifiers in examples.

Closes #59.