### PR TITLE
[Core] Remove `Str`

### DIFF
--- a/resources/perftest/lib.cpp
+++ b/resources/perftest/lib.cpp
@@ -2,7 +2,7 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #include "lib.hpp"
 
-void openassetio::LocateableContentTrait::setUrl(openassetio::Str url) {
+void openassetio::LocateableContentTrait::setUrl(std::string url) {
   data()->setTraitProperty(kId, kUrl, std::move(url));
 }
 

--- a/resources/perftest/lib.hpp
+++ b/resources/perftest/lib.hpp
@@ -52,7 +52,7 @@ struct LocateableContentTrait : trait::TraitBase<LocateableContentTrait> {
 
   using TraitBase<LocateableContentTrait>::TraitBase;
 
-  void setUrl(Str url);
+  void setUrl(std::string url);
 };
 }  // namespace openassetio
 

--- a/resources/perftest/perftest.cpp
+++ b/resources/perftest/perftest.cpp
@@ -65,7 +65,7 @@ struct Fixture {
   /// A dummy HostInterface implementation to satisfy abstract base.
   struct HostImpl : openassetio::hostApi::HostInterface {
     [[nodiscard]] openassetio::Str identifier() const override { return {}; }
-    [[nodiscard]] openassetio::Str displayName() const override { return {}; }
+    [[nodiscard]] std::string displayName() const override { return {}; }
   };
   /// A dummy LoggerInterface implementation
   struct LoggerImpl : openassetio::log::LoggerInterface {

--- a/resources/perftest/perftest.cpp
+++ b/resources/perftest/perftest.cpp
@@ -64,7 +64,7 @@ struct Fixture {
  private:
   /// A dummy HostInterface implementation to satisfy abstract base.
   struct HostImpl : openassetio::hostApi::HostInterface {
-    [[nodiscard]] openassetio::Str identifier() const override { return {}; }
+    [[nodiscard]] openassetio::Identifier identifier() const override { return {}; }
     [[nodiscard]] std::string displayName() const override { return {}; }
   };
   /// A dummy LoggerInterface implementation

--- a/resources/perftest/perftest.cpp
+++ b/resources/perftest/perftest.cpp
@@ -70,7 +70,7 @@ struct Fixture {
   /// A dummy LoggerInterface implementation
   struct LoggerImpl : openassetio::log::LoggerInterface {
     void log([[maybe_unused]] openassetio::log::LoggerInterface::Severity severity,
-             [[maybe_unused]] const openassetio::Str& message) override {}
+             [[maybe_unused]] const std::string& message) override {}
   };
 
   /// Enlarge the path so we likely exceed the small string optimization length

--- a/src/openassetio-core-c/private/InfoDictionary.cpp
+++ b/src/openassetio-core-c/private/InfoDictionary.cpp
@@ -89,8 +89,7 @@ oa_ErrorCode get(oa_StringView *err, Type *out, oa_InfoDictionary_h handle,
 template <class Type>
 void set(oa_InfoDictionary_h handle, const oa_ConstStringView key, Type value) {
   InfoDictionary *infoDictionary = handles::InfoDictionary::toInstance(handle);
-  infoDictionary->insert_or_assign(openassetio::Str{key.data, key.size},
-                                   std::forward<Type>(value));
+  infoDictionary->insert_or_assign(std::string{key.data, key.size}, std::forward<Type>(value));
 }
 
 /**
@@ -144,7 +143,7 @@ oa_ErrorCode oa_InfoDictionary_typeOf(oa_StringView *err, oa_InfoDictionary_Valu
             *out = oa_InfoDictionary_ValueType_kInt;
           } else if constexpr (std::is_same_v<ValueType, openassetio::Float>) {
             *out = oa_InfoDictionary_ValueType_kFloat;
-          } else if constexpr (std::is_same_v<ValueType, openassetio::Str>) {
+          } else if constexpr (std::is_same_v<ValueType, std::string>) {
             *out = oa_InfoDictionary_ValueType_kStr;
           } else {
             static_assert(kAlwaysFalse<ValueType>, "Unhandled variant type");
@@ -173,7 +172,7 @@ oa_ErrorCode oa_InfoDictionary_getFloat(oa_StringView *err, openassetio::Float *
 
 oa_ErrorCode oa_InfoDictionary_getStr(oa_StringView *err, oa_StringView *out,
                                       oa_InfoDictionary_h handle, const oa_ConstStringView key) {
-  openassetio::Str str;
+  std::string str;
   const oa_ErrorCode errorCode = get(err, &str, handle, key);
 
   if (errorCode != oa_ErrorCode_kOK) {
@@ -211,7 +210,7 @@ oa_ErrorCode oa_InfoDictionary_setStr(oa_StringView *err, oa_InfoDictionary_h ha
                                       const oa_ConstStringView key,
                                       const oa_ConstStringView value) {
   return errors::catchUnknownExceptionAsCode(err, [&] {
-    set(handle, key, openassetio::Str{value.data, value.size});
+    set(handle, key, std::string{value.data, value.size});
     return oa_ErrorCode_kOK;
   });
 }

--- a/src/openassetio-core-c/private/errors.hpp
+++ b/src/openassetio-core-c/private/errors.hpp
@@ -2,6 +2,8 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #pragma once
 
+#include <string>
+
 #include <openassetio/c/StringView.h>
 #include <openassetio/c/errors.h>
 #include <openassetio/c/namespace.h>
@@ -23,7 +25,7 @@ namespace errors {
  */
 inline void throwIfError(const oa_ErrorCode code, [[maybe_unused]] const oa_StringView &msg) {
   if (code != oa_ErrorCode_kOK) {
-    Str errorMessageWithCode = std::to_string(code);
+    std::string errorMessageWithCode = std::to_string(code);
     errorMessageWithCode += ": ";
     errorMessageWithCode += std::string_view{msg.data, msg.size};
     throw std::runtime_error(errorMessageWithCode);

--- a/src/openassetio-core-c/private/managerApi/CManagerInterfaceAdapter.cpp
+++ b/src/openassetio-core-c/private/managerApi/CManagerInterfaceAdapter.cpp
@@ -41,7 +41,7 @@ Identifier CManagerInterfaceAdapter::identifier() const {
   return {out.data, out.size};
 }
 
-Str CManagerInterfaceAdapter::displayName() const {
+std::string CManagerInterfaceAdapter::displayName() const {
   // Buffer for error message.
   char errorMessageBuffer[kStringBufferSize];
   // Error message.

--- a/src/openassetio-core-c/private/managerApi/CManagerInterfaceAdapter.hpp
+++ b/src/openassetio-core-c/private/managerApi/CManagerInterfaceAdapter.hpp
@@ -40,7 +40,7 @@ class OPENASSETIO_CORE_C_EXPORT CManagerInterfaceAdapter : ManagerInterface {
   [[nodiscard]] Identifier identifier() const override;
 
   /// Wrap the C suite's `displayName` function.
-  [[nodiscard]] Str displayName() const override;
+  [[nodiscard]] std::string displayName() const override;
 
   /// Wrap the C suite's `info` function.
   [[nodiscard]] InfoDictionary info() const override;

--- a/src/openassetio-core/hostApi/Manager.cpp
+++ b/src/openassetio-core/hostApi/Manager.cpp
@@ -74,9 +74,9 @@ bool Manager::isEntityReferenceString(const std::string &someString) const {
   return managerInterface_->isEntityReferenceString(someString, hostSession_);
 }
 
-const Str kCreateEntityReferenceErrorMessage = "Invalid entity reference: ";
+const char *kCreateEntityReferenceErrorMessage = "Invalid entity reference: ";
 
-EntityReference Manager::createEntityReference(Str entityReferenceString) const {
+EntityReference Manager::createEntityReference(std::string entityReferenceString) const {
   if (!isEntityReferenceString(entityReferenceString)) {
     throw std::domain_error{kCreateEntityReferenceErrorMessage + entityReferenceString};
   }
@@ -84,7 +84,7 @@ EntityReference Manager::createEntityReference(Str entityReferenceString) const 
 }
 
 std::optional<EntityReference> Manager::createEntityReferenceIfValid(
-    Str entityReferenceString) const {
+    std::string entityReferenceString) const {
   if (!isEntityReferenceString(entityReferenceString)) {
     return {};
   }

--- a/src/openassetio-core/hostApi/Manager.cpp
+++ b/src/openassetio-core/hostApi/Manager.cpp
@@ -24,7 +24,7 @@ Manager::Manager(managerApi::ManagerInterfacePtr managerInterface,
 
 Identifier Manager::identifier() const { return managerInterface_->identifier(); }
 
-Str Manager::displayName() const { return managerInterface_->displayName(); }
+std::string Manager::displayName() const { return managerInterface_->displayName(); }
 
 InfoDictionary Manager::info() const { return managerInterface_->info(); }
 

--- a/src/openassetio-core/include/openassetio/EntityReference.hpp
+++ b/src/openassetio-core/include/openassetio/EntityReference.hpp
@@ -2,6 +2,7 @@
 // Copyright 2022 The Foundry Visionmongers Ltd
 #pragma once
 
+#include <string>
 #include <utility>
 
 #include <openassetio/export.h>
@@ -28,16 +29,16 @@ class EntityReference final {
   /**
    * Constructs an EntityReference around the supplied string.
    */
-  explicit EntityReference(Str entityReferenceString)
+  explicit EntityReference(std::string entityReferenceString)
       : entityReferenceString_(std::move(entityReferenceString)) {}
 
   /**
    * @return The string representation of this entity reference.
    */
-  [[nodiscard]] const Str& toString() const { return entityReferenceString_; }
+  [[nodiscard]] const std::string& toString() const { return entityReferenceString_; }
 
  private:
-  Str entityReferenceString_;
+  std::string entityReferenceString_;
 };
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/InfoDictionary.hpp
+++ b/src/openassetio-core/include/openassetio/InfoDictionary.hpp
@@ -2,6 +2,7 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #pragma once
 
+#include <string>
 #include <unordered_map>
 #include <variant>
 
@@ -11,11 +12,11 @@
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 /// Types available as values in a InfoDictionary.
-using InfoDictionaryValue = std::variant<Bool, Int, Float, Str>;
+using InfoDictionaryValue = std::variant<Bool, Int, Float, std::string>;
 /**
  * Dictionary type used for @fqref{managerApi.ManagerInterface.info}
  * "ManagerInterface.info".
  */
-using InfoDictionary = std::unordered_map<Str, InfoDictionaryValue>;
+using InfoDictionary = std::unordered_map<std::string, InfoDictionaryValue>;
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/hostApi/HostInterface.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/HostInterface.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include <openassetio/export.h>
 #include <openassetio/InfoDictionary.hpp>
@@ -75,7 +76,7 @@ class OPENASSETIO_CORE_EXPORT HostInterface {
    *
    * @return Host's display name.
    */
-  [[nodiscard]] virtual Str displayName() const = 0;
+  [[nodiscard]] virtual std::string displayName() const = 0;
 
   /**
    * Returns other information that may be useful about this Host.

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -91,7 +91,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    *
    *     "OpenAssetIO Test Manager"
    */
-  [[nodiscard]] Str displayName() const;
+  [[nodiscard]] std::string displayName() const;
 
   /**
    * Returns other information that may be useful about this @ref

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -396,7 +396,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    *
    * @todo Use a custom exception type rather than std::domain_error.
    */
-  [[nodiscard]] EntityReference createEntityReference(Str entityReferenceString) const;
+  [[nodiscard]] EntityReference createEntityReference(std::string entityReferenceString) const;
 
   /**
    * Create an @ref EntityReference object wrapping a given
@@ -413,7 +413,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * valid, not containing a value otherwise.
    */
   [[nodiscard]] std::optional<EntityReference> createEntityReferenceIfValid(
-      Str entityReferenceString) const;
+      std::string entityReferenceString) const;
 
   /**
    * @}

--- a/src/openassetio-core/include/openassetio/hostApi/ManagerFactory.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/ManagerFactory.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -53,7 +54,7 @@ class OPENASSETIO_CORE_EXPORT ManagerFactory final {
      *
      * @see @fqref{hostApi.Manager.displayName} "Manager.displayName"
      */
-    Str displayName;
+    std::string displayName;
     /**
      * Arbitrary key-value information supplied by the manager.
      *

--- a/src/openassetio-core/include/openassetio/log/ConsoleLogger.hpp
+++ b/src/openassetio-core/include/openassetio/log/ConsoleLogger.hpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 The Foundry Visionmongers Ltd
+#include <string>
 
 #include <openassetio/export.h>
 #include <openassetio/log/LoggerInterface.hpp>
@@ -24,7 +25,7 @@ class OPENASSETIO_CORE_EXPORT ConsoleLogger final : public LoggerInterface {
 
   /**
    */
-  void log(Severity severity, const Str& message) override;
+  void log(Severity severity, const std::string& message) override;
 
  private:
   explicit ConsoleLogger(bool shouldColorOutput);

--- a/src/openassetio-core/include/openassetio/log/LoggerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/log/LoggerInterface.hpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <string>
 
 #include <openassetio/export.h>
 #include <openassetio/enum.hpp>
@@ -48,7 +49,7 @@ class OPENASSETIO_CORE_EXPORT LoggerInterface {
    * @param severity One of the severity constants defined in @ref
    * Severity.
    */
-  virtual void log(Severity severity, const Str& message) = 0;
+  virtual void log(Severity severity, const std::string& message) = 0;
 };
 }  // namespace log
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-core/include/openassetio/log/SeverityFilter.hpp
+++ b/src/openassetio-core/include/openassetio/log/SeverityFilter.hpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 The Foundry Visionmongers Ltd
+#include <string>
 
 #include <openassetio/export.h>
 #include <openassetio/log/LoggerInterface.hpp>
@@ -63,7 +64,7 @@ class OPENASSETIO_CORE_EXPORT SeverityFilter final : public LoggerInterface {
    * @}
    */
 
-  void log(Severity severity, const Str& message) override;
+  void log(Severity severity, const std::string& message) override;
 
  private:
   explicit SeverityFilter(LoggerInterfacePtr upstreamLogger);

--- a/src/openassetio-core/include/openassetio/managerApi/Host.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/Host.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include <openassetio/export.h>
 #include <openassetio/InfoDictionary.hpp>
@@ -66,7 +67,7 @@ class OPENASSETIO_CORE_EXPORT Host final {
    *
    *     "OpenAssetIO Test Host"
    */
-  [[nodiscard]] Str displayName() const;
+  [[nodiscard]] std::string displayName() const;
 
   /**
    * Returns other information that may be useful about the host.

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -198,7 +198,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * @return Manager's display name.
    */
-  [[nodiscard]] virtual Str displayName() const = 0;
+  [[nodiscard]] virtual std::string displayName() const = 0;
 
   /**
    * Returns other information that may be useful about this @ref

--- a/src/openassetio-core/include/openassetio/trait/property.hpp
+++ b/src/openassetio-core/include/openassetio/trait/property.hpp
@@ -35,9 +35,9 @@ namespace property {
  * functions, so it is highly desirable that keys are ASCII to maximise
  * portability when mapping property keys to member function names.
  */
-using Key = openassetio::Str;
+using Key = std::string;
 /// Property dictionary values.
-using Value = std::variant<Bool, Int, Float, Str>;
+using Value = std::variant<Bool, Int, Float, std::string>;
 }  // namespace property
 
 /**

--- a/src/openassetio-core/include/openassetio/typedefs.hpp
+++ b/src/openassetio-core/include/openassetio/typedefs.hpp
@@ -59,7 +59,7 @@ using Str = std::string;
  */
 
 /// A @ref host or @ref manager identifier.
-using Identifier = Str;
+using Identifier = std::string;
 
 /// A list of identifiers.
 using Identifiers = std::vector<Identifier>;

--- a/src/openassetio-core/include/openassetio/typedefs.hpp
+++ b/src/openassetio-core/include/openassetio/typedefs.hpp
@@ -40,9 +40,6 @@ using Bool = bool;
 using Int = int64_t;
 /// Real value type.
 using Float = double;
-/// String value type.
-using Str = std::string;
-
 /**
  * @}
  */

--- a/src/openassetio-core/log/ConsoleLogger.cpp
+++ b/src/openassetio-core/log/ConsoleLogger.cpp
@@ -17,7 +17,7 @@ ConsoleLoggerPtr ConsoleLogger::make(bool shouldColorOutput) {
 
 ConsoleLogger::ConsoleLogger(bool shouldColorOutput) : shouldColorOutput_(shouldColorOutput) {}
 
-void ConsoleLogger::log(Severity severity, const Str& message) {
+void ConsoleLogger::log(Severity severity, const std::string& message) {
   if (shouldColorOutput_) {
     std::cerr << "\033[0;" << kSeverityColors[severity] << "m";
   }

--- a/src/openassetio-core/log/SeverityFilter.cpp
+++ b/src/openassetio-core/log/SeverityFilter.cpp
@@ -32,7 +32,7 @@ SeverityFilter::SeverityFilter(LoggerInterfacePtr upstreamLogger)
   }
 }
 
-void SeverityFilter::log(Severity severity, const Str& message) {
+void SeverityFilter::log(Severity severity, const std::string& message) {
   if (severity < minSeverity_) {
     return;
   }

--- a/src/openassetio-core/managerApi/Host.cpp
+++ b/src/openassetio-core/managerApi/Host.cpp
@@ -15,7 +15,7 @@ HostPtr Host::make(hostApi::HostInterfacePtr hostInterface) {
 Host::Host(hostApi::HostInterfacePtr hostInterface) : hostInterface_{std::move(hostInterface)} {}
 
 Identifier Host::identifier() const { return hostInterface_->identifier(); }
-Str Host::displayName() const { return hostInterface_->displayName(); }
+std::string Host::displayName() const { return hostInterface_->displayName(); }
 InfoDictionary Host::info() const { return hostInterface_->info(); }
 
 }  // namespace managerApi

--- a/src/openassetio-python/module/BatchElementErrorBinding.cpp
+++ b/src/openassetio-python/module/BatchElementErrorBinding.cpp
@@ -15,7 +15,7 @@ void registerBatchElementError(const py::module &mod) {
       "kUnknown", BatchElementError::ErrorCode::kUnknown);
 
   batchElementError
-      .def(py::init<BatchElementError::ErrorCode, openassetio::Str>(), py::arg("code"),
+      .def(py::init<BatchElementError::ErrorCode, std::string>(), py::arg("code"),
            py::arg("message"))
       .def_readonly("code", &BatchElementError::code)
       .def_readonly("message", &BatchElementError::message);

--- a/src/openassetio-python/module/EntityReferenceBinding.cpp
+++ b/src/openassetio-python/module/EntityReferenceBinding.cpp
@@ -10,6 +10,6 @@ void registerEntityReference(const py::module &mod) {
   using openassetio::EntityReference;
 
   py::class_<EntityReference>{mod, "EntityReference", py::is_final()}
-      .def(py::init<openassetio::Str>(), py::arg("entityReferenceString"))
+      .def(py::init<std::string>(), py::arg("entityReferenceString"))
       .def("toString", &EntityReference::toString);
 }

--- a/src/openassetio-python/module/hostApi/HostInterfaceBinding.cpp
+++ b/src/openassetio-python/module/hostApi/HostInterfaceBinding.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <string>
+
 #include <pybind11/stl.h>
 
 #include <openassetio/InfoDictionary.hpp>
@@ -23,8 +25,8 @@ struct PyHostInterface : HostInterface {
     PYBIND11_OVERRIDE_PURE(Identifier, HostInterface, identifier, /* no args */);
   }
 
-  [[nodiscard]] Str displayName() const override {
-    PYBIND11_OVERRIDE_PURE(Str, HostInterface, displayName, /* no args */);
+  [[nodiscard]] std::string displayName() const override {
+    PYBIND11_OVERRIDE_PURE(std::string, HostInterface, displayName, /* no args */);
   }
 
   [[nodiscard]] InfoDictionary info() const override {

--- a/src/openassetio-python/module/hostApi/ManagerFactoryBinding.cpp
+++ b/src/openassetio-python/module/hostApi/ManagerFactoryBinding.cpp
@@ -24,7 +24,7 @@ void registerManagerFactory(const py::module& mod) {
       .def("identifiers", &ManagerFactory::identifiers);
 
   py::class_<ManagerFactory::ManagerDetail>(managerFactory, "ManagerDetail")
-      .def(py::init<openassetio::Str, openassetio::Str, openassetio::InfoDictionary>(),
+      .def(py::init<openassetio::Identifier, std::string, openassetio::InfoDictionary>(),
            py::arg("identifier"), py::arg("displayName"), py::arg("info"))
       .def_readwrite("identifier", &ManagerFactory::ManagerDetail::identifier)
       .def_readwrite("displayName", &ManagerFactory::ManagerDetail::displayName)

--- a/src/openassetio-python/module/log/LoggerInterfaceBinding.cpp
+++ b/src/openassetio-python/module/log/LoggerInterfaceBinding.cpp
@@ -16,7 +16,7 @@ namespace log {
 struct PyLoggerInterface : LoggerInterface {
   using LoggerInterface::LoggerInterface;
 
-  void log(Severity severity, const Str& message) override {
+  void log(Severity severity, const std::string& message) override {
     PYBIND11_OVERRIDE_PURE(void, LoggerInterface, log, severity, message);
   }
 };
@@ -26,7 +26,6 @@ struct PyLoggerInterface : LoggerInterface {
 
 void registerLoggerInterface(const py::module& mod) {
   using openassetio::Float;
-  using openassetio::Str;
   using openassetio::log::LoggerInterface;
   using openassetio::log::LoggerInterfacePtr;
   using openassetio::log::PyLoggerInterface;

--- a/src/openassetio-python/module/managerApi/ManagerInterfaceBinding.cpp
+++ b/src/openassetio-python/module/managerApi/ManagerInterfaceBinding.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <string>
+
 #include <pybind11/stl.h>
 
 #include <openassetio/Context.hpp>
@@ -30,8 +32,8 @@ struct PyManagerInterface : ManagerInterface {
     PYBIND11_OVERRIDE_PURE(Identifier, ManagerInterface, identifier, /* no args */);
   }
 
-  [[nodiscard]] Str displayName() const override {
-    PYBIND11_OVERRIDE_PURE(Str, ManagerInterface, displayName, /* no args */);
+  [[nodiscard]] std::string displayName() const override {
+    PYBIND11_OVERRIDE_PURE(std::string, ManagerInterface, displayName, /* no args */);
   }
 
   [[nodiscard]] InfoDictionary info() const override {

--- a/tests/openassetio-core-c/private/InfoDictionaryTest.cpp
+++ b/tests/openassetio-core-c/private/InfoDictionaryTest.cpp
@@ -25,7 +25,7 @@ constexpr std::size_t kStrStorageCapacity = 500;
 
 SCENARIO("InfoDictionary construction, conversion and destruction") {
   // Storage for error messages coming from C API functions.
-  openassetio::Str errStorage(kStrStorageCapacity, '\0');
+  std::string errStorage(kStrStorageCapacity, '\0');
   oa_StringView actualErrorMsg{errStorage.size(), errStorage.data(), 0};
 
   GIVEN("a InfoDictionary handle constructed using the C API") {
@@ -150,7 +150,7 @@ TEMPLATE_TEST_CASE_METHOD(TypeOfFixture,
     const auto& expectedValueType = Fixture::kExpectedValueType;
 
     // Storage for error messages coming from C API functions.
-    openassetio::Str errStorage(kStrStorageCapacity, '\0');
+    std::string errStorage(kStrStorageCapacity, '\0');
     oa_StringView actualErrorMsg{errStorage.size(), errStorage.data(), 0};
 
     WHEN("the type of an entry is queried") {
@@ -178,7 +178,7 @@ SCENARIO("Attempting to retrieve the type of a non-existent InfoDictionary entry
       const auto& nonExistentKey = InfoDictionaryFixture::kNonExistentKeyStr;
       oa_ConstStringView key{nonExistentKey.data(), nonExistentKey.size()};
       // Storage for error message.
-      openassetio::Str errStorage(kStrStorageCapacity, '\0');
+      std::string errStorage(kStrStorageCapacity, '\0');
       oa_StringView actualErrorMsg{errStorage.size(), errStorage.data(), 0};
       // Initial value of storage for return value.
       const oa_InfoDictionary_ValueType initialValueType{};
@@ -328,7 +328,7 @@ TEMPLATE_TEST_CASE_METHOD(AccessorFixture, "InfoDictionary accessed via C API", 
     const std::string& nonExistentKeyStr = Fixture::kNonExistentKeyStr;
 
     // Storage for error messages coming from C API functions.
-    openassetio::Str errStorage(kStrStorageCapacity, '\0');
+    std::string errStorage(kStrStorageCapacity, '\0');
     oa_StringView actualErrorMsg{errStorage.size(), errStorage.data(), 0};
 
     WHEN("existing value is retrieved through C API") {
@@ -411,7 +411,7 @@ SCENARIO("InfoDictionary string return with insufficient buffer capacity") {
     const auto& infoDictionaryHandle = fixture.infoDictionaryHandle_;
 
     // Storage for error messages coming from C API functions.
-    openassetio::Str errStorage(kStrStorageCapacity, '\0');
+    std::string errStorage(kStrStorageCapacity, '\0');
     oa_StringView actualErrorMsg{errStorage.size(), errStorage.data(), 0};
 
     AND_GIVEN(
@@ -509,7 +509,7 @@ TEMPLATE_TEST_CASE_METHOD(MutatorFixture, "InfoDictionary mutated via C API", ""
     // Storage for error messages coming from C API functions.
     // TODO(DF): The only exception currently possible is `bad_alloc`,
     //  which is tricky to test.
-    openassetio::Str errStorage(kStrStorageCapacity, '\0');
+    std::string errStorage(kStrStorageCapacity, '\0');
     oa_StringView actualErrorMsg{errStorage.size(), errStorage.data(), 0};
 
     WHEN("an existing value of the same type is updated") {

--- a/tests/openassetio-core-c/private/InfoDictionaryTest.cpp
+++ b/tests/openassetio-core-c/private/InfoDictionaryTest.cpp
@@ -41,10 +41,10 @@ SCENARIO("InfoDictionary construction, conversion and destruction") {
       InfoDictionary* infoDictionary = handles::InfoDictionary::toInstance(infoDictionaryHandle);
 
       THEN("instance can be used as a C++ InfoDictionary") {
-        const openassetio::Str key = "some key";
-        const openassetio::Str expectedValue = "some value";
+        const std::string key = "some key";
+        const std::string expectedValue = "some value";
         infoDictionary->insert({key, expectedValue});
-        const openassetio::Str actualValue = std::get<openassetio::Str>(infoDictionary->at(key));
+        const std::string actualValue = std::get<std::string>(infoDictionary->at(key));
         CHECK(actualValue == expectedValue);
 
         AND_WHEN("dtor function is called") {
@@ -80,14 +80,14 @@ SCENARIO("InfoDictionary construction, conversion and destruction") {
  * its C handle.
  */
 struct InfoDictionaryFixture {
-  inline static const openassetio::Str kBoolKey = "aBool";
+  inline static const std::string kBoolKey = "aBool";
   static constexpr openassetio::Bool kBoolValue = true;
-  inline static const openassetio::Str kIntKey = "anInt";
+  inline static const std::string kIntKey = "anInt";
   static constexpr openassetio::Int kIntValue = 123;
-  inline static const openassetio::Str kFloatKey = "aFloat";
+  inline static const std::string kFloatKey = "aFloat";
   static constexpr openassetio::Float kFloatValue = 0.456;
-  inline static const openassetio::Str kStrKey = "aStr";
-  inline static const openassetio::Str kStrValue = "string value";
+  inline static const std::string kStrKey = "aStr";
+  inline static const std::string kStrValue = "string value";
 
   InfoDictionary infoDictionary_{{kBoolKey, kBoolValue},
                                  {kIntKey, kIntValue},
@@ -95,7 +95,7 @@ struct InfoDictionaryFixture {
                                  {kStrKey, kStrValue}};
 
   // Key that doesn't exist in the map.
-  static inline const openassetio::Str kNonExistentKeyStr = "nonExistent";
+  static inline const std::string kNonExistentKeyStr = "nonExistent";
 
   // Note that this models the ownership semantic of "owned by service",
   // i.e. the C client should not call `dtor` to destroy the instance.
@@ -114,36 +114,35 @@ struct TypeOfFixture;
 
 template <>
 struct TypeOfFixture<openassetio::Bool> : InfoDictionaryFixture {
-  inline static const openassetio::Str kKeyStr = kBoolKey;
+  inline static const std::string kKeyStr = kBoolKey;
   static constexpr oa_InfoDictionary_ValueType kExpectedValueType =
       oa_InfoDictionary_ValueType_kBool;
 };
 
 template <>
 struct TypeOfFixture<openassetio::Int> : InfoDictionaryFixture {
-  inline static const openassetio::Str kKeyStr = kIntKey;
+  inline static const std::string kKeyStr = kIntKey;
   static constexpr oa_InfoDictionary_ValueType kExpectedValueType =
       oa_InfoDictionary_ValueType_kInt;
 };
 
 template <>
 struct TypeOfFixture<openassetio::Float> : InfoDictionaryFixture {
-  inline static const openassetio::Str kKeyStr = kFloatKey;
+  inline static const std::string kKeyStr = kFloatKey;
   static constexpr oa_InfoDictionary_ValueType kExpectedValueType =
       oa_InfoDictionary_ValueType_kFloat;
 };
 
 template <>
-struct TypeOfFixture<openassetio::Str> : InfoDictionaryFixture {
-  inline static const openassetio::Str kKeyStr = kStrKey;
+struct TypeOfFixture<std::string> : InfoDictionaryFixture {
+  inline static const std::string kKeyStr = kStrKey;
   static constexpr oa_InfoDictionary_ValueType kExpectedValueType =
       oa_InfoDictionary_ValueType_kStr;
 };
 
 TEMPLATE_TEST_CASE_METHOD(TypeOfFixture,
                           "Retrieving the type of an entry in a InfoDictionary via C API", "",
-                          openassetio::Bool, openassetio::Int, openassetio::Float,
-                          openassetio::Str) {
+                          openassetio::Bool, openassetio::Int, openassetio::Float, std::string) {
   GIVEN("a populated C++ InfoDictionary and its C handle") {
     using Fixture = TypeOfFixture<TestType>;
     const auto& infoDictionaryHandle = Fixture::infoDictionaryHandle_;
@@ -257,8 +256,8 @@ struct AccessorFixture<openassetio::Bool> : InfoDictionaryFixture {
   static constexpr openassetio::Bool kInitialValue = !kBoolValue;
   static constexpr openassetio::Bool kExpectedValue = kBoolValue;
   static constexpr openassetio::Bool kAlternativeValue = !kBoolValue;
-  inline static const openassetio::Str kKeyStr = kBoolKey;
-  inline static const openassetio::Str kWrongValueTypeKeyStr = kIntKey;
+  inline static const std::string kKeyStr = kBoolKey;
+  inline static const std::string kWrongValueTypeKeyStr = kIntKey;
   openassetio::Bool actualValue_ = kInitialValue;
 };
 
@@ -269,8 +268,8 @@ struct AccessorFixture<openassetio::Int> : InfoDictionaryFixture {
   static constexpr openassetio::Int kInitialValue = 0;
   static constexpr openassetio::Int kExpectedValue = kIntValue;
   static constexpr openassetio::Int kAlternativeValue = kIntValue + 1;
-  inline static const openassetio::Str kKeyStr = kIntKey;
-  inline static const openassetio::Str kWrongValueTypeKeyStr = kBoolKey;
+  inline static const std::string kKeyStr = kIntKey;
+  inline static const std::string kWrongValueTypeKeyStr = kBoolKey;
   openassetio::Int actualValue_ = kInitialValue;
 };
 
@@ -281,27 +280,26 @@ struct AccessorFixture<openassetio::Float> : InfoDictionaryFixture {
   static constexpr openassetio::Float kInitialValue = 0.0;
   static constexpr openassetio::Float kExpectedValue = kFloatValue;
   static constexpr openassetio::Float kAlternativeValue = kFloatValue / 2;
-  inline static const openassetio::Str kKeyStr = kFloatKey;
-  inline static const openassetio::Str kWrongValueTypeKeyStr = kIntKey;
+  inline static const std::string kKeyStr = kFloatKey;
+  inline static const std::string kWrongValueTypeKeyStr = kIntKey;
   openassetio::Float actualValue_ = kInitialValue;
 };
 
 /// Specialisation for getStr.
 template <>
-struct AccessorFixture<openassetio::Str> : InfoDictionaryFixture {
+struct AccessorFixture<std::string> : InfoDictionaryFixture {
   INFODICTIONARY_FN(getStr);
-  openassetio::Str valueStorage_ = openassetio::Str(kStrStorageCapacity, '\0');
+  std::string valueStorage_ = std::string(kStrStorageCapacity, '\0');
   oa_StringView kInitialValue{valueStorage_.size(), valueStorage_.data(), 0};
-  inline static const openassetio::Str kExpectedValue = kStrValue;
-  inline static const openassetio::Str kAlternativeValue = kStrValue + " alternative";
-  inline static const openassetio::Str kKeyStr = kStrKey;
-  inline static const openassetio::Str kWrongValueTypeKeyStr = kIntKey;
+  inline static const std::string kExpectedValue = kStrValue;
+  inline static const std::string kAlternativeValue = kStrValue + " alternative";
+  inline static const std::string kKeyStr = kStrKey;
+  inline static const std::string kWrongValueTypeKeyStr = kIntKey;
   oa_StringView actualValue_ = kInitialValue;
 };
 
 TEMPLATE_TEST_CASE_METHOD(AccessorFixture, "InfoDictionary accessed via C API", "",
-                          openassetio::Bool, openassetio::Int, openassetio::Float,
-                          openassetio::Str) {
+                          openassetio::Bool, openassetio::Int, openassetio::Float, std::string) {
   GIVEN("a populated C++ InfoDictionary and its C handle function pointer") {
     using Fixture = AccessorFixture<TestType>;
     // Map constructed with some initial data.
@@ -327,7 +325,7 @@ TEMPLATE_TEST_CASE_METHOD(AccessorFixture, "InfoDictionary accessed via C API", 
     // can be found.
     const auto& wrongValueTypeKeyStr = Fixture::kWrongValueTypeKeyStr;
     // Key that doesn't exist in the map.
-    const openassetio::Str& nonExistentKeyStr = Fixture::kNonExistentKeyStr;
+    const std::string& nonExistentKeyStr = Fixture::kNonExistentKeyStr;
 
     // Storage for error messages coming from C API functions.
     openassetio::Str errStorage(kStrStorageCapacity, '\0');
@@ -420,11 +418,11 @@ SCENARIO("InfoDictionary string return with insufficient buffer capacity") {
         "a StringView with insufficient storage capacity for string stored in "
         "InfoDictionary") {
       constexpr std::size_t kReducedStrStorageCapacity = 5;
-      openassetio::Str valueStorage(kReducedStrStorageCapacity, '\0');
+      std::string valueStorage(kReducedStrStorageCapacity, '\0');
       oa_StringView actualValue{valueStorage.size(), valueStorage.data(), 0};
 
       WHEN("string is retrieved into insufficient-capacity StringView") {
-        openassetio::Str keyStr = "aStr";
+        std::string keyStr = "aStr";
         oa_ConstStringView key{keyStr.data(), keyStr.size()};
 
         oa_ErrorCode actualErrorCode =
@@ -455,8 +453,8 @@ template <>
 struct MutatorFixture<openassetio::Bool> : InfoDictionaryFixture {
   INFODICTIONARY_FN(setBool);
   static constexpr openassetio::Bool kExpectedValue = !kBoolValue;
-  inline static const openassetio::Str kKeyStr = kBoolKey;
-  inline static const openassetio::Str kOtherValueTypeKeyStr = kIntKey;
+  inline static const std::string kKeyStr = kBoolKey;
+  inline static const std::string kOtherValueTypeKeyStr = kIntKey;
 };
 
 /// Specialisation for setInt.
@@ -464,8 +462,8 @@ template <>
 struct MutatorFixture<openassetio::Int> : InfoDictionaryFixture {
   INFODICTIONARY_FN(setInt);
   static constexpr openassetio::Int kExpectedValue = kIntValue + 1;
-  inline static const openassetio::Str kKeyStr = kIntKey;
-  inline static const openassetio::Str kOtherValueTypeKeyStr = kBoolKey;
+  inline static const std::string kKeyStr = kIntKey;
+  inline static const std::string kOtherValueTypeKeyStr = kBoolKey;
 };
 
 /// Specialisation for setFloat.
@@ -473,18 +471,17 @@ template <>
 struct MutatorFixture<openassetio::Float> : InfoDictionaryFixture {
   INFODICTIONARY_FN(setFloat);
   static constexpr openassetio::Float kExpectedValue = kFloatValue / 2;
-  inline static const openassetio::Str kKeyStr = kFloatKey;
-  inline static const openassetio::Str kOtherValueTypeKeyStr = kIntKey;
+  inline static const std::string kKeyStr = kFloatKey;
+  inline static const std::string kOtherValueTypeKeyStr = kIntKey;
 };
 
 /// Specialisation for setStr.
 template <>
-struct MutatorFixture<openassetio::Str> : InfoDictionaryFixture {
+struct MutatorFixture<std::string> : InfoDictionaryFixture {
   INFODICTIONARY_FN(setStr);
-  inline static const openassetio::Str kExpectedValue =
-      InfoDictionaryFixture::kStrValue + " updated";
-  inline static const openassetio::Str kKeyStr = kStrKey;
-  inline static const openassetio::Str kOtherValueTypeKeyStr = kIntKey;
+  inline static const std::string kExpectedValue = InfoDictionaryFixture::kStrValue + " updated";
+  inline static const std::string kKeyStr = kStrKey;
+  inline static const std::string kOtherValueTypeKeyStr = kIntKey;
 };
 
 TEMPLATE_TEST_CASE_METHOD(MutatorFixture, "InfoDictionary mutated via C API", "",
@@ -507,7 +504,7 @@ TEMPLATE_TEST_CASE_METHOD(MutatorFixture, "InfoDictionary mutated via C API", ""
     // can be found.
     const auto& otherValueTypeKeyStr = Fixture::kOtherValueTypeKeyStr;
     // Key that doesn't exist in the map.
-    const openassetio::Str& nonExistentKeyStr = Fixture::kNonExistentKeyStr;
+    const std::string& nonExistentKeyStr = Fixture::kNonExistentKeyStr;
 
     // Storage for error messages coming from C API functions.
     // TODO(DF): The only exception currently possible is `bad_alloc`,

--- a/tests/openassetio-core-c/private/StringViewTest.cpp
+++ b/tests/openassetio-core-c/private/StringViewTest.cpp
@@ -16,7 +16,7 @@
 
 SCENARIO("Creating, modifying and querying a C API mutable StringView") {
   GIVEN("A populated C++ string") {
-    openassetio::Str expectedStr = "some string";
+    std::string expectedStr = "some string";
 
     WHEN("a StringView is constructed wrapping the C++ string") {
       oa_StringView actualStringView{expectedStr.size(), expectedStr.data(), expectedStr.size()};
@@ -39,7 +39,7 @@ SCENARIO("Creating, modifying and querying a C API mutable StringView") {
     }
 
     AND_GIVEN("a StringView wrapping a buffer with sufficient capacity for C++ string") {
-      openassetio::Str storage(expectedStr.size(), '\0');
+      std::string storage(expectedStr.size(), '\0');
 
       oa_StringView actualStringView{storage.size(), storage.data(), 0};
 
@@ -54,7 +54,7 @@ SCENARIO("Creating, modifying and querying a C API mutable StringView") {
     }
 
     AND_GIVEN("a StringView wrapping a buffer with insufficient capacity for C++ string") {
-      openassetio::Str storage(3, '\0');
+      std::string storage(3, '\0');
 
       oa_StringView actualStringView{storage.size(), storage.data(), 0};
 
@@ -70,7 +70,7 @@ SCENARIO("Creating, modifying and querying a C API mutable StringView") {
     constexpr const char* kExpectedStr = "some string";
 
     AND_GIVEN("a StringView wrapping a buffer with sufficient capacity") {
-      openassetio::Str storage(std::string_view(kExpectedStr).size(), '\0');
+      std::string storage(std::string_view(kExpectedStr).size(), '\0');
 
       oa_StringView actualStringView{storage.size(), storage.data(), 0};
 
@@ -85,7 +85,7 @@ SCENARIO("Creating, modifying and querying a C API mutable StringView") {
 
 SCENARIO("Creating and querying a C API immutable ConstStringView") {
   GIVEN("A char buffer storing a string") {
-    openassetio::Str expectedStr;
+    std::string expectedStr;
     expectedStr = "some string";
 
     WHEN("a ConstStringView is constructed wrapping the buffer") {

--- a/tests/openassetio-core-c/private/errorsTest.cpp
+++ b/tests/openassetio-core-c/private/errorsTest.cpp
@@ -24,7 +24,7 @@ SCENARIO("throwIfError error code/message handling") {
 
   GIVEN("an error code and message") {
     const auto code = oa_ErrorCode_kUnknown;
-    openassetio::Str message = "some error";
+    std::string message = "some error";
 
     oa_StringView cmessage{
         message.size(),
@@ -45,10 +45,10 @@ SCENARIO("Using extractExceptionMessage to copy a C++ exception message to a C S
   using openassetio::errors::extractExceptionMessage;
 
   GIVEN("An exception and a StringView") {
-    const openassetio::Str expectedMessage = "some error";
+    const std::string expectedMessage = "some error";
     const std::runtime_error runtimeError{expectedMessage};
 
-    openassetio::Str storage(expectedMessage.size(), '\0');
+    std::string storage(expectedMessage.size(), '\0');
     oa_StringView actualMessage{storage.capacity(), storage.data(), 0};
 
     WHEN("extractExceptionMessage copies the message from the exception to the StringView") {
@@ -72,7 +72,7 @@ SCENARIO("Decorating an exception-throwing C++ function to instead return an err
 
   // Error message storage.
   constexpr std::size_t kErrorStorageSize = 100;
-  openassetio::Str storage(kErrorStorageSize, '\0');
+  std::string storage(kErrorStorageSize, '\0');
   oa_StringView actualErrorMessage{storage.size(), storage.data(), 0};
 
   GIVEN("A callable that doesn't throw") {
@@ -89,7 +89,7 @@ SCENARIO("Decorating an exception-throwing C++ function to instead return an err
   }
 
   GIVEN("A callable that throws an exception") {
-    const openassetio::Str expectedErrorMessage = "some error";
+    const std::string expectedErrorMessage = "some error";
 
     auto const callable = [&]() -> oa_ErrorCode { throw std::length_error{expectedErrorMessage}; };
 
@@ -104,7 +104,7 @@ SCENARIO("Decorating an exception-throwing C++ function to instead return an err
   }
 
   GIVEN("A callable that throws a non-exception") {
-    const openassetio::Str expectedErrorMessage = "Unknown non-exception object thrown";
+    const std::string expectedErrorMessage = "Unknown non-exception object thrown";
 
     auto const callable = [&]() -> oa_ErrorCode { throw "some error"; };
 

--- a/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
+++ b/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
@@ -262,14 +262,14 @@ SCENARIO("A host calls Manager::displayName") {
 
     // Storage for displayName - set to an initial value so that we can
     // assert that the underlying data was updated (or not).
-    const openassetio::Str initialStrValue = "initial string";
-    openassetio::Str displayNameStorage = initialStrValue;
+    const std::string initialStrValue = "initial string";
+    std::string displayNameStorage = initialStrValue;
     displayNameStorage.resize(kStringBufferSize, '\0');
     oa_StringView actualDisplayName{displayNameStorage.size(), displayNameStorage.data(),
                                     initialStrValue.size()};
 
     AND_GIVEN("ManagerInterface::displayName() will succeed") {
-      const openassetio::Str expectedDisplayName = "My Display Name";
+      const std::string expectedDisplayName = "My Display Name";
       REQUIRE_CALL(mockManagerInterface, displayName()).RETURN(expectedDisplayName);
 
       WHEN("the Manager C API is queried for the displayName") {

--- a/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
+++ b/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
@@ -199,8 +199,8 @@ SCENARIO("A host calls Manager::identifier") {
 
     // Storage for identifier - set to an initial value so that we can
     // assert that the underlying data was updated (or not).
-    const openassetio::Str initialStrValue = "initial string";
-    openassetio::Str identifierStorage = initialStrValue;
+    const std::string initialStrValue = "initial string";
+    openassetio::Identifier identifierStorage = initialStrValue;
     identifierStorage.resize(kStringBufferSize, '\0');
     oa_StringView actualIdentifier{identifierStorage.size(), identifierStorage.data(),
                                    initialStrValue.size()};

--- a/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
+++ b/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
@@ -325,8 +325,7 @@ SCENARIO("A host calls Manager::info") {
 
     // Storage for info - pre-populate so we can assert that calls are
     // destructive (or not).
-    const openassetio::InfoDictionary initialInfo{
-        {"initial key", openassetio::Str{"initial value"}}};
+    const openassetio::InfoDictionary initialInfo{{"initial key", std::string{"initial value"}}};
     openassetio::InfoDictionary actualInfo = initialInfo;
 
     AND_GIVEN("ManagerInterface::info() will succeed") {

--- a/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
+++ b/tests/openassetio-core-c/private/hostApi/ManagerTest.cpp
@@ -69,7 +69,7 @@ struct MockLoggerInterface : trompeloeil::mock_interface<LoggerInterface> {
 
 SCENARIO("A Manager is constructed and destructed") {
   // Storage for error messages coming from C API functions.
-  openassetio::Str errStorage(kStringBufferSize, '\0');
+  std::string errStorage(kStringBufferSize, '\0');
   oa_StringView actualErrorMsg{errStorage.size(), errStorage.data(), 0};
   // A mock ManagerInterface whose lifetime is tracked.
   using DeathwatchedMockManagerInterface = trompeloeil::deathwatched<MockManagerInterface>;
@@ -194,7 +194,7 @@ SCENARIO("A host calls Manager::identifier") {
     oa_hostApi_Manager_h managerHandle = handles::hostApi::SharedManager::toHandle(&manager);
 
     // Storage for error messages coming from C API functions.
-    openassetio::Str errStorage(kStringBufferSize, '\0');
+    std::string errStorage(kStringBufferSize, '\0');
     oa_StringView actualErrorMsg{errStorage.size(), errStorage.data(), 0};
 
     // Storage for identifier - set to an initial value so that we can
@@ -222,7 +222,7 @@ SCENARIO("A host calls Manager::identifier") {
     }
 
     AND_GIVEN("ManagerInterface::identifier() will fail with an exception") {
-      const openassetio::Str expectedErrorMsg = "Some error";
+      const std::string expectedErrorMsg = "Some error";
       REQUIRE_CALL(mockManagerInterface, identifier()).THROW(std::logic_error{expectedErrorMsg});
 
       WHEN("the Manager C API is queried for the identifier") {
@@ -257,7 +257,7 @@ SCENARIO("A host calls Manager::displayName") {
     oa_hostApi_Manager_h managerHandle = handles::hostApi::SharedManager::toHandle(&manager);
 
     // Storage for error messages coming from C API functions.
-    openassetio::Str errStorage(kStringBufferSize, '\0');
+    std::string errStorage(kStringBufferSize, '\0');
     oa_StringView actualErrorMsg{errStorage.size(), errStorage.data(), 0};
 
     // Storage for displayName - set to an initial value so that we can
@@ -285,7 +285,7 @@ SCENARIO("A host calls Manager::displayName") {
     }
 
     AND_GIVEN("ManagerInterface::displayName() will fail with an exception") {
-      const openassetio::Str expectedErrorMsg = "Some error";
+      const std::string expectedErrorMsg = "Some error";
       REQUIRE_CALL(mockManagerInterface, displayName()).THROW(std::logic_error{expectedErrorMsg});
 
       WHEN("the Manager C API is queried for the displayName") {
@@ -320,7 +320,7 @@ SCENARIO("A host calls Manager::info") {
     oa_hostApi_Manager_h managerHandle = handles::hostApi::SharedManager::toHandle(&manager);
 
     // Storage for error messages coming from C API functions.
-    openassetio::Str errStorage(kStringBufferSize, '\0');
+    std::string errStorage(kStringBufferSize, '\0');
     oa_StringView actualErrorMsg{errStorage.size(), errStorage.data(), 0};
 
     // Storage for info - pre-populate so we can assert that calls are
@@ -349,7 +349,7 @@ SCENARIO("A host calls Manager::info") {
     }
 
     AND_GIVEN("ManagerInterface::info() will fail with an exception") {
-      const openassetio::Str expectedErrorMsg = "Some error";
+      const std::string expectedErrorMsg = "Some error";
       REQUIRE_CALL(mockManagerInterface, info()).THROW(std::logic_error{expectedErrorMsg});
 
       WHEN("the Manager C API is queried for the info") {

--- a/tests/openassetio-core-c/private/managerApi/CManagerInterfaceAdapterTest.cpp
+++ b/tests/openassetio-core-c/private/managerApi/CManagerInterfaceAdapterTest.cpp
@@ -70,7 +70,7 @@ SCENARIO("A host calls CManagerInterfaceAdapter::identifier") {
           .RETURN(oa_ErrorCode_kOK);
 
       WHEN("the manager's identifier is queried") {
-        const openassetio::Str actualIdentifier = cManagerInterface.identifier();
+        const openassetio::Identifier actualIdentifier = cManagerInterface.identifier();
 
         THEN("the returned identifier matches expected identifier") {
           CHECK(actualIdentifier == expectedIdentifier);

--- a/tests/openassetio-core-c/private/managerApi/CManagerInterfaceAdapterTest.cpp
+++ b/tests/openassetio-core-c/private/managerApi/CManagerInterfaceAdapterTest.cpp
@@ -81,7 +81,7 @@ SCENARIO("A host calls CManagerInterfaceAdapter::identifier") {
     AND_GIVEN("the C suite's identifier() call fails") {
       const std::string_view expectedErrorMsg = "some error happened";
       const auto expectedErrorCode = oa_ErrorCode_kUnknown;
-      const openassetio::Str expectedErrorCodeAndMsg = "1: some error happened";
+      const std::string expectedErrorCodeAndMsg = "1: some error happened";
 
       using trompeloeil::_;
 
@@ -148,7 +148,7 @@ SCENARIO("A host calls CManagerInterfaceAdapter::displayName") {
     AND_GIVEN("the C suite's displayName() call fails") {
       const std::string_view expectedErrorMsg = "some error happened";
       const auto expectedErrorCode = oa_ErrorCode_kUnknown;
-      const openassetio::Str expectedErrorCodeAndMsg = "1: some error happened";
+      const std::string expectedErrorCodeAndMsg = "1: some error happened";
 
       using trompeloeil::_;
 
@@ -212,7 +212,7 @@ SCENARIO("A host calls CManagerInterfaceAdapter::info") {
     AND_GIVEN("the C suite's info() call fails") {
       const std::string_view expectedErrorMsg = "some error happened";
       const auto expectedErrorCode = oa_ErrorCode_kUnknown;
-      const openassetio::Str expectedErrorCodeAndMsg = "1: some error happened";
+      const std::string expectedErrorCodeAndMsg = "1: some error happened";
 
       using trompeloeil::_;
 

--- a/tests/openassetio-core-c/private/managerApi/CManagerInterfaceAdapterTest.cpp
+++ b/tests/openassetio-core-c/private/managerApi/CManagerInterfaceAdapterTest.cpp
@@ -137,7 +137,7 @@ SCENARIO("A host calls CManagerInterfaceAdapter::displayName") {
           .RETURN(oa_ErrorCode_kOK);
 
       WHEN("the manager's displayName is queried") {
-        const openassetio::Str actualDisplayName = cManagerInterface.displayName();
+        const std::string actualDisplayName = cManagerInterface.displayName();
 
         THEN("the returned displayName matches expected displayName") {
           CHECK(actualDisplayName == expectedDisplayName);

--- a/tests/openassetio-core-c/private/managerApi/CManagerInterfaceAdapterTest.cpp
+++ b/tests/openassetio-core-c/private/managerApi/CManagerInterfaceAdapterTest.cpp
@@ -187,7 +187,7 @@ SCENARIO("A host calls CManagerInterfaceAdapter::info") {
     openassetio::managerApi::CManagerInterfaceAdapter cManagerInterface{handle, suite};
 
     AND_GIVEN("the C suite's info() call succeeds") {
-      const openassetio::Str expectedInfoKey = "info key";
+      const std::string expectedInfoKey = "info key";
       const openassetio::Float expectedInfoValue = 123.456;
 
       using trompeloeil::_;

--- a/tests/openassetio-core/trait/TraitBaseTest.cpp
+++ b/tests/openassetio-core/trait/TraitBaseTest.cpp
@@ -8,9 +8,9 @@
 
 namespace {
 
-using openassetio::Str;
 using openassetio::TraitsData;
 using openassetio::TraitsDataPtr;
+using std::string;
 namespace trait = openassetio::trait;
 
 // TraitBase can't be tested directly, so we derive a test trait.
@@ -23,11 +23,13 @@ struct TestTrait : trait::TraitBase<TestTrait> {
 
   using TraitBase<TestTrait>::TraitBase;
 
-  [[nodiscard]] trait::TraitPropertyStatus getSomeProperty(Str* out) const {
+  [[nodiscard]] trait::TraitPropertyStatus getSomeProperty(std::string* out) const {
     return getTraitProperty(out, kId, kSomeProperty);
   }
 
-  void setSomeProperty(const Str& value) { data()->setTraitProperty(kId, kSomeProperty, value); }
+  void setSomeProperty(const std::string& value) {
+    data()->setTraitProperty(kId, kSomeProperty, value);
+  }
 
   // Helpers for tests
 


### PR DESCRIPTION
Closes #572 (and some).

Having solicited broader consensus around the use of typedefs for simple types, the conclusion was that aliasing `std::string` to `Str` adds more conceptual overhead than is justifiable by the potential future benefits of an abstraction.

Principally, casual reading of the code now calls a spade a `std::spade` which means the reader already understands the semantics of the type.

We have no intention to allow customization of this type at build time, so the main merits in future maintenance are hard to justify if its makes learning the code base harder for an integrator.

As there is no compiler checking of the miss-use of these types of aliases, we had also ended up with situations where the wrong one was accidentally used - potentially creating further ambiguity as to the correct approach.