### PR TITLE
[CI] Bump conan version

### DIFF
--- a/resources/build/requirements.txt
+++ b/resources/build/requirements.txt
@@ -1,4 +1,4 @@
-conan==1.50.0
+conan==1.50.2
 cmake==3.21
 ninja==1.10.2.3
 cpplint==1.5.5


### PR DESCRIPTION
Github CI error:
> ERROR: freetype/2.12.1: Cannot load recipe.
>  Error loading conanfile at
> '/home/runner/conan/.conan/data/freetype/2.12.1/_/_/export/conanfile.py':
> Current Conan version (1.50.0) does not satisfy the defined> one
> (>=1.50.2).
