### PR TITLE
[Core] Use Str typedef alias throughout

### DIFF
--- a/resources/perftest/perftest.cpp
+++ b/resources/perftest/perftest.cpp
@@ -64,7 +64,7 @@ struct Fixture {
  private:
   /// A dummy HostInterface implementation to satisfy abstract base.
   struct HostImpl : openassetio::hostApi::HostInterface {
-    [[nodiscard]] openassetio::Str identifier() const override { return {}; }
+    [[nodiscard]] openassetio::Identifier identifier() const override { return {}; }
     [[nodiscard]] openassetio::Str displayName() const override { return {}; }
   };
   /// A dummy LoggerInterface implementation

--- a/src/openassetio-core-c/private/managerApi/CManagerInterfaceAdapter.cpp
+++ b/src/openassetio-core-c/private/managerApi/CManagerInterfaceAdapter.cpp
@@ -93,7 +93,7 @@ trait::TraitsDatas CManagerInterfaceAdapter::managementPolicy(
 }
 
 bool CManagerInterfaceAdapter::isEntityReferenceString(
-    [[maybe_unused]] const std::string& someString,
+    [[maybe_unused]] const Str& someString,
     [[maybe_unused]] const HostSessionPtr& hostSession) const {
   throw std::runtime_error{"Not implemented"};
 }

--- a/src/openassetio-core-c/private/managerApi/CManagerInterfaceAdapter.hpp
+++ b/src/openassetio-core-c/private/managerApi/CManagerInterfaceAdapter.hpp
@@ -57,7 +57,7 @@ class OPENASSETIO_CORE_C_EXPORT CManagerInterfaceAdapter : ManagerInterface {
 
   /// Wrap the C suite's `isEntityReferenceString` function.
   /// @todo Implement C API. Currently throws `runtime_error`.
-  [[nodiscard]] bool isEntityReferenceString(const std::string& someString,
+  [[nodiscard]] bool isEntityReferenceString(const Str& someString,
                                              const HostSessionPtr& hostSession) const override;
 
   /// Wrap the C suite's `resolve` function.

--- a/src/openassetio-core/hostApi/Manager.cpp
+++ b/src/openassetio-core/hostApi/Manager.cpp
@@ -55,14 +55,14 @@ ContextPtr Manager::createChildContext(const ContextPtr &parentContext) {
   return context;
 }
 
-std::string Manager::persistenceTokenForContext(const ContextPtr &context) {
+Str Manager::persistenceTokenForContext(const ContextPtr &context) {
   if (context->managerState) {
     return managerInterface_->persistenceTokenForState(context->managerState, hostSession_);
   }
   return "";
 }
 
-ContextPtr Manager::contextFromPersistenceToken(const std::string &token) {
+ContextPtr Manager::contextFromPersistenceToken(const Str &token) {
   ContextPtr context = Context::make();
   if (!token.empty()) {
     context->managerState = managerInterface_->stateFromPersistenceToken(token, hostSession_);
@@ -70,7 +70,7 @@ ContextPtr Manager::contextFromPersistenceToken(const std::string &token) {
   return context;
 }
 
-bool Manager::isEntityReferenceString(const std::string &someString) const {
+bool Manager::isEntityReferenceString(const Str &someString) const {
   return managerInterface_->isEntityReferenceString(someString, hostSession_);
 }
 

--- a/src/openassetio-core/include/openassetio/BatchElementError.hpp
+++ b/src/openassetio-core/include/openassetio/BatchElementError.hpp
@@ -7,6 +7,7 @@
 
 #include <openassetio/errors.h>
 #include <openassetio/export.h>
+#include <openassetio/typedefs.hpp>
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -83,7 +84,7 @@ class BatchElementError final {
   /// Error code indicating the class of error.
   const ErrorCode code;
   /// Human-readable error message.
-  const std::string message;
+  const Str message;
 };
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -294,7 +294,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    *
    *  @see @ref stable_resolution
    */
-  std::string persistenceTokenForContext(const ContextPtr& context);
+  Str persistenceTokenForContext(const ContextPtr& context);
 
   /**
    * Returns a @ref Context linked to a previous manager state, based
@@ -318,7 +318,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * @todo Should we concatenate the manager id in
    * persistenceTokenForContext so we can verify that they match?
    */
-  ContextPtr contextFromPersistenceToken(const std::string& token);
+  ContextPtr contextFromPersistenceToken(const Str& token);
 
   /**
    * @}
@@ -377,7 +377,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * openassetio.constants.kField_EntityReferencesMatchPrefix if
    * supplied, especially when bridging between C/python.
    */
-  [[nodiscard]] bool isEntityReferenceString(const std::string& someString) const;
+  [[nodiscard]] bool isEntityReferenceString(const Str& someString) const;
 
   /**
    * Create an @ref EntityReference object wrapping a given

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -485,8 +485,8 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * @see @ref stateFromPersistenceToken
    */
-  [[nodiscard]] virtual std::string persistenceTokenForState(const ManagerStateBasePtr& state,
-                                                             const HostSessionPtr& hostSession);
+  [[nodiscard]] virtual Str persistenceTokenForState(const ManagerStateBasePtr& state,
+                                                     const HostSessionPtr& hostSession);
 
   /**
    * Restores the supplied state object to a previously persisted
@@ -502,7 +502,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * implement custom state management.
    */
   [[nodiscard]] virtual ManagerStateBasePtr stateFromPersistenceToken(
-      const std::string& token, const HostSessionPtr& hostSession);
+      const Str& token, const HostSessionPtr& hostSession);
   /**
    * @}
    */
@@ -554,7 +554,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * @see @needsref entityExists
    * @see @ref resolve
    */
-  [[nodiscard]] virtual bool isEntityReferenceString(const std::string& someString,
+  [[nodiscard]] virtual bool isEntityReferenceString(const Str& someString,
                                                      const HostSessionPtr& hostSession) const = 0;
 
   /**

--- a/src/openassetio-core/include/openassetio/typedefs.hpp
+++ b/src/openassetio-core/include/openassetio/typedefs.hpp
@@ -27,8 +27,9 @@ inline namespace OPENASSETIO_CORE_ABI_VERSION {
  * common binary layout across platforms.
  *
  * This also gives us a single point to change should we need to switch
- * to a different primitive representation in future. Therefore all use
- * of primitive types by OpenAssetIO hosts and plugins should use these
+ * to a different primitive representation in future, or to switch
+ * conditionally for a particular platform. Therefore all use of
+ * primitive types by OpenAssetIO hosts and plugins should use these
  * typedefs where possible, to reduce potential find-and-replace pain
  * later.
  *
@@ -40,7 +41,11 @@ using Bool = bool;
 using Int = int64_t;
 /// Real value type.
 using Float = double;
-/// String value type.
+/**
+ * String value type.
+ *
+ * This type is guaranteed to be API compatible with `std::string`.
+ */
 using Str = std::string;
 
 /**

--- a/src/openassetio-core/log/SeverityFilter.cpp
+++ b/src/openassetio-core/log/SeverityFilter.cpp
@@ -23,7 +23,7 @@ SeverityFilter::SeverityFilter(LoggerInterfacePtr upstreamLogger)
     const bool exactConversion = std::to_string(envSeverity) == envSeverityStr;
     if (!exactConversion || envSeverity < int(Severity::kDebugApi) ||
         envSeverity > int(Severity::kCritical)) {
-      std::string msg = "SeverityFilter: Invalid OPENASSETIO_LOGGING_SEVERITY value '";
+      Str msg = "SeverityFilter: Invalid OPENASSETIO_LOGGING_SEVERITY value '";
       msg += envSeverityStr;
       msg += "' - ignoring.";
       upstreamLogger_->log(Severity::kError, msg);

--- a/src/openassetio-core/managerApi/ManagerInterface.cpp
+++ b/src/openassetio-core/managerApi/ManagerInterface.cpp
@@ -29,7 +29,7 @@ ManagerStateBasePtr ManagerInterface::createChildState(
       "createChildState called on a manager that does not implement a custom state.");
 }
 
-std::string ManagerInterface::persistenceTokenForState(
+Str ManagerInterface::persistenceTokenForState(
     [[maybe_unused]] const ManagerStateBasePtr& state,
     [[maybe_unused]] const HostSessionPtr& hostSession) {
   throw std::runtime_error(
@@ -37,8 +37,7 @@ std::string ManagerInterface::persistenceTokenForState(
 }
 
 ManagerStateBasePtr ManagerInterface::stateFromPersistenceToken(
-    [[maybe_unused]] const std::string& token,
-    [[maybe_unused]] const HostSessionPtr& hostSession) {
+    [[maybe_unused]] const Str& token, [[maybe_unused]] const HostSessionPtr& hostSession) {
   throw std::runtime_error(
       "stateFromPersistenceToken called on a manager that does not implement a custom state.");
 }

--- a/src/openassetio-python/module/hostApi/ManagerFactoryBinding.cpp
+++ b/src/openassetio-python/module/hostApi/ManagerFactoryBinding.cpp
@@ -24,7 +24,7 @@ void registerManagerFactory(const py::module& mod) {
       .def("identifiers", &ManagerFactory::identifiers);
 
   py::class_<ManagerFactory::ManagerDetail>(managerFactory, "ManagerDetail")
-      .def(py::init<openassetio::Str, openassetio::Str, openassetio::InfoDictionary>(),
+      .def(py::init<openassetio::Identifier, openassetio::Str, openassetio::InfoDictionary>(),
            py::arg("identifier"), py::arg("displayName"), py::arg("info"))
       .def_readwrite("identifier", &ManagerFactory::ManagerDetail::identifier)
       .def_readwrite("displayName", &ManagerFactory::ManagerDetail::displayName)

--- a/src/openassetio-python/module/managerApi/ManagerInterfaceBinding.cpp
+++ b/src/openassetio-python/module/managerApi/ManagerInterfaceBinding.cpp
@@ -64,19 +64,18 @@ struct PyManagerInterface : ManagerInterface {
                       parentState, hostSession);
   }
 
-  std::string persistenceTokenForState(const ManagerStateBasePtr& parentState,
-                                       const HostSessionPtr& hostSession) override {
-    PYBIND11_OVERRIDE(std::string, ManagerInterface, persistenceTokenForState, parentState,
-                      hostSession);
+  Str persistenceTokenForState(const ManagerStateBasePtr& parentState,
+                               const HostSessionPtr& hostSession) override {
+    PYBIND11_OVERRIDE(Str, ManagerInterface, persistenceTokenForState, parentState, hostSession);
   }
 
-  ManagerStateBasePtr stateFromPersistenceToken(const std::string& token,
+  ManagerStateBasePtr stateFromPersistenceToken(const Str& token,
                                                 const HostSessionPtr& hostSession) override {
     PYBIND11_OVERRIDE(PyRetainingManagerStateBasePtr, ManagerInterface, stateFromPersistenceToken,
                       token, hostSession);
   }
 
-  [[nodiscard]] bool isEntityReferenceString(const std::string& someString,
+  [[nodiscard]] bool isEntityReferenceString(const Str& someString,
                                              const HostSessionPtr& hostSession) const override {
     PYBIND11_OVERRIDE_PURE(bool, ManagerInterface, isEntityReferenceString, someString,
                            hostSession);

--- a/tests/openassetio-core-c/private/managerApi/CManagerInterfaceAdapterTest.cpp
+++ b/tests/openassetio-core-c/private/managerApi/CManagerInterfaceAdapterTest.cpp
@@ -70,7 +70,7 @@ SCENARIO("A host calls CManagerInterfaceAdapter::identifier") {
           .RETURN(oa_ErrorCode_kOK);
 
       WHEN("the manager's identifier is queried") {
-        const openassetio::Str actualIdentifier = cManagerInterface.identifier();
+        const openassetio::Identifier actualIdentifier = cManagerInterface.identifier();
 
         THEN("the returned identifier matches expected identifier") {
           CHECK(actualIdentifier == expectedIdentifier);

--- a/tests/openassetio-core/BatchElementErrorTest.cpp
+++ b/tests/openassetio-core/BatchElementErrorTest.cpp
@@ -12,7 +12,7 @@ using openassetio::BatchElementError;
 SCENARIO("BatchElementError usage") {
   GIVEN("an error code and message") {
     const auto code = BatchElementError::ErrorCode::kUnknown;
-    const std::string message = "some message";
+    const openassetio::Str message = "some message";
 
     WHEN("a BatchElementError is constructed wrapping the code and message") {
       BatchElementError error{code, message};


### PR DESCRIPTION
We may opt to remove aliases for primitive types in future (see https://github.com/OpenAssetIO/OpenAssetIO/issues/572). In the meantime, we should at least be consistent in our usage.

So update the errant usages of `std::string` to instead use `openassetio::Str`.