### PR TITLE
[Core] Add `kEntityAccessError` to `BatchElementError`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+
+### Breaking changes
+
+- Reordered `BatchElementError.ErrorCode` constants to allow grouping of
+  entity-related errors.
+  [#587](https://github.com/OpenAssetIO/OpenAssetIO/issues/587)
+
+
 v1.0.0-alpha.3
 --------------
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,14 @@ v1.0.0-alpha.x
   [#587](https://github.com/OpenAssetIO/OpenAssetIO/issues/587)
 
 
+### Improvements
+
+- Added `BatchElementError.ErrorCode.kEntityAccessError` to better
+  encode the scenario where the supplied context's access is the
+  specific cause of the error.
+  [#587](https://github.com/OpenAssetIO/OpenAssetIO/issues/587)
+
+
 v1.0.0-alpha.3
 --------------
 

--- a/python/openassetio/test/manager/apiComplianceSuite.py
+++ b/python/openassetio/test/manager/apiComplianceSuite.py
@@ -297,13 +297,15 @@ class Test_resolve(FixtureAugmentedTestCase):
         mixed_traits.add("₲₪₡🤯")
         self.__testResolution([ref], mixed_traits, Context.Access.kRead, traits)
 
-    def test_when_resolving_read_only_reference_for_write_then_resolution_error_is_returned(self):
+    def test_when_resolving_read_only_reference_for_write_then_access_error_is_returned(self):
         self.__testResolutionError(
-            "a_reference_to_a_readonly_entity", access=Context.Access.kWrite)
+            "a_reference_to_a_readonly_entity", access=Context.Access.kWrite,
+            errorCode=BatchElementError.ErrorCode.kEntityAccessError)
 
-    def test_when_resolving_write_only_reference_for_read_then_resolution_error_is_returned(self):
+    def test_when_resolving_write_only_reference_for_read_then_access_error_is_returned(self):
         self.__testResolutionError(
-            "a_reference_to_a_writeonly_entity", access=Context.Access.kRead)
+            "a_reference_to_a_writeonly_entity", access=Context.Access.kRead,
+            errorCode=BatchElementError.ErrorCode.kEntityAccessError)
 
     def test_when_resolving_missing_reference_then_then_resolution_error_is_returned(self):
         self.__testResolutionError("a_reference_to_a_missing_entity")

--- a/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
+++ b/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
@@ -116,7 +116,7 @@ class BasicAssetLibraryInterface(ManagerInterface):
     ):
         if context.isForWrite():
             result = BatchElementError(
-                BatchElementError.ErrorCode.kEntityResolutionError,
+                BatchElementError.ErrorCode.kEntityAccessError,
                 "BAL entities are read-only")
             for idx in range(len(entityReferences)):
                 errorCallback(idx, result)

--- a/src/openassetio-core/include/openassetio/BatchElementError.hpp
+++ b/src/openassetio-core/include/openassetio/BatchElementError.hpp
@@ -44,21 +44,6 @@ class BatchElementError final {
   enum class ErrorCode {
     /// Fallback for uncommon errors.
     kUnknown = OPENASSETIO_BatchErrorCode_kUnknown,
-    /**
-     * Error code used during @ref resolve "entity resolution" when the
-     * reference itself is valid, but it is not possible to retrieve
-     * data for the referenced @ref entity.
-     *
-     * This could be because it does not exist, or a read-only entity is
-     * being resolved for write. This code should not be used if an
-     * entity does not have a requested trait - simply do not set that
-     * trait in the resulting data.
-     *
-     * This code is also used during version finalisation and any other
-     * entity-based operations on a valid @ref entity_reference that
-     * fail for some reason.
-     */
-    kEntityResolutionError = OPENASSETIO_BatchErrorCode_kEntityResolutionError,
 
     /**
      * Error code used whenever an Entity-based action is performed on
@@ -78,7 +63,23 @@ class BatchElementError final {
      * pre-validation used when constructing an `EntityReference` object
      * is intended to be a simple in-process check.
      */
-    kInvalidEntityReference = OPENASSETIO_BatchErrorCode_kInvalidEntityReference
+    kInvalidEntityReference = OPENASSETIO_BatchErrorCode_kInvalidEntityReference,
+
+    /**
+     * Error code used during @ref resolve "entity resolution" when the
+     * reference itself is valid, but it is not possible to retrieve
+     * data for the referenced @ref entity.
+     *
+     * This could be because it does not exist, or a read-only entity is
+     * being resolved for write. This code should not be used if an
+     * entity does not have a requested trait - simply do not set that
+     * trait in the resulting data.
+     *
+     * This code is also used during version finalisation and any other
+     * entity-based operations on a valid @ref entity_reference that
+     * fail for some reason.
+     */
+    kEntityResolutionError = OPENASSETIO_BatchErrorCode_kEntityResolutionError
   };
 
   /// Error code indicating the class of error.

--- a/src/openassetio-core/include/openassetio/BatchElementError.hpp
+++ b/src/openassetio-core/include/openassetio/BatchElementError.hpp
@@ -66,14 +66,27 @@ class BatchElementError final {
     kInvalidEntityReference = OPENASSETIO_BatchErrorCode_kInvalidEntityReference,
 
     /**
+     * Error code used when the reference is valid, but the supplied
+     * @ref Context access is invalid for the operation. A common
+     * example of this would be resolving a read-only entity with a
+     * write access Context, or during @ref preflight or @ref register
+     * when the target entity s read-only and does not support
+     * versioning.
+     */
+    kEntityAccessError = OPENASSETIO_BatchErrorCode_kEntityAccessError,
+
+    /**
      * Error code used during @ref resolve "entity resolution" when the
      * reference itself is valid, but it is not possible to retrieve
      * data for the referenced @ref entity.
      *
-     * This could be because it does not exist, or a read-only entity is
-     * being resolved for write. This code should not be used if an
-     * entity does not have a requested trait - simply do not set that
-     * trait in the resulting data.
+     * This could be because it does not exist, or some other
+     * entity-specific reason that this data cannot be resolved for a
+     * specific entity. This code should not be used if an entity does
+     * not have a requested trait - simply do not set that trait in the
+     * resulting data. Fatal runtime errors during resolution (eg:
+     * server connection errors) should be raised as exceptions, rather
+     * than per-entity errors.
      *
      * This code is also used during version finalisation and any other
      * entity-based operations on a valid @ref entity_reference that

--- a/src/openassetio-core/include/openassetio/errors.h
+++ b/src/openassetio-core/include/openassetio/errors.h
@@ -32,5 +32,8 @@
 /// Failure due to malformed entity reference.
 #define OPENASSETIO_BatchErrorCode_kInvalidEntityReference (OPENASSETIO_BatchErrorCode_BEGIN + 1)
 
+/// Failure due to an API method being called with an invalid @ref Context access.
+#define OPENASSETIO_BatchErrorCode_kEntityAccessError (OPENASSETIO_BatchErrorCode_BEGIN + 2)
+
 /// Entity resolution failure.
-#define OPENASSETIO_BatchErrorCode_kEntityResolutionError (OPENASSETIO_BatchErrorCode_BEGIN + 2)
+#define OPENASSETIO_BatchErrorCode_kEntityResolutionError (OPENASSETIO_BatchErrorCode_BEGIN + 3)

--- a/src/openassetio-core/include/openassetio/errors.h
+++ b/src/openassetio-core/include/openassetio/errors.h
@@ -29,8 +29,8 @@
 /// Unknown error when processing a batch element.
 #define OPENASSETIO_BatchErrorCode_kUnknown (OPENASSETIO_BatchErrorCode_BEGIN + 0)
 
-/// Entity resolution failure.
-#define OPENASSETIO_BatchErrorCode_kEntityResolutionError (OPENASSETIO_BatchErrorCode_BEGIN + 1)
-
 /// Failure due to malformed entity reference.
-#define OPENASSETIO_BatchErrorCode_kInvalidEntityReference (OPENASSETIO_BatchErrorCode_BEGIN + 2)
+#define OPENASSETIO_BatchErrorCode_kInvalidEntityReference (OPENASSETIO_BatchErrorCode_BEGIN + 1)
+
+/// Entity resolution failure.
+#define OPENASSETIO_BatchErrorCode_kEntityResolutionError (OPENASSETIO_BatchErrorCode_BEGIN + 2)

--- a/src/openassetio-python/module/BatchElementErrorBinding.cpp
+++ b/src/openassetio-python/module/BatchElementErrorBinding.cpp
@@ -14,6 +14,7 @@ void registerBatchElementError(const py::module &mod) {
   py::enum_<BatchElementError::ErrorCode>{batchElementError, "ErrorCode"}
       .value("kUnknown", BatchElementError::ErrorCode::kUnknown)
       .value("kInvalidEntityReference", BatchElementError::ErrorCode::kInvalidEntityReference)
+      .value("kEntityAccessError", BatchElementError::ErrorCode::kEntityAccessError)
       .value("kEntityResolutionError", BatchElementError::ErrorCode::kEntityResolutionError);
 
   batchElementError

--- a/src/openassetio-python/module/BatchElementErrorBinding.cpp
+++ b/src/openassetio-python/module/BatchElementErrorBinding.cpp
@@ -13,8 +13,8 @@ void registerBatchElementError(const py::module &mod) {
 
   py::enum_<BatchElementError::ErrorCode>{batchElementError, "ErrorCode"}
       .value("kUnknown", BatchElementError::ErrorCode::kUnknown)
-      .value("kEntityResolutionError", BatchElementError::ErrorCode::kEntityResolutionError)
-      .value("kInvalidEntityReference", BatchElementError::ErrorCode::kInvalidEntityReference);
+      .value("kInvalidEntityReference", BatchElementError::ErrorCode::kInvalidEntityReference)
+      .value("kEntityResolutionError", BatchElementError::ErrorCode::kEntityResolutionError);
 
   batchElementError
       .def(py::init<BatchElementError::ErrorCode, openassetio::Str>(), py::arg("code"),

--- a/tests/python/openassetio/test_batchelementerror.py
+++ b/tests/python/openassetio/test_batchelementerror.py
@@ -30,7 +30,8 @@ class Test_BatchElementError_ErrorCode:
     def test_code_values(self):
         assert int(BatchElementError.ErrorCode.kUnknown) == 128
         assert int(BatchElementError.ErrorCode.kInvalidEntityReference) == 129
-        assert int(BatchElementError.ErrorCode.kEntityResolutionError) == 130
+        assert int(BatchElementError.ErrorCode.kEntityAccessError) == 130
+        assert int(BatchElementError.ErrorCode.kEntityResolutionError) == 131
 
 
 class Test_BatchElementError_inheritance:

--- a/tests/python/openassetio/test_batchelementerror.py
+++ b/tests/python/openassetio/test_batchelementerror.py
@@ -29,8 +29,8 @@ from openassetio import BatchElementError
 class Test_BatchElementError_ErrorCode:
     def test_code_values(self):
         assert int(BatchElementError.ErrorCode.kUnknown) == 128
-        assert int(BatchElementError.ErrorCode.kEntityResolutionError) == 129
-        assert int(BatchElementError.ErrorCode.kInvalidEntityReference) == 130
+        assert int(BatchElementError.ErrorCode.kInvalidEntityReference) == 129
+        assert int(BatchElementError.ErrorCode.kEntityResolutionError) == 130
 
 
 class Test_BatchElementError_inheritance:


### PR DESCRIPTION
As part of #587, we need to properly define the API behaviour when calling `preflight` or `register` for an un-versionable, immutable entity.  This required a new error code. Rather than tying this to the specific method, this adds `kEntityAccessError`, that can be used in all cases where the access is the sole cause of error.

As this also applies to `resolve`, updates the `apiComplianceSuite` to check for this too (and consequently updates BAL to be compliant).