### PR TITLE
[Core] Migrate `preflight`/`register` to callbacks

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,10 @@ v1.0.0-alpha.x
   entity-related errors.
   [#587](https://github.com/OpenAssetIO/OpenAssetIO/issues/587)
 
+- Migrated `Manager.preflight` and `Manager.register` to use the new
+  callback based batch API.
+  [#587](https://github.com/OpenAssetIO/OpenAssetIO/issues/587)
+
 
 ### Improvements
 

--- a/python/openassetio/managerApi/ManagerInterface.py
+++ b/python/openassetio/managerApi/ManagerInterface.py
@@ -741,13 +741,13 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         """
         Prepares for some work to be done to create data for the
         referenced entity. The entity may not yet exist (@ref
-        entity_reference). This call is designed to allow sanity
-        checking, placeholder creation or any other sundry preparatory
-        actions to be carried out.
+        entity_reference). This call is designed to allow validation of
+        the target reference, placeholder creation or any other sundry
+        preparatory actions to be carried out.
 
         If this does not apply to the manager's workflow, then the
-        method is effectively a no-op and the default implementation
-        calls the success callback with the input entity reference.
+        method can pass back the input reference once the target entity
+        reference has been validated.
 
         Generally, this will be called before register() in any host
         that creates media, where the return to
@@ -792,7 +792,10 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         along with a populated @fqref{BatchElementError}
         "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
         "ErrorCodes"). The callback must be called on the same thread
-        that initiated the call to `preflight`.
+        that initiated the call to `preflight`. A
+        @fqref{BatchElementError.ErrorCode.kEntityAccessError}
+        "kEntityAccessError" should be used for any target references
+        that are conceptually read-only.
 
         @return None
 
@@ -802,8 +805,7 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
 
         @see @ref register
         """
-        for idx, ref in enumerate(targetEntityRefs):
-            successCallback(idx, ref)
+        raise NotImplementedError
 
     def register(self, targetEntityRefs, entityTraitsDatas, context, hostSession,
                  successCallback, errorCallback):

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -178,11 +178,15 @@ class ValidatingMockManagerInterface(ManagerInterface):
         return self.mock.setRelatedReferences(
             entityRef, relationshipTraitsData, relatedRefs, context, hostSession, append=append)
 
-    def preflight(self, targetEntityRefs, traitSet, context, hostSession):
+    def preflight(self, targetEntityRefs, traitSet, context, hostSession,
+                  successCallback, errorCallback):
         self.__assertIsIterableOf(targetEntityRefs, EntityReference)
         self.__assertIsIterableOf(traitSet, str)
         self.__assertCallingContext(context, hostSession)
-        return self.mock.preflight(targetEntityRefs, traitSet, context, hostSession)
+        assert callable(successCallback)
+        assert callable(errorCallback)
+        return self.mock.preflight(targetEntityRefs, traitSet, context, hostSession,
+                                   successCallback, errorCallback)
 
     def createState(self, hostSession):
         return self.mock.createState(hostSession)
@@ -253,12 +257,16 @@ class ValidatingMockManagerInterface(ManagerInterface):
         return self.mock.getRelatedReferences(
             entityRefs, relationshipTraitsDatas, context, hostSession, resultTraitSet)
 
-    def register(self, targetEntityRefs, entityTraitsDatas, context, hostSession):
+    def register(self, targetEntityRefs, entityTraitsDatas, context, hostSession,
+                 successCallback, errorCallback):
         self.__assertIsIterableOf(targetEntityRefs, EntityReference)
         self.__assertIsIterableOf(entityTraitsDatas, TraitsData)
         self.__assertCallingContext(context, hostSession)
         assert len(targetEntityRefs) == len(entityTraitsDatas)
-        return self.mock.register(targetEntityRefs, entityTraitsDatas, context, hostSession)
+        assert callable(successCallback)
+        assert callable(errorCallback)
+        return self.mock.register(targetEntityRefs, entityTraitsDatas, context, hostSession,
+                                  successCallback, errorCallback)
 
     @staticmethod
     def __assertIsIterableOf(iterable, expectedElemType):

--- a/tests/python/openassetio/managerApi/test_managerinterface.py
+++ b/tests/python/openassetio/managerApi/test_managerinterface.py
@@ -25,6 +25,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from openassetio import Context, EntityReference
 from openassetio.managerApi import ManagerInterface, ManagerStateBase
 
 
@@ -131,6 +132,24 @@ class Test_ManagerInterface_finalizedEntityVersion:
         assert finalized_refs == refs
 
 
+class Test_ManagerInterface_preflight:
+    def test_when_given_refs_then_success_callback_called_with_input_refs(
+            self, manager_interface, some_entity_refs, a_host_session):
+
+        resulting_refs = []
+
+        manager_interface.preflight(some_entity_refs, {"a_trait"}, Context(), a_host_session,
+                                    lambda _, ref: resulting_refs.append(ref),
+                                    lambda _, err: pytest.fail(err.message))
+
+        assert resulting_refs == some_entity_refs
+
+
 @pytest.fixture
 def manager_interface():
     return ManagerInterface()
+
+
+@pytest.fixture
+def some_entity_refs():
+    return [EntityReference(r) for r in ("ref:///🦆", "ref:///🐑")]

--- a/tests/python/openassetio/managerApi/test_managerinterface.py
+++ b/tests/python/openassetio/managerApi/test_managerinterface.py
@@ -25,7 +25,6 @@ from unittest.mock import Mock
 
 import pytest
 
-from openassetio import Context, EntityReference
 from openassetio.managerApi import ManagerInterface, ManagerStateBase
 
 
@@ -132,24 +131,6 @@ class Test_ManagerInterface_finalizedEntityVersion:
         assert finalized_refs == refs
 
 
-class Test_ManagerInterface_preflight:
-    def test_when_given_refs_then_success_callback_called_with_input_refs(
-            self, manager_interface, some_entity_refs, a_host_session):
-
-        resulting_refs = []
-
-        manager_interface.preflight(some_entity_refs, {"a_trait"}, Context(), a_host_session,
-                                    lambda _, ref: resulting_refs.append(ref),
-                                    lambda _, err: pytest.fail(err.message))
-
-        assert resulting_refs == some_entity_refs
-
-
 @pytest.fixture
 def manager_interface():
     return ManagerInterface()
-
-
-@pytest.fixture
-def some_entity_refs():
-    return [EntityReference(r) for r in ("ref:///🦆", "ref:///🐑")]


### PR DESCRIPTION
Closes #587.

Whilst looking at the doc-update aspect of this, I noticed that we didn't update the examples for `resolve` when we did #571, so have added #592 to cover this more holistically.

Takes the opportunity to expand test coverage to (attempt) to capture the required behaviour of a manager when transitioning to callbacks.
