### PR TITLE
[Core] Add `ManagerInterface._createEntityReference`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,11 @@ v1.0.0-alpha.x
   specific cause of the error.
   [#587](https://github.com/OpenAssetIO/OpenAssetIO/issues/587)
 
+- Added (protected) `ManagerInterface.createEntityReference` method
+  to facilitate the creation of `EntityReference` values as required by
+  a manager's implementation.
+  [#549](https://github.com/OpenAssetIO/OpenAssetIO/issues/549)
+
 
 v1.0.0-alpha.3
 --------------

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -681,6 +681,21 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
                        const ResolveErrorCallback& errorCallback) = 0;
 
   /// @}
+ protected:
+  /**
+   * Create an @ref EntityReference object wrapping a given @ref
+   * entity_reference string. This should be used for all reference
+   * creation by a manager's implementation.
+   *
+   * No validation is performed as this method is only visible to the
+   * manager implementation, and so it is assumed that its internal
+   * business logic inherently ensures only valid strings are
+   * returned.
+   *
+   * @param entityReferenceString Raw string representation of the
+   * entity reference.
+   */
+  [[nodiscard]] EntityReference createEntityReference(Str entityReferenceString) const;
 };
 }  // namespace managerApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-core/managerApi/ManagerInterface.cpp
+++ b/src/openassetio-core/managerApi/ManagerInterface.cpp
@@ -42,6 +42,12 @@ ManagerStateBasePtr ManagerInterface::stateFromPersistenceToken(
       "stateFromPersistenceToken called on a manager that does not implement a custom state.");
 }
 
+// To avoid changing this to non-static in the not too distant, when we
+// add manager validation (see https://github.com/OpenAssetIO/OpenAssetIO/issues/553).
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+EntityReference ManagerInterface::createEntityReference(Str entityReferenceString) const {
+  return EntityReference(std::move(entityReferenceString));
+}
 }  // namespace managerApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-python/module/managerApi/ManagerInterfaceBinding.cpp
+++ b/src/openassetio-python/module/managerApi/ManagerInterfaceBinding.cpp
@@ -89,6 +89,9 @@ struct PyManagerInterface : ManagerInterface {
     PYBIND11_OVERRIDE_PURE(void, ManagerInterface, resolve, entityReferences, traitSet, context,
                            hostSession, successCallback, errorCallback);
   }
+
+  // Hoist protected members
+  using ManagerInterface::createEntityReference;
 };
 
 }  // namespace managerApi
@@ -123,5 +126,7 @@ void registerManagerInterface(const py::module& mod) {
            py::arg("someString"), py::arg("hostSession").none(false))
       .def("resolve", &ManagerInterface::resolve, py::arg("entityReferences"), py::arg("traitSet"),
            py::arg("context").none(false), py::arg("hostSession").none(false),
-           py::arg("successCallback"), py::arg("errorCallback"));
+           py::arg("successCallback"), py::arg("errorCallback"))
+      .def("_createEntityReference", &PyManagerInterface::createEntityReference,
+           py::arg("entityReferenceString"));
 }

--- a/tests/python/openassetio/managerApi/test_managerinterface.py
+++ b/tests/python/openassetio/managerApi/test_managerinterface.py
@@ -25,6 +25,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from openassetio import EntityReference
 from openassetio.managerApi import ManagerInterface, ManagerStateBase
 
 
@@ -129,6 +130,28 @@ class Test_ManagerInterface_finalizedEntityVersion:
         finalized_refs = manager_interface.finalizedEntityVersion(refs, Mock(), Mock())
 
         assert finalized_refs == refs
+
+
+class Test_ManagerInterface__createEntityReference:
+    def test_when_input_is_string_then_wrapped_in_entity_reference(self, manager_interface):
+        a_string = "some string"
+        # pylint: disable=protected-access
+        actual = manager_interface._createEntityReference(a_string)
+        assert isinstance(actual, EntityReference)
+        assert actual.toString() == a_string
+
+    def test_when_input_is_none_then_typeerror_raised(self, manager_interface):
+        with pytest.raises(TypeError):
+            manager_interface._createEntityReference(None)  # pylint: disable=protected-access
+
+    def test_when_input_is_not_a_string_then_typeerror_raised(self, manager_interface):
+        with pytest.raises(TypeError):
+            manager_interface._createEntityReference(1)  # pylint: disable=protected-access
+
+    def test_is_entity_reference_string_is_not_called(self, mock_manager_interface):
+        # pylint: disable=protected-access
+        _ = mock_manager_interface._createEntityReference("some string")
+        mock_manager_interface.mock.isEntityReferenceString.assert_not_called()
 
 
 @pytest.fixture


### PR DESCRIPTION
In #549, we added a 'strongly typed' entity reference workflow. This required hosts to ensure that strings are validated through the manager before being used as an entity reference. This ensures that once initial checks have been completed, manager implementations no longer need to worry about re-checking method inputs to see if they are one of their references.

We plan on adding assorted validation checks in the API middleware that will help avoid coding errors when multiple managers are in use.

This raises the question of how should a manager implementation create these strongly typed objects - where it doesn't need the validation?

We wanted to avoid direct construction of `EntityReference` objects on the stack by code so that we can evolve the manager validation aspect with minimal code churn at all the construction sites.

We previously debated an object oriented design (`EntityReference(string, manager)` vs the current function + data approach (`Manager.createEntityReference(string)`). We picked the latter as it matched the approach we have with `Context` and is more portable to other languages.

This seems to have lead to a simple solution to this question - where by, we add an alternate (protected) factory method to the ManagerInterface that bypasses the usual checks performed when the strings originate from outside the manager's implementation.

This should then be used by all manager implementation code that needs to create an entity reference to return to the host
