### PR TITLE
[CI] Pin `sqlite3` conan recipe version

### DIFF
--- a/resources/build/conanfile.txt
+++ b/resources/build/conanfile.txt
@@ -10,6 +10,10 @@ catch2/2.13.8
 # Mocking library
 trompeloeil/42
 
+# Pin recipe version to avoid https://github.com/conan-io/conan/issues/11822.
+# Newer sqlite requires Conan 1.51.x
+sqlite3/3.36.0#743ab7e05e85b38c6c8223cae98ce343
+
 [generators]
 # Generate a CMake toolchain preamble file `conan_paths.cmake`, which
 # augments package search paths with conan package directories.

--- a/resources/build/requirements.txt
+++ b/resources/build/requirements.txt
@@ -1,4 +1,4 @@
-conan==1.50.2
+conan==1.51.2
 cmake==3.21
 ninja==1.10.2.3
 cpplint==1.5.5

--- a/resources/build/requirements.txt
+++ b/resources/build/requirements.txt
@@ -1,4 +1,4 @@
-conan==1.51.3
+conan==1.50.2
 cmake==3.21
 ninja==1.10.2.3
 cpplint==1.5.5


### PR DESCRIPTION
The latest recipe requires Conan 1.51.3, which introduces this bug:
  https://github.com/conan-io/conan/issues/11822

Hopefully this is a band-aid until 1.52 is out and we can create a proper conan lockfile.
