### PR TITLE
[Core] Ensure `resolve` callback implementation can use trait views on the provided trait data

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -52,6 +52,12 @@ v1.0.0-alpha.x
   [#498](https://github.com/OpenAssetIO/OpenAssetIO/issues/498)
 
 
+### Bug fixes
+
+- Fixed `Manager.resolve` success callback such that the trait data
+  provided is compatible with C++ trait views.
+  [#605](https://github.com/OpenAssetIO/OpenAssetIO/pull/605)
+
 
 v1.0.0-alpha.3
 --------------

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -434,7 +434,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
   /**
    * Callback signature used for a successful entity resolution.
    */
-  using ResolveSuccessCallback = std::function<void(std::size_t, const TraitsDataConstPtr&)>;
+  using ResolveSuccessCallback = std::function<void(std::size_t, const TraitsDataPtr&)>;
 
   /**
    * Callback signature used for an unsuccessful entity resolution.

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -579,7 +579,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
   /**
    * Callback signature used for a successful entity resolution.
    */
-  using ResolveSuccessCallback = std::function<void(std::size_t, const TraitsDataConstPtr&)>;
+  using ResolveSuccessCallback = std::function<void(std::size_t, const TraitsDataPtr&)>;
 
   /**
    * Callback signature used for an unsuccessful entity resolution.


### PR DESCRIPTION
`TraitsDataConstPtr` is currently unsupported by (C++) trait views, which require a pointer-to-non-const currently. This will change when we tackle autogeneration of C++ traits.

In the meantime, fix the `resolve` callback signature to take a `TraitsDataPtr`, so that trait views can be utilised in the callback
implementation.
