### PR TITLE
[Tests] Assert Manager methods implemented once

### DIFF
--- a/tests/python/openassetio/hostApi/test_manager.py
+++ b/tests/python/openassetio/hostApi/test_manager.py
@@ -20,7 +20,6 @@ Tests that cover the openassetio.hostApi.Manager wrapper class.
 # pylint: disable=no-self-use
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
-import inspect
 from unittest import mock
 
 import pytest
@@ -114,8 +113,9 @@ class Test_Manager_init:
 
 
 class Test_Manager_identifier:
-    def test_method_defined_in_cpp(self):
-        assert not is_defined_in_python(Manager.identifier)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(Manager.identifier)
+        assert method_introspector.is_implemented_once(Manager, "identifier")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface):
@@ -144,8 +144,9 @@ class Test_Manager_identifier:
 
 
 class Test_Manager_displayName:
-    def test_method_defined_in_cpp(self):
-        assert not is_defined_in_python(Manager.displayName)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(Manager.displayName)
+        assert method_introspector.is_implemented_once(Manager, "displayName")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface):
@@ -170,8 +171,9 @@ class Test_Manager_displayName:
 
 
 class Test_Manager_info:
-    def test_method_defined_in_cpp(self):
-        assert not is_defined_in_python(Manager.info)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(Manager.info)
+        assert method_introspector.is_implemented_once(Manager, "info")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface):
@@ -196,8 +198,9 @@ class Test_Manager_info:
 
 
 class Test_Manager_updateTerminology:
-    def test_method_defined_in_python(self):
-        assert is_defined_in_python(Manager.updateTerminology)
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(Manager.updateTerminology)
+        assert method_introspector.is_implemented_once(Manager, "updateTerminology")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session):
@@ -209,8 +212,9 @@ class Test_Manager_updateTerminology:
 
 
 class Test_Manager_settings:
-    def test_method_defined_in_cpp(self):
-        assert not is_defined_in_python(Manager.settings)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(Manager.settings)
+        assert method_introspector.is_implemented_once(Manager, "settings")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session):
@@ -226,8 +230,9 @@ class Test_Manager_settings:
 
 
 class Test_Manager_initialize:
-    def test_method_defined_in_cpp(self):
-        assert not is_defined_in_python(Manager.initialize)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(Manager.initialize)
+        assert method_introspector.is_implemented_once(Manager, "initialize")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session):
@@ -239,8 +244,9 @@ class Test_Manager_initialize:
 
 
 class Test_Manager_flushCaches:
-    def test_method_defined_in_python(self):
-        assert is_defined_in_python(Manager.flushCaches)
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(Manager.flushCaches)
+        assert method_introspector.is_implemented_once(Manager, "flushCaches")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session):
@@ -251,8 +257,9 @@ class Test_Manager_flushCaches:
 
 
 class Test_Manager_isEntityReferenceString:
-    def test_method_defined_in_cpp(self):
-        assert not is_defined_in_python(Manager.isEntityReferenceString)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(Manager.isEntityReferenceString)
+        assert method_introspector.is_implemented_once(Manager, "isEntityReferenceString")
 
     @pytest.mark.parametrize("expected", (True, False))
     def test_wraps_the_corresponding_method_of_the_held_interface(
@@ -265,8 +272,9 @@ class Test_Manager_isEntityReferenceString:
 
 
 class Test_Manager_createEntityReference:
-    def test_method_defined_in_cpp(self):
-        assert not is_defined_in_python(Manager.createEntityReference)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(Manager.createEntityReference)
+        assert method_introspector.is_implemented_once(Manager, "createEntityReference")
 
     def test_when_invalid_then_raises_ValueError(
             self, manager, mock_manager_interface, a_ref_string, a_host_session):
@@ -292,8 +300,9 @@ class Test_Manager_createEntityReference:
 
 
 class Test_Manager_createEntityReferenceIfValid:
-    def test_method_defined_in_cpp(self):
-        assert not is_defined_in_python(Manager.createEntityReferenceIfValid)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(Manager.createEntityReferenceIfValid)
+        assert method_introspector.is_implemented_once(Manager, "createEntityReferenceIfValid")
 
     def test_when_invalid_then_returns_None(
             self, manager, mock_manager_interface, a_ref_string, a_host_session):
@@ -318,8 +327,9 @@ class Test_Manager_createEntityReferenceIfValid:
 
 
 class Test_Manager_entityExists:
-    def test_method_defined_in_python(self):
-        assert is_defined_in_python(Manager.entityExists)
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(Manager.entityExists)
+        assert method_introspector.is_implemented_once(Manager, "entityExists")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session, some_refs, a_context):
@@ -330,8 +340,9 @@ class Test_Manager_entityExists:
 
 
 class Test_Manager_defaultEntityReference:
-    def test_method_defined_in_python(self):
-        assert is_defined_in_python(Manager.defaultEntityReference)
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(Manager.defaultEntityReference)
+        assert method_introspector.is_implemented_once(Manager, "defaultEntityReference")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session, a_context,
@@ -344,8 +355,9 @@ class Test_Manager_defaultEntityReference:
 
 
 class Test_Manager_entityName:
-    def test_method_defined_in_python(self):
-        assert is_defined_in_python(Manager.entityName)
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(Manager.entityName)
+        assert method_introspector.is_implemented_once(Manager, "entityName")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session, some_refs, a_context):
@@ -356,8 +368,9 @@ class Test_Manager_entityName:
 
 
 class Test_Manager_entityDisplayName:
-    def test_method_defined_in_python(self):
-        assert is_defined_in_python(Manager.entityDisplayName)
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(Manager.entityDisplayName)
+        assert method_introspector.is_implemented_once(Manager, "entityDisplayName")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session, some_refs, a_context):
@@ -368,8 +381,9 @@ class Test_Manager_entityDisplayName:
 
 
 class Test_Manager_entityVersion:
-    def test_method_defined_in_python(self):
-        assert is_defined_in_python(Manager.entityVersion)
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(Manager.entityVersion)
+        assert method_introspector.is_implemented_once(Manager, "entityVersion")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session, some_refs, a_context):
@@ -380,8 +394,9 @@ class Test_Manager_entityVersion:
 
 
 class Test_Manager_entityVersions:
-    def test_method_defined_in_python(self):
-        assert is_defined_in_python(Manager.entityVersions)
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(Manager.entityVersions)
+        assert method_introspector.is_implemented_once(Manager, "entityVersions")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session, some_refs, a_context):
@@ -411,8 +426,9 @@ class Test_Manager_entityVersions:
 
 
 class Test_Manager_finalizedEntityVersion:
-    def test_method_defined_in_python(self):
-        assert is_defined_in_python(Manager.finalizedEntityVersion)
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(Manager.finalizedEntityVersion)
+        assert method_introspector.is_implemented_once(Manager, "finalizedEntityVersion")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session, some_refs, a_context):
@@ -432,8 +448,9 @@ class Test_Manager_finalizedEntityVersion:
 
 
 class Test_Manager_getRelatedReferences:
-    def test_method_defined_in_python(self):
-        assert is_defined_in_python(Manager.getRelatedReferences)
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(Manager.getRelatedReferences)
+        assert method_introspector.is_implemented_once(Manager, "getRelatedReferences")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session, a_ref,
@@ -483,8 +500,9 @@ class Test_Manager_getRelatedReferences:
 
 
 class Test_Manager_resolve:
-    def test_method_defined_in_cpp(self):
-        assert not is_defined_in_python(Manager.resolve)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(Manager.resolve)
+        assert method_introspector.is_implemented_once(Manager, "resolve")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session, some_refs,
@@ -516,8 +534,9 @@ class Test_Manager_resolve:
 
 
 class Test_Manager_managementPolicy:
-    def test_method_defined_in_cpp(self):
-        assert not is_defined_in_python(Manager.managementPolicy)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(Manager.managementPolicy)
+        assert method_introspector.is_implemented_once(Manager, "managementPolicy")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session, some_entity_trait_sets,
@@ -538,8 +557,9 @@ class Test_Manager_managementPolicy:
 
 
 class Test_Manager_preflight:
-    def test_method_defined_in_python(self):
-        assert is_defined_in_python(Manager.preflight)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert method_introspector.is_defined_in_python(Manager.preflight)
+        assert method_introspector.is_implemented_once(Manager, "preflight")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session, some_refs,
@@ -572,8 +592,9 @@ class Test_Manager_preflight:
 
 
 class Test_Manager_register:
-    def test_method_defined_in_python(self):
-        assert is_defined_in_python(Manager.register)
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(Manager.register)
+        assert method_introspector.is_implemented_once(Manager, "register")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, a_host_session, some_refs,
@@ -626,8 +647,9 @@ class Test_Manager_register:
 
 
 class Test_Manager_createContext:
-    def test_method_defined_in_cpp(self):
-        assert not is_defined_in_python(Manager.createContext)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(Manager.createContext)
+        assert method_introspector.is_implemented_once(Manager, "createContext")
 
     def test_context_is_created_with_expected_properties(
             self, manager, mock_manager_interface, a_host_session):
@@ -645,8 +667,9 @@ class Test_Manager_createContext:
 
 
 class Test_Manager_createChildContext:
-    def test_method_defined_in_cpp(self):
-        assert not is_defined_in_python(Manager.createChildContext)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(Manager.createChildContext)
+        assert method_introspector.is_implemented_once(Manager, "createChildContext")
 
     def test_when_called_with_parent_then_props_copied_and_createState_called_with_parent_state(
             self, manager, mock_manager_interface, a_host_session):
@@ -688,8 +711,9 @@ class Test_Manager_createChildContext:
 
 
 class Test_Manager_persistenceTokenForContext:
-    def test_method_defined_in_cpp(self):
-        assert not is_defined_in_python(Manager.persistenceTokenForContext)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(Manager.persistenceTokenForContext)
+        assert method_introspector.is_implemented_once(Manager, "persistenceTokenForContext")
 
     def test_when_called_then_the_managers_persistence_token_is_returned(
              self, manager, mock_manager_interface, a_host_session):
@@ -718,8 +742,9 @@ class Test_Manager_persistenceTokenForContext:
 
 
 class Test_Manager_contextFromPersistenceToken:
-    def test_method_defined_in_cpp(self):
-        assert not is_defined_in_python(Manager.contextFromPersistenceToken)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(Manager.contextFromPersistenceToken)
+        assert method_introspector.is_implemented_once(Manager, "contextFromPersistenceToken")
 
     def test_when_called_then_the_managers_restored_state_is_set_in_the_context(
              self, manager, mock_manager_interface, a_host_session):
@@ -741,23 +766,3 @@ class Test_Manager_contextFromPersistenceToken:
         a_context = manager.contextFromPersistenceToken("")
         assert a_context.managerState is None
         mock_manager_interface.mock.stateFromPersistenceToken.assert_not_called()
-
-
-#
-# Helpers
-#
-
-def is_defined_in_python(method):
-    """
-    Returns True if the method is defined in Python (as opposed to
-    through a cmodule).
-
-    @param The method of a class to be checked (eg: Manager.info). This
-    should be passed from the Class itself, not an instance.
-    """
-    # The way pybind does its thing™, this returns True for a native
-    # Python implementation, False for a C++ method bound to Python
-    # (isntancemthod not function). Mildly tenuous, but serves a
-    # purpose. getsource and similar raise a TypeError if the supplied
-    # object isn't a function, so the flow control is simpler this way.
-    return inspect.isfunction(method)

--- a/tests/python/openassetio/managerApi/test_managerinterface.py
+++ b/tests/python/openassetio/managerApi/test_managerinterface.py
@@ -30,6 +30,10 @@ from openassetio.managerApi import ManagerInterface, ManagerStateBase
 
 
 class Test_ManagerInterface_identifier:
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(ManagerInterface.identifier)
+        assert method_introspector.is_implemented_once(ManagerInterface, "identifier")
+
     def test_when_not_overridden_then_raises_exception(self):
         with pytest.raises(RuntimeError) as err:
             ManagerInterface().identifier()
@@ -38,6 +42,10 @@ class Test_ManagerInterface_identifier:
 
 
 class Test_ManagerInterface_displayName:
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(ManagerInterface.displayName)
+        assert method_introspector.is_implemented_once(ManagerInterface, "displayName")
+
     def test_when_not_overridden_then_raises_exception(self):
         with pytest.raises(RuntimeError) as err:
             ManagerInterface().displayName()
@@ -46,6 +54,10 @@ class Test_ManagerInterface_displayName:
 
 
 class Test_ManagerInterface_info:
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(ManagerInterface.info)
+        assert method_introspector.is_implemented_once(ManagerInterface, "info")
+
     def test_when_not_overridden_then_returns_empty_dict(self):
         info = ManagerInterface().info()
 
@@ -54,11 +66,19 @@ class Test_ManagerInterface_info:
 
 
 class Test_ManagerInterface_createState:
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(ManagerInterface.createState)
+        assert method_introspector.is_implemented_once(ManagerInterface, "createState")
+
     def test_default_implementation_returns_none(self, a_host_session):
         assert ManagerInterface().createState(a_host_session) is None
 
 
 class Test_ManagerInterface_createChildState:
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(ManagerInterface.createChildState)
+        assert method_introspector.is_implemented_once(ManagerInterface, "createChildState")
+
     def test_default_implementation_raises_RuntimeError(self, a_host_session):
         with pytest.raises(RuntimeError):
             ManagerInterface().createChildState(ManagerStateBase(), a_host_session)
@@ -69,6 +89,12 @@ class Test_ManagerInterface_createChildState:
 
 
 class Test_ManagerInterface_persistenceTokenForState:
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(
+            ManagerInterface.persistenceTokenForState)
+        assert method_introspector.is_implemented_once(
+            ManagerInterface, "persistenceTokenForState")
+
     def test_when_none_is_supplied_then_TypeError_is_raised(self, a_host_session):
         with pytest.raises(TypeError):
             ManagerInterface().persistenceTokenForState(None, a_host_session)
@@ -79,6 +105,12 @@ class Test_ManagerInterface_persistenceTokenForState:
 
 
 class Test_ManagerInterface_stateFromPersistenceToken:
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(
+            ManagerInterface.stateFromPersistenceToken)
+        assert method_introspector.is_implemented_once(
+            ManagerInterface, "stateFromPersistenceToken")
+
     def test_when_none_is_supplied_then_TypeError_is_raised(self, a_host_session):
         with pytest.raises(TypeError):
             ManagerInterface().createChildState(None, a_host_session)
@@ -89,6 +121,10 @@ class Test_ManagerInterface_stateFromPersistenceToken:
 
 
 class Test_ManagerInterface_defaultEntityReference:
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(ManagerInterface.defaultEntityReference)
+        assert method_introspector.is_implemented_once(ManagerInterface, "defaultEntityReference")
+
     def test_when_given_single_trait_set_then_returns_single_empty_ref(self, manager_interface):
         refs = manager_interface.defaultEntityReference([()], Mock(), Mock())
         assert refs == [""]
@@ -100,6 +136,10 @@ class Test_ManagerInterface_defaultEntityReference:
 
 
 class Test_ManagerInterface_entityVersion:
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(ManagerInterface.entityVersion)
+        assert method_introspector.is_implemented_once(ManagerInterface, "entityVersion")
+
     def test_when_given_single_ref_then_returns_single_empty_name(self, manager_interface):
         names = manager_interface.entityVersion([Mock()], Mock(), Mock())
         assert names == [""]
@@ -111,6 +151,10 @@ class Test_ManagerInterface_entityVersion:
 
 
 class Test_ManagerInterface_entityVersions:
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(ManagerInterface.entityVersions)
+        assert method_introspector.is_implemented_once(ManagerInterface, "entityVersions")
+
     def test_when_given_single_ref_then_returns_single_empty_version_dicts(
             self, manager_interface):
         versions = manager_interface.entityVersions([Mock()], Mock(), Mock())
@@ -123,6 +167,9 @@ class Test_ManagerInterface_entityVersions:
 
 
 class Test_ManagerInterface_finalizedEntityVersion:
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(ManagerInterface.finalizedEntityVersion)
+        assert method_introspector.is_implemented_once(ManagerInterface, "finalizedEntityVersion")
 
     def test_when_given_refs_then_returns_refs_unaltered(self, manager_interface):
         refs = Mock()
@@ -133,6 +180,11 @@ class Test_ManagerInterface_finalizedEntityVersion:
 
 
 class Test_ManagerInterface__createEntityReference:
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(
+            ManagerInterface._createEntityReference)  # pylint:disable=protected-access
+        assert method_introspector.is_implemented_once(ManagerInterface, "_createEntityReference")
+
     def test_when_input_is_string_then_wrapped_in_entity_reference(self, manager_interface):
         a_string = "some string"
         # pylint: disable=protected-access


### PR DESCRIPTION
Add test for robustness against forgetful developers migrating Python methods to C++ then leaving the old Python implementation around, masking the new C++ implementation.

I.e. ensure the `Manager` Python class hierarchy only has a single implementation of each method.