### PR TITLE
[CI] Use Ninja CMake generator

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Configure CMake build
         run: >
-          cmake -S . -B build
+          cmake -S . -B build -G Ninja
           --install-prefix $GITHUB_WORKSPACE/dist
           --toolchain $HOME/conan/conan_paths.cmake
           --preset lint
@@ -92,7 +92,7 @@ jobs:
 
       - name: Configure CMake build
         run: >
-          cmake -S . -B build
+          cmake -S . -B build -G Ninja
           --install-prefix $GITHUB_WORKSPACE/dist
           --toolchain $HOME/conan/conan_paths.cmake
           --preset sanitize

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Configure CMake build (Unix)
       if: runner.os != 'Windows'
       run: >
-        cmake -S . -B build
+        cmake -S . -B build -G Ninja
         --install-prefix $GITHUB_WORKSPACE/dist
         --toolchain $HOME/conan/conan_paths.cmake
         --preset test


### PR DESCRIPTION
Part of #484. A no-brainer to speed up builds is to enable parallel compilation.

Using the Ninja generator for CMake gives us this automatically, scaling to the number of CPUs available on the build host. Github CI gives each runner two CPUs.

 We don't get a linear improvement, and the improvement is not as great  as running locally (vCPU vs. real CPU, perhaps), but it's still a quick win that shaves a good 20% off the build time.