### PR TITLE
[Core] Fix `RetainPyArgs` for const ref args

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -68,6 +68,14 @@ v1.0.0-alpha.x
   provided is compatible with C++ trait views.
   [#605](https://github.com/OpenAssetIO/OpenAssetIO/pull/605)
 
+- Fixed the `RetainPyArgs` Python binding helper to
+  work with functions that take `shared_ptr`s by const reference, as
+  well as by value. This affected the Python bindings of
+  `createManagerForInterface`, which would allow the Python objects given
+  to it to go out of scope and be destroyed, despite the associated C++
+  objects remaining alive.
+  [#620](https://github.com/OpenAssetIO/OpenAssetIO/pull/620)
+
 
 v1.0.0-alpha.3
 --------------

--- a/tests/openassetio-python/PyRetainingSharedPtrTest.cpp
+++ b/tests/openassetio-python/PyRetainingSharedPtrTest.cpp
@@ -67,8 +67,14 @@ struct SimpleCppListContainer {
  * PyRetainingSharedPtr decorators.
  */
 struct RetainingSimpleCppContainer : SimpleCppContainer {
-  static RetainingSimpleCppContainer make(std::shared_ptr<SimpleBaseCppType> heldObject) {
+  static RetainingSimpleCppContainer makeFromPtrValue(
+      std::shared_ptr<SimpleBaseCppType> heldObject) {
     return RetainingSimpleCppContainer(std::move(heldObject));
+  }
+
+  static RetainingSimpleCppContainer makeFromConstRefPtr(
+      const std::shared_ptr<SimpleBaseCppType>& heldObject) {
+    return RetainingSimpleCppContainer(heldObject);
   }
 
   using SimpleCppContainer::SimpleCppContainer;
@@ -227,8 +233,12 @@ void registerPyRetainingSharedPtrTestTypes(const py::module_& mod) {
 
   py::class_<RetainingSimpleCppContainer>(mod, "PyRetainingSimpleCppContainer")
       .def(py::init<openassetio::PyRetainingSharedPtr<SimpleBaseCppType>>())
-      .def_static("make", openassetio::RetainPyArgs<std::shared_ptr<SimpleBaseCppType>>::forFn<
-                              &RetainingSimpleCppContainer::make>())
+      .def_static("makeFromPtrValue",
+                  openassetio::RetainPyArgs<std::shared_ptr<SimpleBaseCppType>>::forFn<
+                      &RetainingSimpleCppContainer::makeFromPtrValue>())
+      .def_static("makeFromConstRefPtr",
+                  openassetio::RetainPyArgs<std::shared_ptr<SimpleBaseCppType>>::forFn<
+                      &RetainingSimpleCppContainer::makeFromConstRefPtr>())
       .def("heldObject", &RetainingSimpleCppContainer::heldObject);
 
   py::class_<OtherSimpleBaseCppType, std::shared_ptr<OtherSimpleBaseCppType>,

--- a/tests/python/openassetio_test/test_PyRetainingSharedPtr.py
+++ b/tests/python/openassetio_test/test_PyRetainingSharedPtr.py
@@ -68,7 +68,7 @@ class Test_PyRetainingSharedPtr_arg:
 
     def test_when_using_factory_then_TypeError_reports_expected_type_in_error_message(self):
         with pytest.raises(TypeError) as err:
-            _openassetio_test.PyRetainingSimpleCppContainer.make(123)
+            _openassetio_test.PyRetainingSimpleCppContainer.makeFromPtrValue(123)
 
         assert "SimpleBaseCppType" in str(err.value)
 
@@ -79,7 +79,16 @@ class Test_PyRetainingSharedPtr_arg:
         assert element.value() == 2
 
     def test_when_using_factory_then_python_implementation_is_retained(self):
-        container = _openassetio_test.PyRetainingSimpleCppContainer.make(SimpleCppType())
+        container = _openassetio_test.PyRetainingSimpleCppContainer.makeFromPtrValue(
+            SimpleCppType())
+        element = container.heldObject()
+
+        assert element.value() == 2
+
+    def test_when_using_factory_taking_const_ref_argument_then_python_implementation_is_retained(
+            self):
+        container = _openassetio_test.PyRetainingSimpleCppContainer.makeFromConstRefPtr(
+            SimpleCppType())
         element = container.heldObject()
 
         assert element.value() == 2


### PR DESCRIPTION
Discovered during work on #608

`RetainPyArgs` is a utility to decorate C++ functions such that certain `shared_ptr` arguments are swapped out for equivalent `PyRetainingSharedPtr` arguments. These decorated functions are then used for Python bindings in lieu of the original functions. A custom Pybind type caster then detects `PyRetainingSharedPtr` arguments and ensures any associated Python objects are not destroyed prematurely.

The `RetainPyArgs` helper was using strict type matching when comparing function arguments against its `PtrsToPyRetain` (`shared_ptr`) list. This meant, for example, that a `const shared_ptr<SomeType>&` argument would not match because of the const reference qualifiers.

The decorated function returned from `RetainPyArgs::decorator` would then be missing the expected `PyRetainingSharedPtr<SomeType>` argument(s), so the custom Pybind type caster wouldn't trigger on that argument to extend the lifetime of the associated Python instance.

So ensure the argument type is `std::decay`ed, to remove any qualifiers, before checking for a match.