### PR TITLE
[CI] Add ccache to speed up linter/sanitizer build

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -78,7 +78,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/conan
-          key: ubuntu-20.04-conan
+          key: ubuntu-20.04-conan-${{ github.run_id }}
+          restore-keys: ubuntu-20.04-conan-
 
       - name: Install dependencies
         # Configure the system and install library dependencies via
@@ -127,7 +128,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/conan
-          key: ubuntu-20.04-conan
+          key: ubuntu-20.04-conan-${{ github.run_id }}
+          restore-keys: ubuntu-20.04-conan-
 
       - name: Install dependencies
         # Configure the system and install library dependencies via

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -54,11 +54,24 @@ jobs:
       - name: Check Python formatting
         run: black --check .
 
+  # Note: in order to keep an `actions/cache` cache up to date, we must
+  # use the approach detailed in
+  # https://github.com/actions/cache/blob/main/workarounds.md#update-a-cache
+  # i.e. load the most recently created cache that matches a prefix,
+  # then create an entirely new cache with every run.
+
   cpp-linters:
     name: C++ linters
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+
+      - name: Cache ccache cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: ubuntu-20.04-ccache-lint-${{ github.run_id }}
+          restore-keys: ubuntu-20.04-ccache-lint-
 
       - name: Cache conan packages
         id: cache-conan
@@ -82,18 +95,32 @@ jobs:
       - name: Configure CMake build
         run: >
           cmake -S . -B build -G Ninja
+          -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache
+          -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache
           --install-prefix $GITHUB_WORKSPACE/dist
           --toolchain $HOME/conan/conan_paths.cmake
           --preset lint
 
       - name: Build and lint
-        run: cmake --build build
+        run: |
+          /usr/bin/ccache -s
+          cmake --build build
+          /usr/bin/ccache -s
+        env:
+          CCACHE_DIR: /tmp/ccache
 
   sanitizers:
     name: Sanitizers
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+
+      - name: Cache ccache cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: ubuntu-20.04-ccache-sanitize-${{ github.run_id }}
+          restore-keys: ubuntu-20.04-ccache-sanitize-
 
       - name: Cache conan packages
         id: cache-conan
@@ -113,9 +140,16 @@ jobs:
       - name: Configure CMake build
         run: >
           cmake -S . -B build -G Ninja
+          -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache
+          -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache
           --install-prefix $GITHUB_WORKSPACE/dist
           --toolchain $HOME/conan/conan_paths.cmake
           --preset sanitize
 
       - name: Build and test
-        run: ctest -VV --test-dir build
+        run: |
+          /usr/bin/ccache -s
+          ctest -VV --test-dir build
+          /usr/bin/ccache -s
+        env:
+          CCACHE_DIR: /tmp/ccache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/conan
-        key: ${{ matrix.config.os }}-conan
+        key: ${{ matrix.config.os }}-conan-${{ github.run_id }}
+        restore-keys: ${{ matrix.config.os }}-conan-
 
     - name: Install dependencies (Unix)
       if: runner.os != 'Windows'

--- a/resources/build/bootstrap-ubuntu-20.04.sh
+++ b/resources/build/bootstrap-ubuntu-20.04.sh
@@ -5,7 +5,8 @@
 set -xeo pipefail
 sudo apt-get update
 # Install gcc, linters, build tools used by conan and Python 3.
-sudo apt-get install -y build-essential pkgconf clang-format-12 clang-tidy-12 python3-pip
+sudo apt-get install -y build-essential pkgconf clang-format-12 clang-tidy-12 python3-pip ccache
+
 # Install system packages required for the Python 3.9 conan package.
 # These would be installed as part of the conan package install, but
 # we're caching the conan directory via the `actions/cache` Github


### PR DESCRIPTION
Closes #613. `ccache` can save us ~30-50% in build step times for the C++ linter and sanitizer CI jobs.

Use the `restore-keys` trick to simulate updating a Github `actions/cache` cache, which is technically immutable. I.e. restore the most recently used cache by giving a prefix match to `restore-keys`, and generate a whole new cache to save any updates by giving the prefix plus run id (i.e. a unique key per run) as the `key`.

This will rapidly fill our cache quota, but the Github cache evicts based on least-recently used cache keys, which works for this use case.