### PR TITLE
[Examples] Add `simpleResolver` CLI host example

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,14 @@ v1.0.0-alpha.x
 - Added `[[nodiscard]]` attribute to various `make` factory functions,
   may generate additional compiler warnings in your project.
 
+
+### New Features
+
+- Added `simpleResolver.py` example host (under `resources/examples`),
+  that provides a basic CLI to resolve Entity References for a supplied
+  Trait Set.
+
+
 ### Improvements
 
 - Added 'unstable' warning to docs to notify of python api

--- a/resources/examples/host/simpleResolver/README.md
+++ b/resources/examples/host/simpleResolver/README.md
@@ -1,0 +1,87 @@
+# simpleResolver.py
+
+A simple python CLI that uses OpenAssetIO to resolve a supplied Entity
+Reference for some specified traits to JSON data.
+
+It illustrates a "bare minimum" host implementation, that makes use of
+the default OpenAssetIO config mechanism to initialize a pre-configured
+manager.
+
+## Usage
+
+```
+./simpleResolver.py --help
+usage: simpleResolver.py [-h] traitset entityref
+
+positional arguments:
+  traitset    A comma separated list of traits to resolve eg: trati1,trait2
+  entityref   An entity reference to resolve
+
+optional arguments:
+  -h, --help  show this help message and exit
+```
+
+## Example
+
+The included OpenAssetIO config file sets the API up to use the
+[BasicAssetLibrary](../../manager/BasicAssetLibrary) example asset
+manager, with a simple library containing information about some
+random animals.
+
+We can then use the CLI resolver to query this information.
+
+First off, set your working directory to this folder:
+
+```bash
+cd resources/examples/host/simpeResolver
+```
+
+The CLI doesn't have any configuration options itself, it makes use of
+the [default manager](https://openassetio.github.io/OpenAssetIO/classopenassetio_1_1v1_1_1host_api_1_1_manager_factory.html#a8b6c44543faebcb1b441bbf63c064c76)
+mechanism. We need to tell OpenAssetIO which config file to use:
+
+```bash
+export OPENASSETIO_DEFAULT_CONFIG=bal_animals_openassetio_config.toml
+```
+
+This will tell the API to use BAL, we need to configure the environment
+to add it's plugin to the plugin system search paths:
+
+```bash
+export OPENASSETIO_PLUGIN_PATH=../../manager/BasicAssetLibrary/plugin
+```
+
+At this point, we can now use the CLI to resolve entity data.
+The sample library has two entities `bal:///cat` and `bal:///dog`.
+
+The first argument to the CLI is a list of [traits](https://openassetio.github.io/OpenAssetIO/entities_traits_and_specifications.html)
+to resolve for, the second is the entity reference to resolve:
+
+```bash
+python ./simpleResolver.py animal,named bal:///cat
+python ./simpleResolver.py locatableContent bal:///cat
+```
+
+### Tips and tricks
+
+As output is in JSON format, if you have tools such as
+[`jq`](https://github.com/stedolan/jq) available, you can do fun things
+with it (assuming linux/macOS).
+
+Pretty print the output:
+
+```bash
+python ./simpleResolver.py animal bal:///cat | jq
+```
+
+Extract the name:
+
+```bash
+python ./simpleResolver.py named bal:///cat | jq -r '.named.name'
+```
+
+ASCII art for the win!
+
+```bash
+python ./simpleResolver.py locatableContent bal:///cat | jq -r '.locatableContent.url' | xargs jp2a
+```

--- a/resources/examples/host/simpleResolver/bal_animals.json
+++ b/resources/examples/host/simpleResolver/bal_animals.json
@@ -1,0 +1,26 @@
+{
+	"entities": {
+		"cat": {
+			"versions": [
+				{
+					"traits": {
+						"animal": { "species": "🐈", "age": 12 },
+						"named": { "name": "Martin" },
+						"locatableContent": { "url": "https://placekitten.com/g/300/200" }
+					}
+				}
+			]
+		},
+		"dog": {
+			"versions": [
+				{
+					"traits": {
+						"animal": { "species": "🐕", "age": 2 },
+						"named": { "name": "Pauline" },
+						"locatableContent": { "url": "https://placedog.net/300/200" }
+					}
+				}
+			]
+		}
+	}
+}

--- a/resources/examples/host/simpleResolver/bal_animals_openassetio_config.toml
+++ b/resources/examples/host/simpleResolver/bal_animals_openassetio_config.toml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The Foundry Visionmongers Ltd
+
+[manager]
+identifier = "org.openassetio.examples.manager.bal"
+
+[manager.settings]
+library_path = "bal_animals.json"

--- a/resources/examples/host/simpleResolver/simpleResolver.py
+++ b/resources/examples/host/simpleResolver/simpleResolver.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+#
+#   Copyright 2022 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+A simple CLI that demonstrates resolving an Entity Reference through
+the default OpenAssetIO manager.
+
+Simply supply a set of traits and an entity reference, and the resulting
+data will be output in JSON form.
+"""
+import argparse
+import json
+import sys
+
+
+from openassetio import SpecificationBase
+from openassetio.hostApi import HostInterface, ManagerFactory
+from openassetio.log import ConsoleLogger, SeverityFilter
+from openassetio.pluginSystem import PythonPluginSystemManagerImplementationFactory
+
+
+# pylint: disable=missing-function-docstring,no-self-use,invalid-name
+
+
+#
+## OpenAssetIO required host classes
+#
+
+
+class TestHost(HostInterface):
+    """
+    A minimal host interface implementation. This identifiers the
+    calling tool or application to the API and downstream Manager.
+    """
+
+    def identifier(self):
+        return "default.manager.demo.host"
+
+    def displayName(self):
+        return "Default Manager Demo Host"
+
+
+class CLILocale(SpecificationBase):
+    """
+    A minimal locale that defines a CLI environment.
+    Note: In the future, these common starting points will be moved to a
+    shared repository to avoid inconsistencies/duplication.
+    """
+
+    kTraitSet = {"cli", "demo"}
+
+
+#
+## Batch result callbacks
+#
+# The API is batch-centric for entity related calls. The general
+# approach supplies a list of Entity References to a method, which then
+# calls the success or failure callback for each element of that list
+# with the response from the manager. In the future we plan to provide
+# additional conveniences for single entity tasks, or 'list in list out'
+# use cases.
+
+
+def print_traits_data(_, data):
+    """
+    A callback function that will print out the supplied entity
+    TraitsData. As we only deal with a single result, we ignore the
+    index.
+    """
+    as_dict = {
+        trait_id: {
+            property_key: data.getTraitProperty(trait_id, property_key)
+            for property_key in data.traitPropertyKeys(trait_id)
+        }
+        for trait_id in data.traitSet()
+    }
+    print(json.dumps(as_dict))
+
+
+def fail_with_message(_, batch_element_error):
+    """
+    A callback function that will exit with an appropriate message and
+    error code As we only deal with a single result, we ignore the
+    index.
+    """
+    sys.stderr.write(f"ERROR: {batch_element_error.message}\n")
+    sys.exit(int(batch_element_error.code))
+
+
+#
+# main
+#
+
+
+def create_argparser():
+    """
+    Creates an argparse for the tool.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "traitset", help="A comma separated list of traits to resolve eg: trati1,trait2"
+    )
+    parser.add_argument("entityref", help="An entity reference to resolve")
+    return parser
+
+
+def main():
+
+    # Helpers required by the API
+
+    # A simple logger that prints messages to the console.
+    logger = SeverityFilter(ConsoleLogger())
+
+    # The Python plugin system can load manager implementations
+    # defined outside of the API package.
+    impl_factory = PythonPluginSystemManagerImplementationFactory(logger)
+
+    # The HostInterface implementation we supply that identifies
+    # ourselves to the manager
+    host_interface = TestHost()
+
+    # Initialize the default manager as configured by $OPENASSETIO_DEFAULT_CONFIG
+    # See: https://openassetio.github.io/OpenAssetIO/classopenassetio_1_1v1_1_1host_api_1_1_manager_factory.html#a8b6c44543faebcb1b441bbf63c064c76
+    # All API/Manager messaging is channeled through the supplied logger.
+    manager = ManagerFactory.defaultManagerForInterface(host_interface, impl_factory, logger)
+
+    if not manager:
+        raise RuntimeError(
+            "No default manager configured, "
+            f"check ${ManagerFactory.kDefaultManagerConfigEnvVarName}"
+        )
+
+    # Extract the entity reference and trait set to resolve from
+    # the CLI args
+
+    parser = create_argparser()
+    args = parser.parse_args()
+
+    entity_reference = manager.createEntityReference(args.entityref)
+    trait_set = set(args.traitset.split(","))
+
+    # Create an OpenAssetIO context that describes the calling
+    # environment
+
+    context = manager.createContext()
+    context.access = context.Access.kRead
+    context.locale = CLILocale.create().traitsData()
+
+    # Resolve the requested traits for the referenced entity
+
+    manager.resolve(
+        [entity_reference],  # The API is batch-centric
+        trait_set,
+        context,
+        print_traits_data,  # success callback
+        fail_with_message,  # error callback
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # pylint: disable=broad-except
+        sys.stderr.write(f"ERROR: {exc}\n")
+        sys.exit(1)

--- a/resources/examples/host/simpleResolver/test_simpleResolver.py
+++ b/resources/examples/host/simpleResolver/test_simpleResolver.py
@@ -1,0 +1,131 @@
+#
+#   Copyright 2022 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Test cases for the simpleResolver CLI.
+"""
+
+import json
+import subprocess
+import pathlib
+import pytest
+import sys
+
+
+from openassetio import BatchElementError
+from openassetio.hostApi import ManagerFactory
+
+# pylint: disable=no-self-use
+# pylint: disable=invalid-name,redefined-outer-name
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+
+class Test_simpleResolver_errors:
+    def test_when_config_env_not_set_then_message_printed_and_return_code_is_one(self):
+        result = execute_cli()
+        expected_message = [
+            "ERROR: No default manager configured, "
+            f"check ${ManagerFactory.kDefaultManagerConfigEnvVarName}"
+        ]
+        assert result.stderr.splitlines() == expected_message
+        assert result.returncode == 1
+
+    def test_when_config_set_and_plugin_path_not_set_then_error_and_return_code_wrapped(
+        self, test_config_env  # pylint: disable=unused-argument
+    ):
+        result = execute_cli()
+        expected_message = [
+            "\x1b[0;33m    warning: OPENASSETIO_PLUGIN_PATH is not set. "
+            "It is somewhat unlikely that you will find any plugins...\033[0m",
+            "ERROR: PythonPluginSystem: No plug-in registered with the identifier "
+            "'org.openassetio.examples.manager.bal'",
+        ]
+        assert result.stderr.splitlines() == expected_message
+        assert result.returncode == 1
+
+    def test_when_env_set_and_no_args_then_usage_printed_and_return_code_is_one(
+        self, test_config_env, bal_env  # pylint: disable=unused-argument
+    ):
+        result = execute_cli()
+        expected_message = [
+            "usage: simpleResolver.py [-h] traitset entityref",
+            "simpleResolver.py: error: the following arguments are required: traitset, entityref",
+        ]
+        assert result.stderr.splitlines() == expected_message
+        assert result.returncode == 2
+
+    def test_when_entity_ref_and_trait_set_valid_then_expected_data_output_and_return_code_zero(
+        self, test_config_env, bal_env  # pylint: disable=unused-argument
+    ):
+        result = execute_cli("animal,named", "bal:///cat")
+        data = json.loads(result.stdout)
+        expected_data = {
+            "animal": {"species": "🐈", "age": 12},
+            "named": {"name": "Martin"},
+        }
+        assert data == expected_data
+        assert result.returncode == 0
+
+    def test_when_entity_ref_valid_and_trait_set_invalid_then_data_empty_and_return_code_zero(
+        self, test_config_env, bal_env  # pylint: disable=unused-argument
+    ):
+        result = execute_cli("someMissingTrait", "bal:///cat")
+        data = json.loads(result.stdout)
+        assert data == {}
+        assert result.returncode == 0
+
+    def test_when_entity_ref_invalid_then_error_and_return_code_wrapped(
+        self, test_config_env, bal_env  # pylint: disable=unused-argument
+    ):
+        result = execute_cli("named", "bal:///doesNotExist")
+        expected_message = ["ERROR: Entity 'bal:///doesNotExist' not found"]
+        assert result.stderr.splitlines() == expected_message
+        assert result.returncode == int(BatchElementError.ErrorCode.kEntityResolutionError)
+
+
+def execute_cli(*args):
+    """
+    Executes simplerResolver with the supplied args, as per subprocess.run.
+    """
+    this_file = pathlib.Path(__file__)
+    cli_path = this_file.parent / "simpleResolver.py"
+    all_args = [sys.executable, str(cli_path)]
+    all_args.extend(args)
+    # We explicitly don't want an exception to be raised.
+    # pylint: disable=subprocess-run-check
+    return subprocess.run(all_args, capture_output=True, encoding="utf-8", cwd=this_file.parent)
+
+
+@pytest.fixture
+def bal_env(monkeypatch):
+    """
+    A fixture that configures the process environment such that the
+    OpenAssetIO library can load the BAL test manager plugin.
+    """
+    this_file = pathlib.Path(__file__)
+    examples_dir = this_file.parents[2]
+    bal_plugin_dir = examples_dir / "manager" / "BasicAssetLibrary" / "plugin"
+    monkeypatch.setenv("OPENASSETIO_PLUGIN_PATH", str(bal_plugin_dir))
+
+
+@pytest.fixture
+def test_config_env(monkeypatch):
+    """
+    A fixture that configures the process environment such that the
+    OpenAssetIO default config points to the example toml file.
+    """
+    this_file = pathlib.Path(__file__)
+    config_file = this_file.parent / "bal_animals_openassetio_config.toml"
+    monkeypatch.setenv("OPENASSETIO_DEFAULT_CONFIG", str(config_file))


### PR DESCRIPTION
Adds a very simple CLI host, that resolves the supplied entity reference for the given trait set. The resulting data is written to stdout as JSON.

This was a sprint demo, but since the addition of the OPENASSETIO_DEFAULT_CONFIG mechanism in #608, it's generally a lot more useful to the wider world.