### PR TITLE
Unstable warning on non-ported python functionality

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,17 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+
+### Improvements
+
+- Added 'unstable' warning to docs to notify of python api
+  that has not yet been updated for the C++ api,
+  and is thus inherently unstable.
+  [#600](https://github.com/OpenAssetIO/OpenAssetIO/issues/600)
+
+
 v1.0.0-alpha.4
 --------------
 

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -252,7 +252,8 @@ ALIASES                = "envvar=\xrefitem envvar \"Environment Variables\" \"En
                          "event=\xrefitem event \"Events\" \"Event List\"" \
                          "needsref=" \
                          "fqref{1}=@ref openassetio::$(OPENASSETIO_CORE_ABI_VERSION)::\1" \
-                         "fqcref{1}=@ref oa_\1"
+                         "fqcref{1}=@ref oa_\1" \
+                         "unstable=@warning This method or class has not been updated for the new C++ API and may be subject to a changes in signature in subsequent releases."
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/python/openassetio/exceptions.py
+++ b/python/openassetio/exceptions.py
@@ -28,6 +28,8 @@ class OpenAssetIOException(RuntimeError):
     Managers and any API-related exceptions raised in a Host. These
     exceptions are guaranteed to properly bridge across the C plugin
     divide...
+
+    @unstable
     """
 
 
@@ -35,6 +37,8 @@ class UserCanceled(OpenAssetIOException):
     """
     Thrown by the progress mechanism to interrupt execution whenever the
     user cancels an action (perhaps using an on-screen button).
+
+    @unstable
     """
 
     def __str__(self):
@@ -50,6 +54,8 @@ class UserCanceled(OpenAssetIOException):
 class ManagerException(OpenAssetIOException):
     """
     A base class for exceptions relating to, or raised by a manager.
+
+    @unstable
     """
 
 
@@ -57,6 +63,8 @@ class StateError(ManagerException):
     """
     Thrown by managers in error situations relating to the
     managerState object.
+
+    @unstable
     """
 
 
@@ -64,6 +72,8 @@ class RetryableError(ManagerException):
     """
     Thrown by managers in error situations that can be safely retried
     with idempotent behavior.
+
+    @unstable
     """
 
 
@@ -81,6 +91,8 @@ class BaseEntityException(ManagerException):
     A base Exception for any @ref entity related errors to ensure
     consistent presentation and encapsulation of the associated @ref
     entity_reference.
+
+    @unstable
     """
 
     def __init__(self, message, entityReference=None):
@@ -106,6 +118,8 @@ class InvalidEntityReference(BaseEntityException):
     """
     Thrown whenever an Entity-based action is performed on an
     unrecognized @ref entity_reference.
+
+    @unstable
     """
 
     def __init__(self, message="Invalid Entity Reference", entityReference=None):
@@ -116,6 +130,8 @@ class MalformedEntityReference(BaseEntityException):
     """
     Thrown whenever an Entity-based action is performed on a
     malformed @ref entity_reference.
+
+    @unstable
     """
 
     def __init__(self, message="Malformed Entity Reference", entityReference=None):
@@ -129,6 +145,8 @@ class EntityResolutionError(BaseEntityException):
     some other reason. It is also used during version finalisation and
     any other entity-based operations on a valid @ref entity_reference
     that fail for some reason.
+
+    @unstable
     """
 
     def __init__(self, message="Error resolving entity", entityReference=None):
@@ -138,6 +156,8 @@ class EntityResolutionError(BaseEntityException):
 class BaseEntityInteractionError(BaseEntityException):
     """
     A base class for errors relating to entity-centric actions.
+
+    @unstable
     """
 
 
@@ -145,6 +165,8 @@ class PreflightError(BaseEntityInteractionError):
     """
     Thrown to represent some error during pre-flight that isn't due to
     any specific of the @ref entity_reference itself.
+
+    @unstable
     """
 
 
@@ -152,6 +174,8 @@ class RegistrationError(BaseEntityInteractionError):
     """
     Thrown to represent some error during registration that isn't due to
     any specific of the @ref entity_reference itself.
+
+    @unstable
     """
 
 
@@ -162,4 +186,6 @@ class PluginError(OpenAssetIOException):
     """
     Thrown by the plugin system in relation to errors encountered
     during the loading/initialization of plugins.
+
+    @unstable
     """

--- a/python/openassetio/hostApi/Manager.py
+++ b/python/openassetio/hostApi/Manager.py
@@ -123,6 +123,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         @param[out] stringDict `Dict[str, str]` Dictionary that is
         modified in-place by the manager if it has any alternate
         terminology.
+
+        @unstable
         """
         self.__impl.updateTerminology(stringDict, self.__hostSession)
         # This is purely so we can see it in the debug log, the
@@ -144,6 +146,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         makes use of any caching, otherwise it is a no-op.  In caching
         interfaces, this should cause any retained data to be discarded
         to ensure future queries are fresh.
+
+        @unstable
         """
         return self.__impl.flushCaches(self.__hostSession)
 
@@ -188,6 +192,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         @return `List[bool]` `True` if the corresponding element in
         entityRefs points to an existing entity, `False` if the entity
         is not known or ready yet.
+
+        @unstable
         """
         return self.__impl.entityExists(entityRefs, context, self.__hostSession)
 
@@ -221,6 +227,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
 
         @return `List[str]` An @ref entity_reference or empty string for
         each given trait set.
+
+        @unstable
         """
         return self.__impl.defaultEntityReference(traitSets, context, self.__hostSession)
 
@@ -256,6 +264,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
 
         @return `List[str]` Strings containing any valid characters for
         the manager's implementation.
+
+        @unstable
         """
         return self.__impl.entityName(entityRefs, context, self.__hostSession)
 
@@ -286,6 +296,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         characters for the @ref asset_management_system's
         implementation; or an `InvalidEntityReference` if the supplied
         reference is not recognised by the asset management system.
+
+        @unstable
         """
         return self.__impl.entityDisplayName(entityRefs, context, self.__hostSession)
 
@@ -324,6 +336,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
 
         @see @ref entityVersions
         @see @ref finalizedEntityVersion
+
+        @unstable
         """
         return self.__impl.entityVersion(entityRefs, context, self.__hostSession)
 
@@ -359,6 +373,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
 
         @see @ref entityVersion
         @see @ref finalizedEntityVersion
+
+        @unstable
         """
         return self.__impl.entityVersions(
             entityRefs,
@@ -407,6 +423,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
 
         @see @ref entityVersion
         @see @ref entityVersions
+
+        @unstable
         """
         return self.__impl.finalizedEntityVersion(
             entityRefs, context, self.__hostSession, overrideVersionName=overrideVersionName
@@ -521,6 +539,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         @exception ValueError If more than one reference and
         relationship is provided, but they lists are not equal in
         length, ie: not a 1:1 mapping of entities to relationships.
+
+        @unstable
 
         @todo Implement missing setRelatedReferences()
         """

--- a/python/openassetio/hostApi/terminology.py
+++ b/python/openassetio/hostApi/terminology.py
@@ -67,6 +67,8 @@ class Mapper:
     """
     The Mapper class provides string substitution methods and lookups to
     determine the correct terminology for the supplied @ref manager.
+
+    @unstable
     """
 
     def __init__(self, manager, terminology=defaultTerminology):

--- a/python/openassetio/managerApi/ManagerInterface.py
+++ b/python/openassetio/managerApi/ManagerInterface.py
@@ -187,6 +187,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         @see @ref openassetio.constants "constants"
         @see @ref openassetio.hostApi.terminology.defaultTerminology
         "terminology.defaultTerminology"
+
+        @unstable
         """
 
     ## @}
@@ -202,6 +204,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         implementation makes use of any caching, otherwise it is a
         no-op. In caching interfaces, this should cause any retained
         data to be discarded to ensure future queries are fresh.
+
+        @unstable
         """
 
     ## @}
@@ -246,6 +250,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         @return `List[bool]` `True` if the corresponding element in
         entityRefs points to an existing entity, `False` if the entity
         is not known or ready yet.
+
+        @unstable
         """
         raise NotImplementedError
 
@@ -299,6 +305,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
 
         @return `List[str]` An @ref entity_reference or empty string for
         each given trait set.
+
+        @unstable
         """
         return ["" for _ in traitSets]
 
@@ -338,6 +346,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
 
         @return `List[str]` Strings containing any valid characters for
         the manager's implementation.
+
+        @unstable
         """
         raise NotImplementedError
 
@@ -372,6 +382,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         characters for the @ref asset_management_system's
         implementation; or an `InvalidEntityReference` if the supplied
         reference is not recognised by the asset management system.
+
+        @unstable
         """
         raise NotImplementedError
 
@@ -412,6 +424,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
 
         @see @ref entityVersions
         @see @ref finalizedEntityVersion
+
+        @unstable
         """
         return ["" for _ in entityRefs]
 
@@ -452,6 +466,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
 
         @see @ref entityVersion
         @see @ref finalizedEntityVersion
+
+        @unstable
         """
         return [{} for _ in entityRefs]
 
@@ -497,6 +513,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
 
         @see @ref entityVersion
         @see @ref entityVersions
+
+        @unstable
         """
         return entityRefs
 
@@ -617,6 +635,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         function.
 
         @see @ref setRelatedReferences
+
+        @unstable
         """
         raise NotImplementedError
 
@@ -666,6 +686,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
 
         @see @ref getRelatedReferences
         @see @ref register
+
+        @unstable
         """
         if not self.entityExists(entityRef, context, hostSession):
             raise exceptions.InvalidEntityReference(entityReference=entityRef)


### PR DESCRIPTION
Closes #600 
Add an @unstable doxygen alias, which warns that a method/function has not yet been ported to C++ and is liable to change. Adds this tag to all as-yet-unported methods/classes in the python api.