### PR TITLE
[Examples] Add note on runtime requirements to `simpleResolver.py` docs

### DIFF
--- a/resources/examples/host/simpleResolver/README.md
+++ b/resources/examples/host/simpleResolver/README.md
@@ -23,6 +23,11 @@ optional arguments:
 
 ## Example
 
+> Note: This script requires the `openassetio` module to be available to
+> Python. Presently, this requires manual installation, see
+> [BUILDING.md](../../../../BUILDING.md) in the main OpenAssetIO
+> repository for more details.
+
 The included OpenAssetIO config file sets the API up to use the
 [BasicAssetLibrary](../../manager/BasicAssetLibrary) example asset
 manager, with a simple library containing information about some


### PR DESCRIPTION
This was inadvertently lost in a PR revision edit to the copy. It has been proven useful to highlight these things in the past.
