### PR TITLE
[Core] Add logging convenience methods

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -46,6 +46,10 @@ v1.0.0-alpha.x
   now automatically installs python dependencies of enabled components.
   [#629](https://github.com/OpenAssetIO/OpenAssetIO/issues/629)
 
+- Added convenience methods `debugApi`, `debug`, `info`, `progress`,
+  `warning`, `error`, `critical` to `LoggerInterface` to log messages of
+  the respective severity.
+
 
 v1.0.0-alpha.4
 --------------

--- a/src/openassetio-core/include/openassetio/log/LoggerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/log/LoggerInterface.hpp
@@ -49,6 +49,26 @@ class OPENASSETIO_CORE_EXPORT LoggerInterface {
    * Severity.
    */
   virtual void log(Severity severity, const Str& message) = 0;
+
+  /**
+   * @name Conveniences
+   * @{
+   *
+   * Conveniences, equivalent to calling @ref LoggerInterface.log "log"
+   * with the corresponding @ref Severity.
+   */
+
+  void debugApi(const Str& message);
+  void debug(const Str& message);
+  void info(const Str& message);
+  void progress(const Str& message);
+  void warning(const Str& message);
+  void error(const Str& message);
+  void critical(const Str& message);
+
+  /**
+   * @}
+   */
 };
 }  // namespace log
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-core/log/LoggerInterface.cpp
+++ b/src/openassetio-core/log/LoggerInterface.cpp
@@ -9,6 +9,21 @@ namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace log {
 LoggerInterface::~LoggerInterface() = default;
+
+void LoggerInterface::debugApi(const Str &message) { log(Severity::kDebugApi, message); }
+
+void LoggerInterface::debug(const Str &message) { log(Severity::kDebug, message); }
+
+void LoggerInterface::info(const Str &message) { log(Severity::kInfo, message); }
+
+void LoggerInterface::progress(const Str &message) { log(Severity::kProgress, message); }
+
+void LoggerInterface::warning(const Str &message) { log(Severity::kWarning, message); }
+
+void LoggerInterface::error(const Str &message) { log(Severity::kError, message); }
+
+void LoggerInterface::critical(const Str &message) { log(Severity::kCritical, message); }
+
 }  // namespace log
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-python/module/log/LoggerInterfaceBinding.cpp
+++ b/src/openassetio-python/module/log/LoggerInterfaceBinding.cpp
@@ -46,5 +46,12 @@ void registerLoggerInterface(const py::module& mod) {
   loggerInterface.def_readonly_static("kSeverityNames", &LoggerInterface::kSeverityNames);
 
   loggerInterface.def(py::init())
-      .def("log", &LoggerInterface::log, py::arg("severity"), py::arg("message"));
+      .def("log", &LoggerInterface::log, py::arg("severity"), py::arg("message"))
+      .def("debugApi", &LoggerInterface::debugApi, py::arg("message"))
+      .def("debug", &LoggerInterface::debug, py::arg("message"))
+      .def("info", &LoggerInterface::info, py::arg("message"))
+      .def("progress", &LoggerInterface::progress, py::arg("message"))
+      .def("warning", &LoggerInterface::warning, py::arg("message"))
+      .def("error", &LoggerInterface::error, py::arg("message"))
+      .def("critical", &LoggerInterface::critical, py::arg("message"));
 }

--- a/tests/python/openassetio/test_log.py
+++ b/tests/python/openassetio/test_log.py
@@ -131,6 +131,47 @@ class Test_LoggerInterface:
         for index, severity in enumerate(all_severities):
             assert severity.value == index
 
+    def test_debugApi_calls_log_with_expected_severity_and_message(self, mock_logger):
+        message = "a debugApi message"
+        mock_logger.debugApi(message)
+        mock_logger.mock.log.assert_called_once_with(
+            lg.LoggerInterface.Severity.kDebugApi, message
+        )
+
+    def test_debug_calls_log_with_expected_severity_and_message(self, mock_logger):
+        message = "a debug message"
+        mock_logger.debug(message)
+        mock_logger.mock.log.assert_called_once_with(lg.LoggerInterface.Severity.kDebug, message)
+
+    def test_info_calls_log_with_expected_severity_and_message(self, mock_logger):
+        message = "an info message"
+        mock_logger.info(message)
+        mock_logger.mock.log.assert_called_once_with(lg.LoggerInterface.Severity.kInfo, message)
+
+    def test_progress_calls_log_with_expected_severity_and_message(self, mock_logger):
+        message = "a progress message"
+        mock_logger.progress(message)
+        mock_logger.mock.log.assert_called_once_with(
+            lg.LoggerInterface.Severity.kProgress, message
+        )
+
+    def test_warning_calls_log_with_expected_severity_and_message(self, mock_logger):
+        message = "a warning message"
+        mock_logger.warning(message)
+        mock_logger.mock.log.assert_called_once_with(lg.LoggerInterface.Severity.kWarning, message)
+
+    def test_error_calls_log_with_expected_severity_and_message(self, mock_logger):
+        message = "an error message"
+        mock_logger.error(message)
+        mock_logger.mock.log.assert_called_once_with(lg.LoggerInterface.Severity.kError, message)
+
+    def test_critical_calls_log_with_expected_severity_and_message(self, mock_logger):
+        message = "a critical message"
+        mock_logger.critical(message)
+        mock_logger.mock.log.assert_called_once_with(
+            lg.LoggerInterface.Severity.kCritical, message
+        )
+
 
 class Test_SeverityFilter_inheritance:
     def test_class_is_final(self):


### PR DESCRIPTION
The severity + message signature of `LoggerInterface::log` becomes somewhat verbose in regular use. We want to encourage implementations to make good use of `debug` and similar, these conveniences hopefully reduce to overhead of adding "useful logging".

@elliotcmorris @feltech Let me know if there are better/more performant ways of implementing this, went for the "simple" option in my aged brain.