### PR TITLE
Package wheels CI workflow

### DIFF
--- a/.github/bootstrap_platform/action.yml
+++ b/.github/bootstrap_platform/action.yml
@@ -32,7 +32,7 @@ runs:
     run: |
       source resources/build/bootstrap-${{ matrix.config.os }}.sh
     env:
-      WORKSPACE: .
+      WORKSPACE: ${{ github.workspace }}
     # Annoyingly required for Github composite actions.
     shell: bash
 
@@ -43,6 +43,6 @@ runs:
     run: |
       cmd /C resources\build\bootstrap-${{ matrix.config.os }}.bat
     env:
-      WORKSPACE: .
+      WORKSPACE: ${{ github.workspace }}
     # Annoyingly required for Github composite actions.
     shell: cmd

--- a/.github/workflows/build-instructions.yml
+++ b/.github/workflows/build-instructions.yml
@@ -1,5 +1,4 @@
 # A simple workflow that runs the documented build steps work.
-
 name: Build Instructions
 on:
   pull_request:
@@ -58,7 +57,7 @@ jobs:
         ${{ matrix.config.preamble }}
         pip install .
       env:
-        CMAKE_TOOLCHAIN_FILE: ~/conan/conan_paths.cmake
+        CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/.conan/conan_paths.cmake
 
     - name: Install test dependencies
       run: pip install -r tests/python/requirements.txt

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,76 @@
+name: Build Wheels
+
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  pull_request:
+    branches-ignore:
+      - docs
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.config.os }} - ${{matrix.python-build}}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config: 
+          - os: ubuntu-20.04
+            shell: bash
+          # - os: macos-10.15
+          #   shell: bash
+          - os: windows-2019
+            preamble: call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64
+            shell: cmd
+          # These are the platform build strings provided to
+          # cibuildwheel, with wildcarding. See
+          # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
+        python-build: ['cp39*64', 'cp310*64']
+    defaults:
+      run:
+        # Annoyingly required here since `matrix` isn't available in the
+        # `shell` property of individual steps.
+        shell: ${{ matrix.config.shell }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Bootstrap
+        uses: ./.github/bootstrap_platform
+        env:
+          # As we're building wheels inside a managed environment,
+          # (cibuildwheels) there is no need to install cpython. 
+          OPENASSETIO_CONAN_SKIP_CPYTHON: "True"
+
+      - name: Build wheels
+        run: |
+          ${{ matrix.config.preamble }}
+          pip install cibuildwheel==2.11.1
+          cibuildwheel --output-dir wheelhouse
+        env: 
+          # Windows + Mac runs use this environment variable, as they
+          # execute directly on the runner. Linux runs are somewhat
+          # different, and are containerised fully, therefore they get
+          # their toolchain path from pyproject.toml
+          CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/.conan/conan_paths.cmake
+          # We matrix the python build here ourselves, rather than
+          # letting cibuildwheel do its regular python matrix, as we
+          # want to allow a full release pipeline to run "vertically" on
+          # CI, on individual agents, rather than building every python
+          # version sequentially on each platform. This is done less for
+          # performance reasons (although it does help) and more so a
+          # single failing python version won't interrupt every other
+          # deploy on that platform.
+          CIBW_BUILD: ${{ matrix.python-build }}
+          CIBW_SKIP: '*musllinux* *arm64*'
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          PIP_VERBOSE: 1
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: "openassetio-wheels"
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,6 +1,6 @@
 name: Code quality
 on: pull_request
-
+  
 jobs:
   pylint:
     runs-on: ubuntu-latest
@@ -25,7 +25,7 @@ jobs:
         run: |
           python -m pip install .
         env:
-          CMAKE_TOOLCHAIN_FILE: ~/conan/conan_paths.cmake
+          CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/.conan/conan_paths.cmake
 
       - name: Lint
         uses: TheFoundryVisionmongers/fn-pylint-action@v1.1
@@ -98,8 +98,8 @@ jobs:
           cmake -S . -B build -G Ninja
           -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache
           -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache
-          --install-prefix $GITHUB_WORKSPACE/dist
-          --toolchain $HOME/conan/conan_paths.cmake
+          --install-prefix ${{ github.workspace }}/dist
+          --toolchain ${{ github.workspace }}/.conan/conan_paths.cmake
           --preset lint
 
       - name: Build and lint
@@ -135,8 +135,8 @@ jobs:
           cmake -S . -B build -G Ninja
           -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache
           -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache
-          --install-prefix $GITHUB_WORKSPACE/dist
-          --toolchain $HOME/conan/conan_paths.cmake
+          --install-prefix ${{ github.workspace }}/dist
+          --toolchain ${{ github.workspace }}/.conan/conan_paths.cmake
           --preset sanitize
 
       - name: Build and test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,17 @@ jobs:
         # environments.
         config:
         - os: windows-2019
-          vcvars: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat"
+          preamble: call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64
+          shell: cmd
         - os: ubuntu-20.04
+          shell: bash
         - os: macos-10.15
+          shell: bash
+    defaults:
+      run:
+        # Annoyingly required here since `matrix` isn't available in
+        # the `shell` property of individual steps.
+        shell: ${{ matrix.config.shell }}
 
     steps:
     - uses: actions/checkout@v2
@@ -30,36 +38,20 @@ jobs:
     - name: Bootstrap
       uses: ./.github/bootstrap_platform
 
-    - name: Configure CMake build (Unix)
-      if: runner.os != 'Windows'
+    - name: Configure CMake build
       run: >
+        ${{ matrix.config.preamble }}
+
         cmake -S . -B build -G Ninja
-        --install-prefix $GITHUB_WORKSPACE/dist
-        --toolchain $HOME/conan/conan_paths.cmake
+        --install-prefix ${{ github.workspace }}/dist
+        --toolchain ${{ github.workspace }}/.conan/conan_paths.cmake
         --preset test
 
-    - name: Configure CMake build (Windows)
-      if: runner.os == 'Windows'
+    - name: Build, install and test
       run: >
-        call "${{ matrix.config.vcvars }}"
-
-        cmake -G Ninja -S . -B build --install-prefix %GITHUB_WORKSPACE%\dist
-        --toolchain %USERPROFILE%\conan\conan_paths.cmake -DCMAKE_VERBOSE_MAKEFILE=ON
-        --preset test
-
-      shell: cmd
-
-    - name: Build, install and test (Unix)
-      if: runner.os != 'Windows'
-      run: |
+        ${{ matrix.config.preamble }}
+        
         ctest -VV --test-dir build --parallel 2
-
-    - name: Build, install and test (Windows)
-      if: runner.os == 'Windows'
-      run: |
-        call "${{ matrix.config.vcvars }}"
-        ctest -VV --test-dir build --parallel 2
-      shell: cmd
 
   docs:
     runs-on: ubuntu-latest

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -126,7 +126,7 @@ vagrant up
 # Wait a while...
 vagrant ssh
 cmake -S openassetio -B build --install-prefix ~/dist \
-  --toolchain ~/conan/conan_paths.cmake
+  --toolchain ~/.conan/conan_paths.cmake
 ```
 
 Then we can run the usual steps (see above) to build and install

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -61,6 +61,15 @@ v1.0.0-alpha.x
   `warning`, `error`, `critical` to `LoggerInterface` to log messages of
   the respective severity.
 
+- Added `OPENASSETIO_CONAN_SKIP_CPYTHON` environment variable to prevent
+  conan installing its own python version. This is to support workflows
+  where the user is bringing their own python environment, and does not 
+  want python installations to conflict.
+  [#653](https://github.com/OpenAssetIO/OpenAssetIO/issues/653)]
+
+- Bleeding edge python wheels are now downloadable as artifacts from the
+  `Build wheels` github actions workflow.
+  [[#653](https://github.com/OpenAssetIO/OpenAssetIO/issues/653)]
 
 v1.0.0-alpha.4
 --------------

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,11 @@ v1.0.0-alpha.x
   `OPENASSETIO_ENABLE_PYTHON_TEST_VENV` is enabled.
   [#629](https://github.com/OpenAssetIO/OpenAssetIO/issues/629)
 
+- Changed `--install-folder` location of conan install in bootstrap
+  scripts from `$CONAN_USER_HOME` to `$WORKSPACE/.conan`. Users who
+  have been using the bootstrap scripts directly may need to update
+  their toolchain CMake arguments.
+
 ### New Features
 
 - Added `simpleResolver.py` example host (under `resources/examples`),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,3 +115,13 @@ ignore-imports = true
 [tool.black]
 line-length = 99
 target-version = ["py39"]
+
+[tool.cibuildwheel]
+test-requires = ["pytest"]
+test-command = "pytest {package}/tests/python/openassetio"
+
+[tool.cibuildwheel.linux]
+# Linux runs in a docker container, with the project at top level
+before-build = "resources/build/bootstrap-cibuildwheel-manylinux-2014.sh"
+environment = { CMAKE_TOOLCHAIN_FILE=".conan/conan_paths.cmake" }
+environment-pass = ["PIP_VERBOSE"]

--- a/resources/build/bootstrap-cibuildwheel-manylinux-2014.sh
+++ b/resources/build/bootstrap-cibuildwheel-manylinux-2014.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -xeo pipefail
+
+# This script not runnable from outside a cibuildwheel environment.
+if [ "$CIBUILDWHEEL" != "1" ]
+then
+  echo "Error. Attempting to run cibuildwheel-manylinux bootstrap outside of cibuildwheel"
+  exit 1
+fi
+
+# Install additional build tools.
+pip3 install -r "resources/build/requirements.txt"
+# Use explicit predictable conan root path, where packages are cached.
+export CONAN_USER_HOME="$HOME/conan"
+
+# Create default conan profile so we can configure it before instlibXcomposite-develall.
+# Use --force so that if it already exists we don't error out.
+conan profile new default --detect --force
+# Use old C++11 ABI as per VFX Reference Platform CY2022. Not strictly
+# necessary as this is the default for conan, but we can't be certain
+# it'll remain the default in future.
+conan profile update settings.compiler.libcxx=libstdc++ default
+
+# Install openassetio third-party dependencies from public Conan Center
+# package repo.
+export OPENASSETIO_CONAN_SKIP_CPYTHON="True"
+conan install --install-folder ".conan" --build=missing \
+    "resources/build"

--- a/resources/build/bootstrap-macos-10.15.sh
+++ b/resources/build/bootstrap-macos-10.15.sh
@@ -11,6 +11,7 @@ export CONAN_USER_HOME="$HOME/conan"
 # Create default conan profile so we can configure it before install.
 # Use --force so that if it already exists we don't error out.
 conan profile new default --detect --force
+
 # Install openassetio third-party dependencies from public Conan Center
 # package repo.
 conan install --install-folder "$WORKSPACE/.conan" --build=missing \

--- a/resources/build/bootstrap-macos-10.15.sh
+++ b/resources/build/bootstrap-macos-10.15.sh
@@ -6,13 +6,12 @@ set -xeo pipefail
 
 # Install additional build tools.
 pip3 install -r "$WORKSPACE/resources/build/requirements.txt"
-# Use explicit predictable conan root path, to be used for both packages
-# and conan CMake toolchain config.
+# Use explicit predictable conan root path, where packages are cached.
 export CONAN_USER_HOME="$HOME/conan"
 # Create default conan profile so we can configure it before install.
 # Use --force so that if it already exists we don't error out.
 conan profile new default --detect --force
 # Install openassetio third-party dependencies from public Conan Center
 # package repo.
-conan install --install-folder "$CONAN_USER_HOME" --build=missing \
+conan install --install-folder "$WORKSPACE/.conan" --build=missing \
     "$WORKSPACE/resources/build"

--- a/resources/build/bootstrap-ubuntu-20.04.sh
+++ b/resources/build/bootstrap-ubuntu-20.04.sh
@@ -22,8 +22,7 @@ sudo apt-get install -y --no-install-recommends libfontenc-dev libice-dev libsm-
 
 # Install additional build tools.
 sudo pip3 install -r "$WORKSPACE/resources/build/requirements.txt"
-# Use explicit predictable conan root path, to be used for both packages
-# and conan CMake toolchain config.
+# Use explicit predictable conan root path, where packages are cached.
 export CONAN_USER_HOME="$HOME/conan"
 # Create default conan profile so we can configure it before install.
 # Use --force so that if it already exists we don't error out.
@@ -39,7 +38,7 @@ conan profile update settings.compiler.libcxx=libstdc++ default
 # system packages are already available. In particular, this affects
 # recent versions of the xorg/system recipe (a dependency of cpython).
 # The problem is reported and fixed in https://github.com/conan-io/conan/pull/11712
-conan install --install-folder "$CONAN_USER_HOME" --build=missing \
+conan install --install-folder "$WORKSPACE/.conan" --build=missing \
     -c tools.system.package_manager:mode=install \
     -c tools.system.package_manager:sudo=True \
     "$WORKSPACE/resources/build"

--- a/resources/build/bootstrap-windows-2019.bat
+++ b/resources/build/bootstrap-windows-2019.bat
@@ -7,6 +7,7 @@ set CONAN_USER_HOME=%USERPROFILE%\conan
 :: Use --force so that if it already exists we don't error out.
 conan profile new default --detect --force
 conan profile show default
+
 :: Install openassetio third-party dependencies from public Conan Center
 :: package repo.
 conan install --install-folder "%WORKSPACE%\.conan" ^

--- a/resources/build/bootstrap-windows-2019.bat
+++ b/resources/build/bootstrap-windows-2019.bat
@@ -1,6 +1,7 @@
 @echo off
 :: Install additional build tools.
 pip3 install -r "%WORKSPACE%\resources\build\requirements.txt"
+:: Use explicit predictable conan root path, where packages are cached.
 set CONAN_USER_HOME=%USERPROFILE%\conan
 :: Create default conan profile so we can configure it before install.
 :: Use --force so that if it already exists we don't error out.
@@ -8,4 +9,5 @@ conan profile new default --detect --force
 conan profile show default
 :: Install openassetio third-party dependencies from public Conan Center
 :: package repo.
-conan install --install-folder "%CONAN_USER_HOME%" --build=missing "%WORKSPACE%\resources\build"
+conan install --install-folder "%WORKSPACE%\.conan" ^
+              --build=missing "%WORKSPACE%\resources\build"

--- a/resources/build/conanfile.py
+++ b/resources/build/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 
 
 class OpenAssetIOConan(ConanFile):
@@ -7,17 +7,17 @@ class OpenAssetIOConan(ConanFile):
         # which augments package search paths with conan package
         # directories.
         "cmake_paths",
-        # Generate `Find<PackageName>.cmake` finders, required for
-        # various public ConanCenter packages (e.g. pybind11) since they
-        # disallow bundling of `<PackageName>Config.cmake`-like files in
-        # the package.
+        # Generate `Find<PackageName>.cmake` finders, required for various
+        # public ConanCenter packages (e.g. pybind11) since they disallow
+        # bundling of `<PackageName>Config.cmake`-like files in the package.
         "cmake_find_package",
     )
     settings = "os"
 
     def build_requirements(self):
         # CY2022
-        self.tool_requires("cpython/3.9.7")
+        if not tools.get_env("OPENASSETIO_CONAN_SKIP_CPYTHON", False):
+            self.tool_requires("cpython/3.9.7")
         # Same as ASWF CY2022 Docker image:
         # https://github.com/AcademySoftwareFoundation/aswf-docker/blob/master/ci-base/README.md
         self.tool_requires("pybind11/2.8.1")


### PR DESCRIPTION
Add workflow that invokes `cibuildwheel` to build a set of python wheels upon push to main branch (or manual invocation)
Prerequisite for having an automated PyPI release pipeline, but useful in its own right. Will archive built wheels into github storage for later retrieval.

Currently, we create 4 wheels, win-x86_64-python3.9, win-x86_64-python3.10, manylinux-x86_64-python3.9, manylinux-x86_64-python3.10
 
---
#### `cibuildwheel' platform differences
It's worth noting that `cibuildwheel` has a very different paradigm when building on linux platforms vs mac and windows. On linux platforms, a docker container is invoked, (using the `manylinux` images,) whereas on windows and mac, a virtual environment is configured directly inside the existing environment.

This is the reason you'll see a new bootstrapping script, as we need to bootstrap this docker container, which is centOS.

---
#### Running the action.
This action uses `workflow_dispatch`, so as well as running upon push/merge to master, is runnable from the `Build Wheels` section on the [Actions](https://github.com/elliotcmorris/OpenAssetIO/actions/workflows/build-wheels.yml) page. Be sure to select the correct branch.

Whilst we wait for that to cook, here's one I made earlier : [Link](https://github.com/elliotcmorris/OpenAssetIO/actions/runs/3291239068)