### PR TITLE
[CI] Enable Dependabot tracking of GitHub Action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"  # See docs, they say not to use '.github'
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[CI]"


### PR DESCRIPTION
Actions deprecation warnings only show up in the detailed logs for an action, so are easily missed.

Part of #668.

Im not entirely sure how best to test this!

Notes: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file