### PR TITLE
PyPI Release Process

### DIFF
--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -1,0 +1,56 @@
+name: Deploy_PyPI
+
+on: 
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  # testpypi and pypi are done as two seperate jobs due to a potential
+  # fail in the pypi upload, and wanting to be able to rerun just the
+  # mainline pypi upload. This can happen when pypi goes into read 
+  # only mode, which happens sometimes.
+  publish_testpypi:
+    name: Publish distribution 📦 to TestPyPI
+    runs-on: ubuntu-20.04
+    steps:
+      # This action will download the artifact for workflow runs that
+      # happen for this actual commit (the commit that the tag points to).
+      # It also restores the files timestamps.
+      # This does however mean that when making a release, you must be
+      # sure that the build-wheels job on main has completed
+      - name: Download wheels from commit ${{ github.sha }}
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          commit: ${{ github.sha }}
+          name: openassetio-wheels
+          path: dist
+
+      - name: Upload to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_ACCESS_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+  publish_pypi:
+    name: Publish distribution 📦 to PyPI
+    needs: publish_testpypi
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download wheels from commit ${{ github.sha }}
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          commit: ${{ github.sha }}
+          name: openassetio-wheels
+          path: dist
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_ACCESS_TOKEN }}


### PR DESCRIPTION
Closes #653 

Release workflow for uploading to pypi, including verification tests.
Runs upon a release being created, or upon being manually triggered.

### [Release in action](https://github.com/elliotcmorris/OpenAssetIO/actions/runs/3339481952)

Above release run was done prior to this PR. (I had the changeset on main at the time to most fully replicate the expected environment.) Notice that the real pyPI upload fails, the reason for this being that this fork intentionally dosen't have the real pyPI secret on it.

Putting this up as a draft as there's a few things I want to run by some folks and perhaps change, and seeing the source is helpful. Although it's not really a lot of code anyway...

---
### Questions and Concerns

**1.** Python Venvs. We discussed doing the testing in a virtual environment, but i'm really not sure if it's necessary in this formulation. As the testing is done in a dependent job, one should be be able to assume a clean environment, and not really need to insulate. If it were up to me i'd remove the usage of venvs here. Thoughts?

**2.** This workflow uses 2 thirdparty actions, which i don't relish depending on, although i'd relish rolling our own even less.

-- **2.1.** The first, SebRollen/toml-action@v1.0.1, is used to parse our toml file, and extract the version string. This lets us pin the version for the test pip install, so we can be certain we're querying for the correct version. (This is good as it verifies we've actually uploaded all the architectures we're planning to test.)

-- **2.2.** The second, nick-fields/retry@v2, is used due to `testPyPI` not immediately reporting downloadable packages after upload, it can take a little while to propagate. During testing, occasionally some machines didn't report the new version for the platform as yet uploaded, but on retry, it functioned as expected. Normally a retry is not required, but occasionally I have been seeing this step needing be be reran once. A little bit dubious about this, because having time dependencies is never good. Whilst during testing I was observing gaps of 5-10s being the difference maker, it's no guarantee that we'll be able to see the libs even within the minute timeframe I've given the install step.

[here's an example of a run that failed due to this ](https://github.com/elliotcmorris/OpenAssetIO/actions/runs/3337524613/jobs/5524066932)

**3.** I could still be convinced that doing any testing at all on built wheels isn't worth it, even to this more limited, release time only degree. It would remove the dependency on testPyPI entirely, and allow us to remove practically all of the complexity from this workflow.


... Also added some emojis because I like the way they look in the github UI.