### PR TITLE
Bump CI runners to macOS-11

### DIFF
--- a/.github/workflows/build-instructions.yml
+++ b/.github/workflows/build-instructions.yml
@@ -38,7 +38,7 @@ jobs:
             shell: cmd
           - os: ubuntu-20.04
             shell: bash
-          - os: macos-10.15
+          - os: macos-11
             shell: bash
     defaults:
       run:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -21,8 +21,8 @@ jobs:
         config: 
           - os: ubuntu-20.04
             shell: bash
-          # - os: macos-10.15
-          #   shell: bash
+          - os: macos-11
+            shell: bash
           - os: windows-2019
             preamble: call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64
             shell: cmd

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -69,6 +69,8 @@ jobs:
           CIBW_SKIP: '*musllinux* *arm64*'
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           PIP_VERBOSE: 1
+          # Required as we make use of c++17 features
+          MACOSX_DEPLOYMENT_TARGET: 10.15
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,6 +1,6 @@
 name: Build Wheels
 
-on: 
+on:
   push:
     branches:
       - main
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: 
+        config:
           - os: ubuntu-20.04
             shell: bash
           - os: macos-11
@@ -43,7 +43,7 @@ jobs:
         uses: ./.github/bootstrap_platform
         env:
           # As we're building wheels inside a managed environment,
-          # (cibuildwheels) there is no need to install cpython. 
+          # (cibuildwheels) there is no need to install cpython.
           OPENASSETIO_CONAN_SKIP_CPYTHON: "True"
 
       - name: Build wheels
@@ -51,7 +51,7 @@ jobs:
           ${{ matrix.config.preamble }}
           pip install cibuildwheel==2.11.1
           cibuildwheel --output-dir wheelhouse
-        env: 
+        env:
           # Windows + Mac runs use this environment variable, as they
           # execute directly on the runner. Linux runs are somewhat
           # different, and are containerised fully, therefore they get

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           shell: cmd
         - os: ubuntu-20.04
           shell: bash
-        - os: macos-10.15
+        - os: macos-11
           shell: bash
     defaults:
       run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,8 @@ cmake_minimum_required(VERSION 3.21)
 # Additional include directories for CMake utils.
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
-# TODO(DF): Set CMAKE_OSX_DEPLOYMENT_TARGET when it's time to tackle OSX
+# Minimum required for the C++17 features used.
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
 
 # Forbid in-source builds.
 if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})

--- a/resources/build/bootstrap-macos-11.sh
+++ b/resources/build/bootstrap-macos-11.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# This bootstrap script is used by both the Github CI action and the
+# Vagrant VM configuration.
+
+set -xeo pipefail
+
+# macOS 11 runners ship with clang 13. Conan Center only has pre-built
+# binaries for clang 12. This allows packages to be built locally.
+brew install automake autoconf
+
+# Install additional build tools.
+pip3 install -r "$WORKSPACE/resources/build/requirements.txt"
+# Use explicit predictable conan root path, where packages are cached.
+export CONAN_USER_HOME="$HOME/conan"
+# Create default conan profile so we can configure it before install.
+# Use --force so that if it already exists we don't error out.
+conan profile new default --detect --force
+
+# Install openassetio third-party dependencies from public Conan Center
+# package repo.
+conan install --install-folder "$WORKSPACE/.conan" --build=missing \
+    "$WORKSPACE/resources/build"


### PR DESCRIPTION
The issue was that 11 comes with Clang 13, for which there are no re-built packages on Conan. This adds `automake` tools so that Conan can build them locally. They should then be cached so hopefully this won't impact normal CI run times.