### PR TITLE
Bump pybind to 2.10.0, build for Python 3.11

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,7 +33,7 @@ jobs:
           # These are the platform build strings provided to
           # cibuildwheel, with wildcarding. See
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-        python-build: ['cp37*64', 'cp39*64', 'cp310*64']
+        python-build: ['cp37*64', 'cp39*64', 'cp310*64', 'cp311*64']
     defaults:
       run:
         # Annoyingly required here since `matrix` isn't available in the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -95,6 +95,9 @@ v1.0.0-alpha.5
   `Build wheels` github actions workflow.
   [#653](https://github.com/OpenAssetIO/OpenAssetIO/issues/653)
 
+- Updated pybind to `2.10.0` for wheel builds to support Python `3.11`.
+
+
 v1.0.0-alpha.4
 --------------
 

--- a/resources/build/conanfile.py
+++ b/resources/build/conanfile.py
@@ -18,9 +18,8 @@ class OpenAssetIOConan(ConanFile):
         # CY2022
         if not tools.get_env("OPENASSETIO_CONAN_SKIP_CPYTHON", False):
             self.tool_requires("cpython/3.9.7")
-        # Same as ASWF CY2022 Docker image:
-        # https://github.com/AcademySoftwareFoundation/aswf-docker/blob/master/ci-base/README.md
-        self.tool_requires("pybind11/2.8.1")
+        # Later versions required to support more recent Python versions
+        self.tool_requires("pybind11/2.10.0")
         # Test framework
         self.tool_requires("catch2/2.13.8")
         # Mocking library


### PR DESCRIPTION
Hopefully should allow us to support Python 3.11 wheels

Closes #683