### PR TITLE
[CI] Populate cache on push to main/feature branches

### DIFF
--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -1,0 +1,29 @@
+# A dummy workflow that populates the runner with dependencies
+# and pops them in the actions cache, so we know there is
+# always a fallback for subsequent PRs
+#
+name: Populate Runner Cache
+on:
+  push:
+    branches:
+      - main
+      - feature/**
+
+jobs:
+  cache:
+    name: ${{ matrix.config.os }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # config.os vs os to match requirements of bootstrap_platform
+        config:
+          - os: ubuntu-20.04
+          - os: macos-11
+          - os: windows-2019
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Bootstrap
+      uses: ./.github/bootstrap_platform


### PR DESCRIPTION
This should hopefully allow us to populate the actions cache to speed up first-runs on PRs. These are currently very slow, now we have to build certain conan packages on macOS (see #680).

Signed-off-by: Tom Cowland <tom@foundry.com>

Closes #686 