### PR TITLE
[CI] Set concurrency groups for CI jobs

### DIFF
--- a/.github/workflows/build-instructions.yml
+++ b/.github/workflows/build-instructions.yml
@@ -7,6 +7,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   aswf-docker:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -11,6 +11,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.config.os }} - ${{matrix.python-build}}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,6 +1,10 @@
 name: Code quality
 on: pull_request
-  
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pylint:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron: '24 22 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/commit-checks.yml
+++ b/.github/workflows/commit-checks.yml
@@ -1,6 +1,10 @@
 name: Commit policy
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   commits_check_job:
     runs-on: ubuntu-latest

--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -9,6 +9,10 @@ on:
       - main
       - feature/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cache:
     name: ${{ matrix.config.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: ${{ matrix.config.os }}
@@ -50,7 +54,7 @@ jobs:
     - name: Build, install and test
       run: >
         ${{ matrix.config.preamble }}
-        
+
         ctest -VV --test-dir build --parallel 2
 
   docs:


### PR DESCRIPTION
This should ensure that we don't waste runners repeatedly running jobs for out-of-date commits.

Anchoring to `github.ref`[1] seems like it should "do the right thing" so they are unique to each PR/etc.

[1] https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

Closes #696 

It can be seen in action [here](https://github.com/foundrytom/OpenAssetIO/actions).