### PR TITLE
[CI] Update action versions

### DIFF
--- a/.github/bootstrap_platform/action.yml
+++ b/.github/bootstrap_platform/action.yml
@@ -12,14 +12,14 @@ runs:
   steps:
 
   - name: Set up Python
-    uses: actions/setup-python@v2
+    uses: actions/setup-python@v4
     with:
       # CY2022 (https://vfxplatform.com)
       python-version: "3.9"
 
   - name: Cache conan packages
     id: cache-conan
-    uses: actions/cache@v2
+    uses: actions/cache@v3
     with:
       path: ~/conan
       key: ${{ matrix.config.os }}-conan-${{ github.run_id }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -82,7 +82,7 @@ jobs:
         uses: ./.github/bootstrap_platform
 
       - name: Cache ccache cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/ccache
           key: ubuntu-20.04-ccache-lint-${{ github.run_id }}
@@ -128,7 +128,7 @@ jobs:
         uses: ./.github/bootstrap_platform
 
       - name: Cache ccache cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/ccache
           key: ubuntu-20.04-ccache-sanitize-${{ github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
         ! grep -qE "^.*?/src/[^:]+:[0-9]+: ?[a-zA-Z]+: ?.*$" doxygen-log.txt
 
     - name: Expose archive docs artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: doxygen-documentation
         path: doc/html


### PR DESCRIPTION
Avoids assorted deprecations. For some reason Dependabot didn't spot these. Hopefully this will remove the remaining warnings on CI runs.