### PR TITLE
[Build] Update Pybind to support Python 3.11

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,7 +33,7 @@ jobs:
           # These are the platform build strings provided to
           # cibuildwheel, with wildcarding. See
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-        python-build: ['cp37*64', 'cp39*64', 'cp310*64']
+        python-build: ['cp37*64', 'cp39*64', 'cp310*64', 'cp311*64']
     defaults:
       run:
         # Annoyingly required here since `matrix` isn't available in the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+
+### Improvements
+
+- Updated pybind to `2.10.0` for wheel builds to support Python `3.11`.
+
 v1.0.0-alpha.6
 --------------
 

--- a/resources/build/conanfile.py
+++ b/resources/build/conanfile.py
@@ -18,9 +18,9 @@ class OpenAssetIOConan(ConanFile):
         # CY2022
         if not tools.get_env("OPENASSETIO_CONAN_SKIP_CPYTHON", False):
             self.tool_requires("cpython/3.9.7")
-        # Same as ASWF CY2022 Docker image:
-        # https://github.com/AcademySoftwareFoundation/aswf-docker/blob/master/ci-base/README.md
-        self.tool_requires("pybind11/2.8.1")
+        # Later versions than ASWF CY2022 (pybind11 v2.8.1) required to
+        # support more recent Python versions.
+        self.tool_requires("pybind11/2.10.0")
         # Test framework
         self.tool_requires("catch2/2.13.8")
         # Mocking library

--- a/tests/python/openassetio/test_batchelementerror.py
+++ b/tests/python/openassetio/test_batchelementerror.py
@@ -62,11 +62,11 @@ class Test_BatchElementError_init:
     def test_when_code_modified_then_raises_AttributeError(self):
         a_batch_element_error = BatchElementError(BatchElementError.ErrorCode.kUnknown, "whatever")
 
-        with pytest.raises(AttributeError, match="can't set attribute"):
+        with pytest.raises(AttributeError, match="property of 'BatchElementError' object has no setter"):
             a_batch_element_error.code = BatchElementError.ErrorCode.kUnknown
 
     def test_when_message_modified_then_raises_AttributeError(self):
         a_batch_element_error = BatchElementError(BatchElementError.ErrorCode.kUnknown, "whatever")
 
-        with pytest.raises(AttributeError, match="can't set attribute"):
+        with pytest.raises(AttributeError, match="property of 'BatchElementError' object has no setter"):
             a_batch_element_error.message = "whatever"


### PR DESCRIPTION
Closes #683 

In order to support building python 3.11 wheels, update pybind. This causes the error messages to change, which we test against, so also update those messages.