### PR TITLE
[Docs] Add missing fields to DR 13

### DIFF
--- a/decisions/DR013-Project-structure.md
+++ b/decisions/DR013-Project-structure.md
@@ -3,8 +3,8 @@
 - **Status:** Proposed
 - **Impact:** Low
 - **Driver:** @feltech
-- **Approver:** @tomfoundry
-- **Outcome:**
+- **Approver:** @tomfoundry @elliotcmorris
+- **Outcome:** Restructure to group sources by component.
 
 
 ## Background
@@ -142,6 +142,7 @@ org.
 * Plugins for DCC tools under subdirectories of the repo-root `vendor`
   directory, with additional scripts under subdirectories of the
   repo-root `share` directory.
+
 
 ## Options considered
 


### PR DESCRIPTION
Fixing up #627. This was merged a little prematurely. Add missing fields, plus an extra whitespace fix to match the template.