### PR TITLE
[CI] Don't build wheels on PR

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-  pull_request:
-    branches-ignore:
-      - docs
-    paths-ignore:
-      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
CI is very slow (approx 12 mins). By not building wheels on PR (only `main`) we can halve the time taken (first push to this PR took 7 mins)
