### PR TITLE
[CI] Fix Doxygen docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,4 +41,4 @@ jobs:
         git config --global user.name "GitHub Actions"
         git config --global user.email "github-actions@github.com"
         # Pass the path to the actions/checkout@v3 docs branch checkout
-        OPENASSETIO_DOCS_REPO_DIR=`pwd`/target make -C src/doc deploy
+        OPENASSETIO_DOCS_REPO_DIR=`pwd`/target make -C src/doc/doxygen deploy


### PR DESCRIPTION
After merging the project restructure (#740), deployment of generated Doxygen docs failed. So fix the erroneous path.
