### PR TITLE
[Core] Conform Python to C++ method argument names

### DIFF
--- a/src/openassetio-python/module/src/TraitsDataBinding.cpp
+++ b/src/openassetio-python/module/src/TraitsDataBinding.cpp
@@ -22,23 +22,24 @@ void registerTraitsData(const py::module& mod) {
       .def(py::init(static_cast<TraitsDataPtr (*)()>(&TraitsData::make)))
       .def(py::init(static_cast<TraitsDataPtr (*)(const trait::TraitSet&)>(&TraitsData::make)),
            py::arg("traitSet"))
-      .def(py::init(static_cast<TraitsDataPtr (*)(const TraitsDataConstPtr&)>(&TraitsData::make)))
+      .def(py::init(static_cast<TraitsDataPtr (*)(const TraitsDataConstPtr&)>(&TraitsData::make)),
+           py::arg("other"))
       .def("traitSet", &TraitsData::traitSet)
-      .def("hasTrait", &TraitsData::hasTrait, py::arg("id"))
-      .def("addTrait", &TraitsData::addTrait)
-      .def("addTraits", &TraitsData::addTraits)
-      .def("setTraitProperty", &TraitsData::setTraitProperty, py::arg("id"),
+      .def("hasTrait", &TraitsData::hasTrait, py::arg("traitId"))
+      .def("addTrait", &TraitsData::addTrait, py::arg("traitId"))
+      .def("addTraits", &TraitsData::addTraits, py::arg("traitSet"))
+      .def("setTraitProperty", &TraitsData::setTraitProperty, py::arg("traitId"),
            py::arg("propertyKey"), py::arg("propertyValue").none(false))
       .def(
           "getTraitProperty",
           [](const TraitsData& self, const trait::TraitId& traitId,
-             const property::Key& key) -> MaybeValue {
-            if (property::Value out; self.getTraitProperty(&out, traitId, key)) {
+             const property::Key& propertyKey) -> MaybeValue {
+            if (property::Value out; self.getTraitProperty(&out, traitId, propertyKey)) {
               return out;
             }
             return {};
           },
-          py::arg("id"), py::arg("key"))
-      .def("traitPropertyKeys", &TraitsData::traitPropertyKeys, py::arg("id"))
+          py::arg("traitId"), py::arg("propertyKey"))
+      .def("traitPropertyKeys", &TraitsData::traitPropertyKeys, py::arg("traitId"))
       .def(py::self == py::self);  // NOLINT(misc-redundant-expression)
 }

--- a/src/openassetio-python/module/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/module/src/hostApi/ManagerBinding.cpp
@@ -32,7 +32,7 @@ void registerManager(const py::module& mod) {
       .def("info", &Manager::info)
       .def("settings", &Manager::settings)
       .def("initialize", &Manager::initialize, py::arg("managerSettings"))
-      .def("managementPolicy", &Manager::managementPolicy, py::arg("traitSet"),
+      .def("managementPolicy", &Manager::managementPolicy, py::arg("traitSets"),
            py::arg("context").none(false))
       .def("createContext", &Manager::createContext)
       .def("createChildContext", &Manager::createChildContext,
@@ -52,17 +52,18 @@ void registerManager(const py::module& mod) {
       .def(
           "register",
           [](Manager& self, const EntityReferences& entityReferences,
-             const trait::TraitsDatas& traitsDatas, const ContextConstPtr& context,
+             const trait::TraitsDatas& entityTraitsDatas, const ContextConstPtr& context,
              const Manager::RegisterSuccessCallback& successCallback,
              const openassetio::BatchElementErrorCallback& errorCallback) {
             // Pybind has no built-in way to assert that a collection
             // does not contain any `None` elements, so we must add our
             // own check here.
-            if (std::any_of(traitsDatas.begin(), traitsDatas.end(),
+            if (std::any_of(entityTraitsDatas.begin(), entityTraitsDatas.end(),
                             std::logical_not<TraitsDataPtr>{})) {
               throw pybind11::type_error{"Traits data cannot be None"};
             }
-            self.register_(entityReferences, traitsDatas, context, successCallback, errorCallback);
+            self.register_(entityReferences, entityTraitsDatas, context, successCallback,
+                           errorCallback);
           },
           py::arg("entityReferences"), py::arg("entityTraitsDatas"),
           py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"))

--- a/src/openassetio-python/module/src/log/SeverityFilterBinding.cpp
+++ b/src/openassetio-python/module/src/log/SeverityFilterBinding.cpp
@@ -18,6 +18,6 @@ void registerSeverityFilter(const py::module& mod) {
       .def(py::init(RetainCommonPyArgs::forFn<&SeverityFilter::make>()),
            py::arg("upstreamLogger").none(false))
       .def("getSeverity", &SeverityFilter::getSeverity)
-      .def("setSeverity", &SeverityFilter::setSeverity)
+      .def("setSeverity", &SeverityFilter::setSeverity, py::arg("severity"))
       .def("upstreamLogger", &SeverityFilter::upstreamLogger);
 }

--- a/src/openassetio-python/module/src/managerApi/ManagerInterfaceBinding.cpp
+++ b/src/openassetio-python/module/src/managerApi/ManagerInterfaceBinding.cpp
@@ -128,7 +128,7 @@ void registerManagerInterface(const py::module& mod) {
       .def("settings", &ManagerInterface::settings, py::arg("hostSession").none(false))
       .def("initialize", &ManagerInterface::initialize, py::arg("managerSettings"),
            py::arg("hostSession").none(false))
-      .def("managementPolicy", &ManagerInterface::managementPolicy, py::arg("traitSet"),
+      .def("managementPolicy", &ManagerInterface::managementPolicy, py::arg("traitSets"),
            py::arg("context").none(false), py::arg("hostSession").none(false))
       .def("createState", &ManagerInterface::createState, py::arg("hostSession").none(false))
       .def("createChildState", RetainCommonPyArgs::forFn<&ManagerInterface::createChildState>(),


### PR DESCRIPTION
Closes #743. Fix class methods in Python bindings to have the same argument names as the C++ member functions they're wrapping, insomuch as that is possible/relevant.

A quick-and-dirty `libclang`-based script was used for the majority of the mismatch detection (see issue). Manual checks were still required for constructors and other Python methods where the script couldn't find a C++ match.  

Any non-method symbols were skimmed over but not checked thoroughly (enums, constants, member variables, etc).