### PR TITLE
Block fixup merges.

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,13 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  # Prevent any PR's being merge that have fixup commits in them
+  block-fixup:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
Closes #746 

Add a small integration that prevents fixup commits being merged.
Only takes 10s or so to run, and only needs to run on the one platform, so not a big CI load.

Note how the fixup before the force push [failed](https://github.com/OpenAssetIO/OpenAssetIO/actions/runs/3533323086/jobs/5928798700), as there was a fixup, and after, they [succeed](https://github.com/OpenAssetIO/OpenAssetIO/actions/runs/3533336591/jobs/5928829222).

Note : One could argue that the DCO checks will also serve to catch fixups, because they tend not to be signed, but i've had this nearly catch me out before, when using the github UI to make fixup commits, which allows signing now, and I guess there's no law written that fixups coming in arn't signed.