### PR TITLE
Add issue/PR template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,26 @@
+---
+name: Feature
+about: Generic template for a proposed OpenAssetIO feature
+title: Feature Title
+labels: ''
+assignees: ''
+
+---
+
+## What
+<!---Describe the final goal of the task, what should it accomplish.--->
+## Why
+<!---Why does this task need to get done at all?--->
+
+## Acceptance Criteria
+<!---
+An exhaustive list of falsifiable outcomes that define fully whether
+this task is complete.
+
+Remember to consider:
+
+- Release note updates.
+- Documentation updates.
+- Additional tests or test updates.
+- Impact on dependent repos.
+--->

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request.md
@@ -1,0 +1,16 @@
+## Description
+
+Closes # (issue)
+
+- [ ] I have updated the release notes.
+- [ ] I have updated all relevant user documentation.
+
+## Reviewer Notes
+
+<!--- Provide any notes to the reviewer that might help them more easily
+      understand the changeset. --->
+
+## Test Instructions
+
+<!--- Provide instructions to the reviewer on how to explicitly test
+      these changes. --->


### PR DESCRIPTION
## Description

Add minimal issue template and minimal pull request template, as discussed at retro.

The main purpose of the issue template is to include a refinement reminder checklist so we remember to discuss release-notes, docs, and tests when doing planning.

The main purpose of the pull request template is to include a reminder to write notes to make the review easier, as well as notes on how to test your changeset. Also adds a reminder to have a #closes tag

Have attempted to keep these as minimal as possible because it's very easy for these things to become bloated and useless.

## Reviewer Notes

I'm not entirely sure the pull-request template justifies its own existence, let me know what you think, it can be annoying deleting non-relevant sections all the time. Conversely, it is nice to have these around though, occasionally a nice "oh that can just go in the template" thought manifests.