### PR TITLE
[CI] Block PyPI deploy whilst wheels are building

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -12,7 +12,7 @@ on:
       - 'docs/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: wheel-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -5,6 +5,12 @@ on:
     types: [published]
   workflow_dispatch:
 
+concurrency:
+  # Shared with `build-wheels`.
+  group: wheel-${{ github.ref }}
+  # Allow `build-wheels` to finish.
+  cancel-in-progress: false
+
 jobs:
   # testpypi and pypi are done as two seperate jobs due to a potential
   # fail in the pypi upload, and wanting to be able to rerun just the


### PR DESCRIPTION
Avoids PyPI release failing if the wheels haven't built yet.