### PR TITLE
[Docs] Warn GIL required for Python plugin system

### DIFF
--- a/src/openassetio-python/bridge/include/openassetio/python/hostApi.hpp
+++ b/src/openassetio-python/bridge/include/openassetio/python/hostApi.hpp
@@ -19,6 +19,9 @@ namespace hostApi {
 /**
  * Retrieve an instance of the the Python plugin system implementation.
  *
+ * @warning This function requires the Python GIL to be acquired prior
+ * to being called.
+ *
  * @return Python plugin system.
  */
 OPENASSETIO_PYTHON_BRIDGE_EXPORT openassetio::hostApi::ManagerImplementationFactoryInterfacePtr


### PR DESCRIPTION

## Description

Until #797 is properly addressed, add a warning to the Doxygen docs for `createPythonPluginSystemManagerImplementationFactory` that the Python GIL must be acquired before using it.

## Reviewer Notes

This is just a temporary fix until we add the code to acquire the GIL in the function.

## Test Instructions
```
cd docs/Doxygen
make
```
Then view `file:///path/to/OpenAssetIO/doc/doxygen/html/namespaceopenassetio_1_1v1_1_1python_1_1host_api.html`.
