### PR TITLE
[Core] Acquire GIL before C++ imports Python plugin system

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,14 @@ v1.0.0-alpha.X
 - Disabled the (nascent) C bindings by default. To enable, the
   `OPENASSETIO_ENABLE_C` CMake option must be explicitly set to `ON`.
 
+### Bug fixes
+
+- Ensured that the Python GIL is acquired within
+  `createPythonPluginSystemManagerImplementationFactory`, so that it is
+  no longer necessary to acquire externally by the calling (host)
+  thread.
+  [#797](https://github.com/OpenAssetIO/OpenAssetIO/issues/797)
+
 
 v1.0.0-alpha.8
 --------------

--- a/src/openassetio-python/bridge/include/openassetio/python/hostApi.hpp
+++ b/src/openassetio-python/bridge/include/openassetio/python/hostApi.hpp
@@ -19,9 +19,6 @@ namespace hostApi {
 /**
  * Retrieve an instance of the the Python plugin system implementation.
  *
- * @warning This function requires the Python GIL to be acquired prior
- * to being called.
- *
  * @return Python plugin system.
  */
 OPENASSETIO_PYTHON_BRIDGE_EXPORT openassetio::hostApi::ManagerImplementationFactoryInterfacePtr

--- a/src/openassetio-python/bridge/src/python/hostApi.cpp
+++ b/src/openassetio-python/bridge/src/python/hostApi.cpp
@@ -22,6 +22,9 @@ using openassetio::hostApi::ManagerImplementationFactoryInterfacePtr;
 
 ManagerImplementationFactoryInterfacePtr createPythonPluginSystemManagerImplementationFactory(
     log::LoggerInterfacePtr logger) {  // NOLINT(performance-unnecessary-value-param)
+  // Caller might not hold the GIL, which is required for `import`s.
+  py::gil_scoped_acquire gil{};
+
   // Get Python class.
   py::object pyClass =
       py::module_::import(

--- a/src/openassetio-python/tests/bridge/python/test_hostApi.cpp
+++ b/src/openassetio-python/tests/bridge/python/test_hostApi.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 The Foundry Visionmongers Ltd
 
+#include <pybind11/gil.h>
 #include <catch2/catch.hpp>
 #include <catch2/trompeloeil.hpp>
 
@@ -17,6 +18,9 @@ using trompeloeil::_;
 
 SCENARIO("Accessing the Python plugin system from C++") {
   GIVEN("a logger") {
+    // Release the GIL to ensure GIL-safe handling of Python import.
+    pybind11::gil_scoped_release gil{};
+
     openassetio::log::LoggerInterfacePtr logger = std::make_shared<MockLogger>();
     auto& mockLogger = static_cast<MockLogger&>(*logger);
 


### PR DESCRIPTION
Fixes #797. 

If the host thread does not hold the GIL when `createPythonPluginSystemManagerImplementationFactory` is called, then segfaults abound when trying to `import` the Python plugin system via pybind11.

So ensure the GIL is acquired first. pybind11's `gil_scoped_acquire` is clever enough to restore the state to whatever it was before, upon function exit.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.

## Reviewer Notes

Note that, as described below, this can be tested using OpenAssetIO's CTest suite, so no need for changes to the OpenAssetIO-Test-CMake integration test project to check this fix.

## Test Instructions

The `openassetio.internal.python-bridge-test` CTest in OpenAssetIO has been updated to trigger the bug.  If you leave that change, but remove the fix, and run CTest, then the segfault (or exception, if in Debug mode) will be apparent.