### PR TITLE
[Core] Fix PyObject cleanup if interpreter gone

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,11 @@ v1.0.0-alpha.X
   thread.
   [#797](https://github.com/OpenAssetIO/OpenAssetIO/issues/797)
 
+- Fixed use-after-free issue in hybrid C++/Python applications, where
+  the Python interpreter is destroyed before OpenAssetIO objects are
+  cleaned up. This could manifest as segfaults or hangs at program exit.
+  [#805](https://github.com/OpenAssetIO/OpenAssetIO/pull/805)
+
 
 v1.0.0-alpha.8
 --------------

--- a/src/openassetio-python/tests/cmodule/CMakeLists.txt
+++ b/src/openassetio-python/tests/cmodule/CMakeLists.txt
@@ -32,3 +32,5 @@ openassetio_add_test_fixture_dependencies(
     openassetio.internal.install
 )
 openassetio_add_test_venv_fixture_dependency(openassetio.internal.pytest.cmodule)
+# Use-after-free can result in hangs, so set a timeout.
+set_tests_properties(openassetio.internal.pytest.cmodule PROPERTIES TIMEOUT 30)

--- a/src/openassetio-python/tests/cmodule/resources/_openassetio_test/PyRetainingSharedPtrTest.cpp
+++ b/src/openassetio-python/tests/cmodule/resources/_openassetio_test/PyRetainingSharedPtrTest.cpp
@@ -211,7 +211,18 @@ struct PyDeathwatchedSimpleCppType : DeathwatchedSimpleCppType {
   }
 };
 
-void registerPyRetainingSharedPtrTestTypes(const py::module_& mod) {
+/**
+ * Store a SimpleBaseCppType shared_ptr in a static variable.
+ *
+ * This allows us to test object lifetimes that outlive the Python
+ * interpreter.
+ */
+void setSimpleSingleton(std::shared_ptr<SimpleBaseCppType> newSingleton) {
+  static std::shared_ptr<SimpleBaseCppType> singleton;
+  singleton = std::move(newSingleton);
+}
+
+void registerPyRetainingSharedPtrTestTypes(py::module_& mod) {
   py::class_<SimpleBaseCppType, std::shared_ptr<SimpleBaseCppType>, PySimpleBaseCppType>(
       mod, "SimpleBaseCppType")
       .def(py::init())
@@ -274,4 +285,9 @@ void registerPyRetainingSharedPtrTestTypes(const py::module_& mod) {
       mod, "DeathwatchedSimpleCppType")
       .def(py::init<py::function>())
       .def("value", &SimpleBaseCppType::value);
+
+  mod.def("setSimplePyRetainedSingleton",
+          [](openassetio::PyRetainingSharedPtr<SimpleBaseCppType> newSingleton) {
+            setSimpleSingleton(std::move(newSingleton));
+          });
 }

--- a/src/openassetio-python/tests/cmodule/resources/_openassetio_test/_openassetio_test.cpp
+++ b/src/openassetio-python/tests/cmodule/resources/_openassetio_test/_openassetio_test.cpp
@@ -4,6 +4,6 @@
 
 namespace py = pybind11;
 
-void registerPyRetainingSharedPtrTestTypes(const py::module_&);
+void registerPyRetainingSharedPtrTestTypes(py::module_&);
 
 PYBIND11_MODULE(_openassetio_test, mod) { registerPyRetainingSharedPtrTestTypes(mod); }

--- a/src/openassetio-python/tests/cmodule/test_PyRetainingSharedPtr.py
+++ b/src/openassetio-python/tests/cmodule/test_PyRetainingSharedPtr.py
@@ -250,6 +250,16 @@ class Test_PyRetainingSharedPtr_cleanup:
         self.death_watcher.assert_called()
 
 
+class Test_PyRetainingSharedPtr_static:
+    def test_when_interpreter_dies_before_object_then_cleanup_happens_gracefully(self):
+        # This will store a bound C++ object in a static (i.e. global)
+        # variable. The assertion for this test is simply the lack of
+        # segfaults/errors/hangs when cleaning up the PyObject during
+        # destruction of the C++ object after the interpreter has shut
+        # down.
+        _openassetio_test.setSimplePyRetainedSingleton(SimpleCppType())
+
+
 class SimpleCppType(_openassetio_test.SimpleBaseCppType):
     def value(self):
         return 2


### PR DESCRIPTION
The `PyRetainingSharedPtr` mechanism in OpenAssetIO allows a C++ `shared_ptr` chain to keep a `PyObject` alive, even if that object is not currently visible from the Python interpreter. This allows e.g. a C++ host to hold a reference to (and call) a Python manager plugin.

A side effect of this mechanism is that it is possible for a C++ object to keep a `PyObject` alive beyond the lifetime of the Python interpreter. Then, when the C++ object is finally destroyed (e.g. on application exit), attempting to clean up the `PyObject` is a use-after-free error, causing segfaults or hangs.

So ensure cleanup of the `PyObject` is trivial, in the case that the Python interpreter has been shut down, by not trying to acquire the GIL and by `release`ing the pybind11 handle.

- [x] I have updated the release notes.
- ~~[ ] I have updated all relevant user documentation.~~

## Test Instructions

Undoing the fix in `pointers.hpp` and running CTest (specifically, `openassetio.internal.pytest.cmodule`) will demonstrate the problem. The issue is use-after-free, so the symptoms can vary. On my system I see a hang (hence the test timeout added in the CMakeLists), you may see a segfault, or (if running a debug build of Python) an `assert` failure.