### PR TITLE
[CI] Bump Conan version

### DIFF
--- a/resources/build/requirements.txt
+++ b/resources/build/requirements.txt
@@ -1,4 +1,4 @@
-conan==1.54.0
+conan==1.55.0
 cmake==3.21
 ninja==1.10.2.3
 pip>=21.3


### PR DESCRIPTION
The `m4` ConanCenter recipe (dependency of `cpython`) now needs Conan 1.55 at minimum.

First noticed due to [CI failure](https://github.com/OpenAssetIO/OpenAssetIO/actions/runs/4043843352/jobs/6953267028) of PR #805
