### PR TITLE
[Core] Add ability to create a new manager for each harness test case

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,16 @@ v1.0.0-alpha.X
 - Disabled the (nascent) C bindings by default. To enable, the
   `OPENASSETIO_ENABLE_C` CMake option must be explicitly set to `ON`.
 
+### New features
+
+- The `FixtureAugmentedTestCase` class of the
+  `openassetio.test.manager.harness` can now be configured to create a
+  new, uninitialized manager instance for each test case, by setting the
+  `shareManger` class variable or derived classes to `False`. This
+  facilitates testing of a manager's initialization behavior.
+  [BAL#26](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/26)
+
+
 ### Bug fixes
 
 - Ensured that the Python GIL is acquired within

--- a/src/openassetio-python/package/openassetio/test/manager/harness.py
+++ b/src/openassetio-python/package/openassetio/test/manager/harness.py
@@ -162,7 +162,17 @@ class FixtureAugmentedTestCase(unittest.TestCase):
     @warning The supplied locale should always be used for interactions
     with the manager under test, the @ref createTestContext convenience
     method will create a new context pre-configured with this locale.
+
+    For performance reasons, by default, all test cases will share a
+    single instance of the manager under test. This reduces setup costs,
+    but precludes any testing of initialization behaviour.
+
+    If the class variable `shareManager` is set to False for any given
+    suite, the harness will instead create a new, uninitializesd manager
+    for each case.
     """
+
+    shareManager = True
 
     def __init__(self, fixtures, manager, locale, *args, **kwargs):
         """

--- a/src/openassetio-python/tests/package/test/manager/resources/suite_executeSuiteTests.py
+++ b/src/openassetio-python/tests/package/test/manager/resources/suite_executeSuiteTests.py
@@ -111,6 +111,53 @@ class Test_executeSuite_locale(FixtureAugmentedTestCase):
         )
 
 
+class Test_executeSuite_shareManager_is_true_by_default(FixtureAugmentedTestCase):
+    """
+    A slightly different formulation as we need to assert that different
+    test cases are invoked with the same manager.
+    """
+
+    __managers = {}
+
+    def test_case_a(self):
+        self.__managers["a"] = self._manager
+
+    def test_case_b(self):
+        self.__managers["b"] = self._manager
+
+    @classmethod
+    def tearDownClass(cls):
+        assert len(cls.__managers) == 2
+        assert len(set(cls.__managers.values())) == 1
+
+
+class Test_executeSuite_when_shareManager_is_false_then_managers_unique(FixtureAugmentedTestCase):
+    """
+    A slightly different formulation as we need to assert that different
+    test cases are invoked with unique, uninitialized managers.
+    """
+
+    shareManager = False
+
+    __managers = {}
+
+    def test_case_a(self):
+        self.__managers["a"] = self._manager
+
+    def test_case_b(self):
+        self.__managers["b"] = self._manager
+
+    @classmethod
+    def tearDownClass(cls):
+        assert len(cls.__managers) == 2
+        assert len(set(cls.__managers.values())) == 2
+        # The StubManager used for these tests captures the host
+        # identifier during initialize, so this serves as a handy check
+        # to ensure the manager is uninitialized.
+        for manager in cls.__managers.values():
+            assert "host_identifier" not in manager.info()
+
+
 # Contrived tests that are expected by the actual test suite.
 # They exist so that we can validate they are run and present in
 # the process output.


### PR DESCRIPTION
The `openassetio.test.manager` harness used to create a single manager for the entire test run, reusing it for each case. This was mainly for performance reasons.

This does however, preclude the ability to test manager initialization behaviour.

This adds a class variable that instructs the harness to create a new, uninitialized manager for each case instead.

Part of OpenAssetIO/OpenAssetIO-Manager-BAL#26.

Note: I've had a world of a time getting builds working again on my laptop, so hopefully I haven't missed something obvious!