### PR TITLE
`TraitBase` `isImbued` and `isImbuedTo`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+v1.0.0-alpha.X
+--------------
+
+### Breaking changes
+
+- Renamed `TraitBase.isValid` to `isImbued` for symmetry with
+  `imbue`/`imbueTo` methods.
+  [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)
+
+
 v1.0.0-alpha.9
 --------------
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,12 @@ v1.0.0-alpha.X
   `imbue`/`imbueTo` methods.
   [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)
 
+### New features
+
+- Added `TraitBase.isImbuedTo` static/class method, giving a cheaper
+  mechanism for testing whether a `TraitsData` is imbued with a trait.
+  [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)
+
 
 v1.0.0-alpha.9
 --------------

--- a/doc/doxygen/src/Examples.dox
+++ b/doc/doxygen/src/Examples.dox
@@ -223,7 +223,7 @@
  *     working_spec = TextFileSpecification(working_data)
  *     save_path = working_spec.locatableContentTrait().getUrl()
  *     encoding_trait = working_spec.textEncodingTrait()
- *     if encoding_trait.isValid() and (custom_encoding := encoding_trait.getEncoding()):
+ *     if encoding_trait.isImbued() and (custom_encoding := encoding_trait.getEncoding()):
  *         encoding = custom_encoding
  *
  *
@@ -276,10 +276,10 @@
  *     requested = manager.resolve([thumbnail_ref], ThumbnailFileSpecification.kTraitSet, context)[0]
  *     requested_spec = ThumbnailFileSpecification(requested)
  *     file_trait = requested_spec.fileTrait()
- *     if file_trait.isValid() and (requested_path := file_trait.getPath()):
+ *     if file_trait.isImbued() and (requested_path := file_trait.getPath()):
  *         thumbnail_path = requested_path
  *     raster_trait = requested_spec.rasterTrait()
- *     if raster_trait.isValid():
+ *     if raster_trait.isImbued():
  *         thumbnail_attr["width"] = raster_trait.getWidth() or thumbnail_attr["width"]
  *         thumbnail_attr["height"] = raster_trait.getHeight() or thumbnail_attr["height"]
  *

--- a/src/openassetio-core/include/openassetio/trait/TraitBase.hpp
+++ b/src/openassetio-core/include/openassetio/trait/TraitBase.hpp
@@ -85,13 +85,24 @@ struct TraitBase {
   explicit TraitBase(TraitsDataPtr data) : data_{std::move(data)} {}
 
   /**
+   * Check whether a TraitsData instance has this trait set.
+   *
+   * @param data Data to check.
+   * @return `true` if the given TraitsData instance has this trait
+   * set, `false` otherwise.
+   */
+  [[nodiscard]] static bool isImbuedTo(const TraitsDataPtr& data) {
+    return data->hasTrait(Derived::kId);
+  }
+
+  /**
    * Check whether the TraitsData instance this trait has been
    * constructed with has this trait set.
    *
    * @return `true` if the underlying TraitsData instance has this trait
    * set, `false` otherwise.
    **/
-  [[nodiscard]] bool isImbued() const { return data_->hasTrait(Derived::kId); }
+  [[nodiscard]] bool isImbued() const { return isImbuedTo(data_); }
 
   /**
    * Applies this trait to the wrapped TraitsData instance.

--- a/src/openassetio-core/include/openassetio/trait/TraitBase.hpp
+++ b/src/openassetio-core/include/openassetio/trait/TraitBase.hpp
@@ -38,7 +38,7 @@ namespace trait {
  *
  *     MyTrait myTrait{traitsData};
  *
- *     if (myTrait.isValid()) {
+ *     if (myTrait.isImbued()) {
  *
  *       if (myTrait.getMyValue(&myValue) != TraitPropertyStatus::kFound) {
  *
@@ -70,7 +70,7 @@ namespace trait {
  *
  * @note Attempting to access a trait's properties without first
  * ensuring the underlying TraitsData instance has that trait via
- * `isValid`, or otherwise, may trigger a `std::out_of_range` exception
+ * `isImbued`, or otherwise, may trigger a `std::out_of_range` exception
  * if the trait is not set.
  *
  * @tparam Derived Concrete subclass.
@@ -91,7 +91,7 @@ struct TraitBase {
    * @return `true` if the underlying TraitsData instance has this trait
    * set, `false` otherwise.
    **/
-  [[nodiscard]] bool isValid() const { return data_->hasTrait(Derived::kId); }
+  [[nodiscard]] bool isImbued() const { return data_->hasTrait(Derived::kId); }
 
   /**
    * Applies this trait to the wrapped TraitsData instance.

--- a/src/openassetio-core/tests/trait/TraitBaseTest.cpp
+++ b/src/openassetio-core/tests/trait/TraitBaseTest.cpp
@@ -56,12 +56,31 @@ SCENARIO("Retrieving the undelying data") {
 }
 
 SCENARIO("Checking a trait is imbued") {
-  GIVEN("a trait view on an empty TraitsData") {
+  GIVEN("an empty TraitsData") {
     const TraitsDataPtr data = TraitsData::make();
-    const TestTrait trait(data);
 
-    WHEN("the view is queried for the imbued status") {
-      const bool isImbued = trait.isImbued();
+    AND_GIVEN("an instance of a trait view wrapping the TraitsData") {
+      const TestTrait trait(data);
+
+      WHEN("the view instance is queried for the imbued status") {
+        const bool isImbued = trait.isImbued();
+
+        THEN("the view reports that the trait is not imbued") { CHECK(!isImbued); }
+      }
+
+      AND_GIVEN("the TraitsData is imbued with the view's trait") {
+        data->addTrait(TestTrait::kId);
+
+        WHEN("the view instance is queried for the imbued status") {
+          const bool isImbued = trait.isImbued();
+
+          THEN("the view reports that the trait is imbued") { CHECK(isImbued); }
+        }
+      }
+    }
+
+    WHEN("the TraitsData is queried for imbued status using static trait view function") {
+      const bool isImbued = TestTrait::isImbuedTo(data);
 
       THEN("the view reports that the trait is not imbued") { CHECK(!isImbued); }
     }
@@ -69,8 +88,8 @@ SCENARIO("Checking a trait is imbued") {
     AND_GIVEN("the TraitsData is imbued with the view's trait") {
       data->addTrait(TestTrait::kId);
 
-      WHEN("the view is queried for the imbued status") {
-        const bool isImbued = trait.isImbued();
+      WHEN("the TraitsData is queried for imbued status using static trait view function") {
+        const bool isImbued = TestTrait::isImbuedTo(data);
 
         THEN("the view reports that the trait is imbued") { CHECK(isImbued); }
       }

--- a/src/openassetio-core/tests/trait/TraitBaseTest.cpp
+++ b/src/openassetio-core/tests/trait/TraitBaseTest.cpp
@@ -55,22 +55,25 @@ SCENARIO("Retrieving the undelying data") {
   }
 }
 
-SCENARIO("Checking a trait is valid") {
-  GIVEN("Some known traits data") {
-    TraitsDataPtr data = TraitsData::make();
+SCENARIO("Checking a trait is imbued") {
+  GIVEN("a trait view on an empty TraitsData") {
+    const TraitsDataPtr data = TraitsData::make();
+    const TestTrait trait(data);
 
-    AND_GIVEN("the data has the trait set") {
-      data->addTrait(TestTrait::kId);
+    WHEN("the view is queried for the imbued status") {
+      const bool isImbued = trait.isImbued();
 
-      WHEN("called") {
-        TestTrait trait(data);
-        THEN("isValid returns true") { CHECK(trait.isValid()); }
-      }
+      THEN("the view reports that the trait is not imbued") { CHECK(!isImbued); }
     }
 
-    AND_GIVEN("the data does not have trait") {
-      TestTrait trait(data);
-      THEN("isValid returns false") { CHECK(!trait.isValid()); }
+    AND_GIVEN("the TraitsData is imbued with the view's trait") {
+      data->addTrait(TestTrait::kId);
+
+      WHEN("the view is queried for the imbued status") {
+        const bool isImbued = trait.isImbued();
+
+        THEN("the view reports that the trait is imbued") { CHECK(isImbued); }
+      }
     }
   }
 }

--- a/src/openassetio-python/package/openassetio/TraitBase.py
+++ b/src/openassetio-python/package/openassetio/TraitBase.py
@@ -46,7 +46,7 @@ class TraitBase:
     "setTraitProperty".
 
     @note Attempting to access a trait's properties without first
-    ensuring the data holds that trait via `isValid`, or
+    ensuring the data holds that trait via `isImbued`, or
     otherwise, may trigger an exception if the trait is not set in
     the data.
     """
@@ -60,7 +60,7 @@ class TraitBase:
         """
         self._data = traitsData
 
-    def isValid(self):
+    def isImbued(self):
         """
         Checks whether the data this trait has been applied to
         actually has this trait.

--- a/src/openassetio-python/package/openassetio/TraitBase.py
+++ b/src/openassetio-python/package/openassetio/TraitBase.py
@@ -60,15 +60,26 @@ class TraitBase:
         """
         self._data = traitsData
 
+    @classmethod
+    def isImbuedTo(cls, traitsData):
+        """
+        Checks whether the given data actually has this trait.
+
+        @param traitsData: Data to check for trait.
+        @return `True` if the underlying data has this trait, `False`
+        otherwise.
+        """
+        return traitsData.hasTrait(cls.kId)  # pylint: disable=no-member
+
     def isImbued(self):
         """
         Checks whether the data this trait has been applied to
         actually has this trait.
 
-        @return `True` if the underlying data has this
-        trait, `False` otherwise.
+        @return `True` if the underlying data has this trait, `False`
+        otherwise.
         """
-        return self._data.hasTrait(self.kId)  # pylint: disable=no-member
+        return self.isImbuedTo(self._data)
 
     def imbue(self):
         """

--- a/src/openassetio-python/tests/package/test_trait.py
+++ b/src/openassetio-python/tests/package/test_trait.py
@@ -33,16 +33,16 @@ class Test_Trait_Construction:
         assert trait._data is a_data  # pylint: disable=protected-access
 
 
-class Test_Trait_isValid:
+class Test_Trait_isImbued:
     def test_when_data_has_trait_returns_true(self):
         a_data = TraitsData({ACustomTrait.kId})
         trait = ACustomTrait(a_data)
-        assert trait.isValid() is True
+        assert trait.isImbued() is True
 
     def test_when_data_does_not_have_trait_returns_false(self):
         a_data = TraitsData({"someOtherTrait"})
         trait = ACustomTrait(a_data)
-        assert trait.isValid() is False
+        assert trait.isImbued() is False
 
 
 class Test_Trait_imbue:
@@ -50,7 +50,7 @@ class Test_Trait_imbue:
         a_data = TraitsData()
         trait = ACustomTrait(a_data)
         trait.imbue()
-        assert trait.isValid()
+        assert trait.isImbued()
         assert trait.kId in a_data.traitSet()
 
     def test_when_data_has_trait_then_is_noop(self):

--- a/src/openassetio-python/tests/package/test_trait.py
+++ b/src/openassetio-python/tests/package/test_trait.py
@@ -36,11 +36,13 @@ class Test_Trait_Construction:
 class Test_Trait_isImbued:
     def test_when_data_has_trait_returns_true(self):
         a_data = TraitsData({ACustomTrait.kId})
+        assert ACustomTrait.isImbuedTo(a_data) is True
         trait = ACustomTrait(a_data)
         assert trait.isImbued() is True
 
     def test_when_data_does_not_have_trait_returns_false(self):
         a_data = TraitsData({"someOtherTrait"})
+        assert ACustomTrait.isImbuedTo(a_data) is False
         trait = ACustomTrait(a_data)
         assert trait.isImbued() is False
 


### PR DESCRIPTION
## Description

Closes #815

For symmetry with `imbue` and `imbueTo` methods, rename the `isValid` method to `isImbued.`

For C++ in particular, where performance is likely a concern, constructing a `TraitBase`-derived instance, just to check `isImbued`, is wasteful. So add a static `isImbuedTo` (for symmetry with `imbueTo`), which tests a `TraitsData` without unnecessary temporary
construction.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.