### PR TITLE
[CI] Fix CI for latest version of Conan/recipes

### DIFF
--- a/resources/build/conanfile.py
+++ b/resources/build/conanfile.py
@@ -37,17 +37,17 @@ class OpenAssetIOConan(ConanFile):
         # CY2022
         if not tools.get_env("OPENASSETIO_CONAN_SKIP_CPYTHON", False):
             self.requires("cpython/3.9.7")
+            # Pin recipe as latest not compatible with Conan 1.59
+            self.requires("ncurses/6.2@#54f100a8e4a94700d4123ed31420506c")
         # Same as ASWF CY2022 Docker image:
         # https://github.com/AcademySoftwareFoundation/aswf-docker/blob/master/ci-base/README.md
         self.requires("pybind11/2.8.1")
-
-    def build_requirements(self):
         # TOML library
-        self.tool_requires("tomlplusplus/3.2.0")
+        self.requires("tomlplusplus/3.2.0")
         # Test framework
-        self.tool_requires("catch2/2.13.8")
+        self.requires("catch2/2.13.8")
         # Mocking library
-        self.tool_requires("trompeloeil/42")
+        self.requires("trompeloeil/42")
 
     def configure(self):
         if self.settings.os == "Windows":

--- a/resources/build/requirements.txt
+++ b/resources/build/requirements.txt
@@ -1,4 +1,4 @@
-conan==1.55.0
+conan==1.59.0
 cmake==3.21
 ninja==1.10.2.3
 pip>=21.3


### PR DESCRIPTION
The latest version of Conan does not install the CMake config files for `tool_requires` dependencies when using `conan install -g CMakeDeps`

We must use the latest version of Conan due to a recipe change in the `ncurses` package (a dependency of `cpython`).

`tool_requires` are intended for build requirements, when building a package via Conan.  We abuse this slightly during dev/CI by stopping short of building via Conan, instead using it just to provide dependencies. The latest Conan has changed its behaviour to no longer install `tool_requires` build system artifacts (i.e. CMake config files) as part of a `conan install`, which makes some sense since they shouldn't be required by consumers, only by builders.