### PR TITLE
[CI] Fix CI for latest version of Conan/recipes

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,7 +7,7 @@ concurrency:
 
 jobs:
   pylint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.config.os }}
     name: Pylint
     strategy:
       matrix:

--- a/resources/build/bootstrap-cibuildwheel-manylinux-2014.sh
+++ b/resources/build/bootstrap-cibuildwheel-manylinux-2014.sh
@@ -21,7 +21,9 @@ conan profile new default --detect --force
 # necessary as this is the default for conan, but we can't be certain
 # it'll remain the default in future.
 conan profile update settings.compiler.libcxx=libstdc++ default
-
+# If we need to pin a package to a specific Conan recipe revision, then
+# we need to explicitly opt-in to this functionality.
+conan config set general.revisions_enabled=True
 # Install openassetio third-party dependencies from public Conan Center
 # package repo.
 export OPENASSETIO_CONAN_SKIP_CPYTHON="True"

--- a/resources/build/bootstrap-macos-10.15.sh
+++ b/resources/build/bootstrap-macos-10.15.sh
@@ -11,7 +11,9 @@ export CONAN_USER_HOME="$HOME/conan"
 # Create default conan profile so we can configure it before install.
 # Use --force so that if it already exists we don't error out.
 conan profile new default --detect --force
-
+# If we need to pin a package to a specific Conan recipe revision, then
+# we need to explicitly opt-in to this functionality.
+conan config set general.revisions_enabled=True
 # Install openassetio third-party dependencies from public Conan Center
 # package repo.
 conan install --install-folder "$WORKSPACE/.conan" --build=missing \

--- a/resources/build/bootstrap-macos-11.sh
+++ b/resources/build/bootstrap-macos-11.sh
@@ -15,7 +15,9 @@ export CONAN_USER_HOME="$HOME/conan"
 # Create default conan profile so we can configure it before install.
 # Use --force so that if it already exists we don't error out.
 conan profile new default --detect --force
-
+# If we need to pin a package to a specific Conan recipe revision, then
+# we need to explicitly opt-in to this functionality.
+conan config set general.revisions_enabled=True
 # Install openassetio third-party dependencies from public Conan Center
 # package repo.
 conan install --install-folder "$WORKSPACE/.conan" --build=missing \

--- a/resources/build/bootstrap-ubuntu-20.04.sh
+++ b/resources/build/bootstrap-ubuntu-20.04.sh
@@ -31,6 +31,10 @@ conan profile new default --detect --force
 # necessary as this is the default for conan, but we can't be certain
 # it'll remain the default in future.
 conan profile update settings.compiler.libcxx=libstdc++ default
+# If we need to pin a package to a specific Conan recipe revision, then
+# we need to explicitly opt-in to this functionality.
+conan config set general.revisions_enabled=True
+
 # Install openassetio third-party dependencies from public Conan Center
 # package repo.
 # TODO(DF): conan<1.51 (not yet released) has a bug that means we have

--- a/resources/build/bootstrap-ubuntu-20.04.sh
+++ b/resources/build/bootstrap-ubuntu-20.04.sh
@@ -37,15 +37,7 @@ conan config set general.revisions_enabled=True
 
 # Install openassetio third-party dependencies from public Conan Center
 # package repo.
-# TODO(DF): conan<1.51 (not yet released) has a bug that means we have
-# to allow conan recipes to try to install system packages, even if the
-# system packages are already available. In particular, this affects
-# recent versions of the xorg/system recipe (a dependency of cpython).
-# The problem is reported and fixed in https://github.com/conan-io/conan/pull/11712
-conan install --install-folder "$WORKSPACE/.conan" --build=missing \
-    -c tools.system.package_manager:mode=install \
-    -c tools.system.package_manager:sudo=True \
-    "$WORKSPACE/resources/build"
+conan install --install-folder "$WORKSPACE/.conan" --build=missing "$WORKSPACE/resources/build"
 # Ensure we have the expected version of clang-* available
 sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-12 10
 sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-12 10

--- a/resources/build/bootstrap-windows-2019.bat
+++ b/resources/build/bootstrap-windows-2019.bat
@@ -7,7 +7,9 @@ set CONAN_USER_HOME=%USERPROFILE%\conan
 :: Use --force so that if it already exists we don't error out.
 conan profile new default --detect --force
 conan profile show default
-
+:: If we need to pin a package to a specific Conan recipe revision, then
+:: we need to explicitly opt-in to this functionality.
+conan config set general.revisions_enabled=True
 :: Install openassetio third-party dependencies from public Conan Center
 :: package repo.
 conan install --install-folder "%WORKSPACE%\.conan" ^

--- a/resources/build/conanfile.py
+++ b/resources/build/conanfile.py
@@ -42,14 +42,12 @@ class OpenAssetIOConan(ConanFile):
         # Same as ASWF CY2022 Docker image:
         # https://github.com/AcademySoftwareFoundation/aswf-docker/blob/master/ci-base/README.md
         self.requires("pybind11/2.8.1")
-
-    def build_requirements(self):
         # TOML library
-        self.tool_requires("tomlplusplus/3.2.0")
+        self.requires("tomlplusplus/3.2.0")
         # Test framework
-        self.tool_requires("catch2/2.13.8")
+        self.requires("catch2/2.13.8")
         # Mocking library
-        self.tool_requires("trompeloeil/42")
+        self.requires("trompeloeil/42")
 
     def configure(self):
         if self.settings.os == "Windows":

--- a/resources/build/conanfile.py
+++ b/resources/build/conanfile.py
@@ -37,6 +37,8 @@ class OpenAssetIOConan(ConanFile):
         # CY2022
         if not tools.get_env("OPENASSETIO_CONAN_SKIP_CPYTHON", False):
             self.requires("cpython/3.9.7")
+            # Pin recipe as latest not compatible with Conan 1.59
+            self.requires("ncurses/6.2@#54f100a8e4a94700d4123ed31420506c")
         # Same as ASWF CY2022 Docker image:
         # https://github.com/AcademySoftwareFoundation/aswf-docker/blob/master/ci-base/README.md
         self.requires("pybind11/2.8.1")

--- a/resources/build/requirements.txt
+++ b/resources/build/requirements.txt
@@ -1,4 +1,4 @@
-conan==1.55.0
+conan==1.59.0
 cmake==3.21
 ninja==1.10.2.3
 pip>=21.3


### PR DESCRIPTION
The latest Conan recipe for the `ncurses` dependency of `cpython` is incompatible with Conan V1, so we must pin it.

One of the initial attempted fixes was to upgrade to the latest Conan. This may not actually have been required, but is worth keeping.  This necessitated a slight change in our conanfile.py to no longer use `tool_requires`, since their CMake config files are no longer installed (into the `.conan` directory).

Also fixed a couple of minor issues discovered whilst debugging
* The linter CI job was using the wrong GitHub runner (Ubuntu 22.04 rather than 20.04), meaning, at best, duplicated packages in the Conan package cache, or at worst, cache misses due to the caching race condition between jobs.
* A long-standing TODO comment was resolved, since the latest Conan versions no longer have the bug, where we must allow Conan to install system packages, even if none actually need to be installed.

See commit messages for more info.