### PR TITLE
[Core] Remove [[nodiscard]] from getTraitProperty

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,13 @@ v1.0.0-alpha.X
   mechanism for testing whether a `TraitsData` is imbued with a trait.
   [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)
 
+### Bug fixes
+
+- Removed `nodiscard` from `TraitsData::getTraitProperty`, and
+  `TraitBase::getTraitProperty`, to allow "value or default" style use
+  cases.
+  [#825](https://github.com/OpenAssetIO/OpenAssetIO/issues/825)
+
 
 v1.0.0-alpha.9
 --------------

--- a/src/openassetio-core/include/openassetio/TraitsData.hpp
+++ b/src/openassetio-core/include/openassetio/TraitsData.hpp
@@ -132,8 +132,8 @@ class OPENASSETIO_CORE_EXPORT TraitsData final {
    * @exception `std::out_of_range` if this instance does not have
    * this trait.
    */
-  [[nodiscard]] bool getTraitProperty(trait::property::Value* out, const trait::TraitId& traitId,
-                                      const trait::property::Key& propertyKey) const;
+  bool getTraitProperty(trait::property::Value* out, const trait::TraitId& traitId,
+                        const trait::property::Key& propertyKey) const;
 
   /**
    * Set the value of given trait property.

--- a/src/openassetio-core/include/openassetio/trait/TraitBase.hpp
+++ b/src/openassetio-core/include/openassetio/trait/TraitBase.hpp
@@ -146,8 +146,8 @@ struct TraitBase {
    * @return Status of property in the underlying data.
    */
   template <class T>
-  [[nodiscard]] TraitPropertyStatus getTraitProperty(T* out, const TraitId& traitId,
-                                                     const property::Key& propertyKey) const {
+  TraitPropertyStatus getTraitProperty(T* out, const TraitId& traitId,
+                                       const property::Key& propertyKey) const {
     if (property::Value value; data()->getTraitProperty(&value, traitId, propertyKey)) {
       if (T* maybeOut = std::get_if<T>(&value)) {
         *out = *maybeOut;


### PR DESCRIPTION
## Description

The value of getTraitProperty is returned via an out param. It's actual return value is merely a status flag.

It's possible the user may wish to employ a "value or default" style, which would not be possible with [[nodiscard]]

Closes #825

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.

## Reviewer Notes
Also applied the same logic to `getTraitProperty` in `TraitBase`, it applies the same I think.

## Test Instructions

To test, building and running `ctest` is sufficient.
