### PR TITLE
[Doc] Update C Flag default doc

### DIFF
--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -181,7 +181,7 @@ behaviour of the build.
 | ----------- | ----------- | ------- |
 | `BUILD_SHARED_LIBS` | `ON` to build shared libraries. `OFF` to build static libraries. | `ON` |
 | `OPENASSETIO_ENABLE_PYTHON` | Additionally build python bindings | `ON` |
-| `OPENASSETIO_ENABLE_C` | Additionally build C bindings | `ON` |
+| `OPENASSETIO_ENABLE_C` | Additionally build C bindings | `OFF` |
 | `OPENASSETIO_ENABLE_TESTS` | Additionally build tests | `OFF` |
 | `OPENASSETIO_ENABLE_PYTHON_TEST_VENV` | Automatically create environment when running tests | `ON` |
 | `OPENASSETIO_WARNINGS_AS_ERRORS` | Treat compiler warnings as errors | `OFF` |


### PR DESCRIPTION
## Description
[Recently](https://github.com/OpenAssetIO/OpenAssetIO/commit/3ffc8897bff874215ecbe61a16879f11119f9a56), we had changed the default behaviour of the OpenAssetIO build to not build the C libraries, due to how they are unstable and shouldn't be considered ready-for-use.
This commit updates a flag in the build docs to reflect that.

- [x] I have updated the release notes. (no need)
- [x] I have updated all relevant user documentation. (This is that.)