### PR TITLE
[Docs] Add more examples to displayName and identifier docs

### DIFF
--- a/doc/doxygen/src/Examples.dox
+++ b/doc/doxygen/src/Examples.dox
@@ -28,15 +28,15 @@
  * from openassetio.hostApi import HostInterface, Manager, ManagerFactory
  * from openassetio.pluginSystem import PythonPluginSystemManagerImplementationFactory
  *
- * class ExampleHost(HostInterface):
+ * class ExamplesHost(HostInterface):
  *     """
  *     A minimal host implementation.
  *     """
  *     def identifier(self):
- *         return "org.openassetio.example.host"
+ *         return "org.openassetio.examples"
  *
  *     def displayName(self):
- *         return "OpenAssetIO Example Host"
+ *         return "OpenAssetIO Examples"
  *
  * # For simplicity, use a filtered console logger, this logs to
  * # stderr based on the value of OPENASSETIO_LOGGING_SEVERITY.
@@ -50,7 +50,7 @@
  * factory_impl = PythonPluginSystemManagerImplementationFactory(logger)
  *
  * # We then need our implementation of the HostInterface class
- * host_interface = ExampleHost()
+ * host_interface = ExamplesHost()
  *
  * # We can now create an OpenAssetIO ManagerFactory. The ManagerFactory
  * # allows us to query the available managers, and pick one to talk to.

--- a/src/openassetio-core/include/openassetio/hostApi/HostInterface.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/HostInterface.hpp
@@ -62,16 +62,22 @@ class OPENASSETIO_CORE_EXPORT HostInterface {
    * example:
    *
    *    "org.openassetio.test.host"
+   *    "io.aswf.openrv"
+   *    "com.foundry.nuke"
    *
    * @return host identifier.
+   *
+   * @see https://en.wikipedia.org/wiki/Reverse_domain_name_notation
    */
   [[nodiscard]] virtual Identifier identifier() const = 0;
 
   /**
    * Returns a human readable name to be used to reference this
-   * specific host in user-facing presentations.
+   * specific host in user-facing presentations, for example:
    *
    *     "OpenAssetIO Test Host"
+   *     "OpenRV"
+   *     "Nuke"
    *
    * @return Host's display name.
    */

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -188,6 +188,8 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *     "org.openassetio.test.manager"
    *
    * @return Unique identifier of the manager.
+   *
+   * @see https://en.wikipedia.org/wiki/Reverse_domain_name_notation
    */
   [[nodiscard]] virtual Identifier identifier() const = 0;
 


### PR DESCRIPTION
Our previous examples lead people to think they need to include 'Host' or similar in these strings. This attempts to make it clearer that it's supposed to just be the common name for host/manager in question.

Closes #829 