### PR TITLE
[Docs] Document C++ `make` convention

### DIFF
--- a/src/openassetio-core/include/openassetio/hostApi/HostInterface.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/HostInterface.hpp
@@ -33,6 +33,11 @@ OPENASSETIO_DECLARE_PTR(HostInterface)
  * always accessed via the @ref openassetio.managerApi.Host wrapper.
  * This allows the API to insert suitable house-keeping and auditing
  * functionality in between.
+ *
+ * @note OpenAssetIO makes use of shared pointers to facilitate object
+ * lifetime management across multiple languages. Instances passed into
+ * API methods via shared pointer may have their lifetimes extended
+ * beyond that of your code.
  */
 class OPENASSETIO_CORE_EXPORT HostInterface {
  public:

--- a/src/openassetio-core/include/openassetio/log/LoggerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/log/LoggerInterface.hpp
@@ -22,6 +22,11 @@ OPENASSETIO_DECLARE_PTR(LoggerInterface)
 /**
  * An abstract base class that defines the receiving interface for
  * log messages generated a @ref manager or the API middleware.
+ *
+ * @note OpenAssetIO makes use of shared pointers to facilitate object
+ * lifetime management across multiple languages. Instances passed into
+ * API methods via shared pointer may have their lifetimes extended
+ * beyond that of your code.
  */
 class OPENASSETIO_CORE_EXPORT LoggerInterface {
  public:

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -147,6 +147,11 @@ OPENASSETIO_DECLARE_PTR(ManagerInterface)
  *
  * @todo Finish/Document settings mechanism.
  * @see @ref initialize
+ *
+ * @note OpenAssetIO makes use of shared pointers to facilitate object
+ * lifetime management across multiple languages. Instances passed into
+ * API methods via shared pointer may have their lifetimes extended
+ * beyond that of your code.
  */
 class OPENASSETIO_CORE_EXPORT ManagerInterface {
  public:


### PR DESCRIPTION
There isn't anything we can do in code to help with this (as you can't force a derived class constructor to be private, or inherit static methods without Template Fun™). So document how to do the right thing...

Closes #822 