### PR TITLE
[Docs] Document plugin loading and config mechanisms

### DIFF
--- a/doc/doxygen/src/Configuration.dox
+++ b/doc/doxygen/src/Configuration.dox
@@ -1,0 +1,172 @@
+/*!
+ * @page runtime_configuration Configuring OpenAssetIO
+ *
+ * This page covers how to configure OpenAssetIO for a specific
+ * end-user working environment.
+ *
+ * @section runtime_configuration_overview Overview
+ *
+ * @startuml
+ * node Host {
+ *   package OpenAssetIO {
+ *     collections ManagerPlugin
+ *   }
+ * }
+ *
+ * cloud "Asset Management System" as ams
+ *
+ * ManagerPlugin -right-> ams
+ * ams -left-> ManagerPlugin
+ * @enduml
+ *
+ * An OpenAssetIO enabled tool or application is known as a @ref host
+ * "Host" (as it "hosts" the API). Through the use of manager plugins,
+ * OpenAssetIO allows the host to communicate with one or more
+ * @ref asset_management_system "Asset Management Systems", called
+ * @ref manager "Managers".
+ *
+ * This page covers hows to configure OpenAssetIO so that the hosts you
+ * use (e.g. @ref DCC "DCC tools", applications and other scripts) use a
+ * specific manager of your choice to @ref resolve and potentially @ref
+ * publish data.
+ *
+ * OpenAssetIO itself is usually built into any host that supports it,
+ * this means you don't normally need do to anything to ensure the API
+ * itself is present. The most common tasks in configuration are:
+ *
+ * - Installing manager plugins and making them available to a host.
+ * - Configuring which manager a host should use.
+ *
+ *
+ * @section installing_manager_plugins Installing Manager plugins
+ *
+ * @note To aid problem solving, the plugin system logs debug messages
+ * when it searches for, and loads plugins.
+ *
+ * Presently, OpenAssetIO only supports Python based plugins.
+ * These can be installed in one of two ways.
+ *
+ * @subsection installing_manager_plugins_pip Using pip
+ *
+ * Most Python-based plugins should support what is known as
+ * <a href="https://packaging.python.org/en/latest/specifications/entry-points/" target="_blank">"entry point" based loading</a>.
+ * This means they can be installed using the package installer for
+ * Python, and will then be automatically detected.
+ *
+ * These plugins are usually published to
+ * <a href="https://pypi.org" target="_blank">PyPI</a>, and so are
+ * easy to install. Simply use the `pip` module of the Python
+ * installation you wish to make the plugin available to:
+ *
+ * @code{.sh}
+ * python -m pip install <manager-plugin-package>
+ * @endcode
+ *
+ * If the plugin is not published, you may be able to install it from a
+ * local checkout of its source code:
+ *
+ * @code{.sh}
+ * python -m pip install <path/to/src>
+ * @endcode
+ *
+ * @warning Many hosts use their own embedded Python interpreter. You
+ * may need to consult the relevant documentation to determine its
+ * location, version, `sys.path` etc. and adjust the invocation
+ * of `python` accordingly, so that the plugin is installed to the
+ * correct Python instance.
+ *
+ *
+ * @subsection installing_manager_plugins_manual Manual installation
+ *
+ * The OpenAssetIO plugin system can also be explicitly configured to
+ * look in specific locations. The @ref plugin_path_var environment
+ * variable can be set to point to one or more directories containing
+ * manager plugins.
+ *
+ * It is a standard 'left-most wins' search-path, that uses platform
+ * specific delimiters (see @ref plugin_path_var "here" for more
+ * information).
+ *
+ * This variable is completely independent from `$PYTHONPATH` or any
+ * other language/host specific configuration.
+ *
+ * This can simplify deployment by allowing a common location to be
+ * specified to service multiple hosts and Python versions (assuming the
+ * manager plugins have been suitably coded).
+ *
+ * To install a plugin using this approach:
+ *
+ * - Download or otherwise obtain the required manager plugin.
+ * - Place this in your chosen location. This can be anywhere on a
+ *   filesystem that is visible to the hosts that you wish to use.
+ * - Set, or extend @ref plugin_path_var to include this location.
+ *
+ *
+ * @section host_settings Host configuration
+ *
+ * In order to make use of OpenAssetIO to manage data, the host needs to
+ * know which manager plugin it should use, and any associated settings
+ * that plugin many need (e.g. server configuration).
+ *
+ * Most hosts should support the OpenAssetIO default configuration
+ * mechanism. This simplifies sharing settings between hosts in a
+ * centralized fashion.
+ *
+ * Advanced hosts with specific workflows may require configuring by
+ * other means - please consult the relevant host provided documentation
+ * in these cases.
+ *
+ * @subsection host_default_config The Default Config Mechanism
+ *
+ * You can specify your preferred manager and settings in a simple
+ * <a href="https://toml.io/en/" target="_blank">TOML</a> file, and set
+ * the @ref default_config_var to point to this file. Hosts should then
+ * use this configuration to setup the API at startup.
+ *
+ * The format for manager-specific sections of this file is documented
+ * @fqref{hostApi.ManagerFactory.defaultManagerForInterface} "here".
+ *
+ * To configure OpenAssetIO using this approach:
+ *
+ * - Create a TOML file with the identifier and any settings in a
+ *   location of your choosing. This can be anywhere on a filesystem
+ *   that is visible to the hosts that you wish to use.
+ * - Set @ref default_config_var to point to that file.
+ *
+ * @note Some hosts may provide functionality to override or ignore this
+ * configuration.
+ *
+
+ * @section configuration_troubleshooting Troubleshooting
+ *
+ * To help diagnose issues, first make sure that debug logging is
+ * enabled in your host. You usually do this by adjusting the host's
+ * native logging controls, or in some cases you may need to set @ref
+ * logging_severity_var to `1`.
+ *
+ * @subsection pip_plugins_missing Pip installed Python plugins not being found
+ *
+ * - Check any messages logged by the plugin system during startup.
+ * - Check with the plugin's documentation that it does support entry
+ *   point based loading.
+ * - Check that the Python interpreter used by your host is the same
+ *   version as the one used to install via `pip`.
+ * - Check that the appropriate directory is on `sys.path` in the
+ *   host's interpreter.
+ * - Check that `importlib_metadata` is available to the host
+ *   interpreter (a message will be logged during startup if this is
+ *   missing).
+ *
+ * @subsection manual_plugins_missing Manually installed plugins not being found
+ *
+ * - Check @ref plugin_path_var includes the directory in which the
+ *   desired plugins reside.
+ * - Check any messages logged by the plugin system during startup.
+ *
+ * @subsection default_config_not_working Default config mechanism not working
+ *
+ * - Check @ref default_config_var points to the file using a valid path
+ *   for the operating system in question.
+ * - Check the user has read permissions for the file.
+ * - Check any messages logged by the manager factory during startup.
+ */

--- a/doc/doxygen/src/Glossary.dox
+++ b/doc/doxygen/src/Glossary.dox
@@ -37,6 +37,13 @@
  *
  * @see @fqref{Context} "Context"
  *
+ * @section DCC Digital Contentent Creation tool (DCC)
+ *
+ * Within the Media and Entertainment industry (and possibly further
+ * afield), Digital Content Creation tools refer to the applications
+ * used to produce graphics, audio and other artistic works. For
+ * example, Adobe Photoshop, Autodesk Maya, and Foundry's Nuke.
+ *
  *
  * @section entity entity
  *
@@ -275,6 +282,14 @@
  *
  * So to override a plug-in with a dev version, ensure it is to the left
  * of the standard plug-in.
+ *
+ *
+ * @section logging_severity_var $OPENASSETIO_LOGGING_SEVERITY
+ *
+ * This is the environment variable used to control the default logging
+ * severity of the API. Note that many @ref host "hosts" re-direct
+ * logging to their own system. Usually in these cases, logging severity
+ * is then controlled by the host's own configuration mechanism(s).
  *
  *
  * @section manager_state Manager State

--- a/doc/doxygen/src/footer.html
+++ b/doc/doxygen/src/footer.html
@@ -12,7 +12,7 @@
 <address class="footer"><small> $doxygenversion </small></address>
 <!--END !GENERATE_TREEVIEW-->
 <hr class="footer"/>
-<p id="copyright"><small>Copyright 2013-2021 The Foundry Visionmongers Ltd. OpenAssetIO is released under the <a href="https://www.apache.org/licenses/LICENSE-2.0.txt" target="_blank">Apache 2.0 License</a></small></p>
+<p id="copyright"><small>Copyright 2013-2023 The Foundry Visionmongers Ltd. OpenAssetIO is released under the <a href="https://www.apache.org/licenses/LICENSE-2.0.txt" target="_blank">Apache 2.0 License</a></small></p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
An attempt to capture the snippets of setup notes scattered around the docs in once place.

Pre-built version here: https://github.com/OpenAssetIO/OpenAssetIO/suites/11835979369/artifacts/618358855

`index.html` -> Configuring OpenAsset IO

Closes #770