### PR TITLE
[CI] Fix docs build artifact path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: doxygen-documentation
-        path: doc/html
+        path: doc/doxygen/html
 
   business-language:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When we refactored the repo, we inadvertently neglected to update the path in the step that publishes the built docs as an artifact of the run.

Test from CI run: https://github.com/OpenAssetIO/OpenAssetIO/actions/runs/4532689159