### PR TITLE
C++ `resolve` method host conveniences

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -14,5 +14,7 @@ root=.
 # -readability/casting: Causes false positives with Trompeloeil mocks,
 #   where CppLint seems to think a macro is actually a C-style cast.
 #   This check is also performed by Clang-Tidy, anyway.
+# -whitespace/parens: Conflicts with ClangFormat in function pointer
+#   signatures.
 filter=-runtime/references,-readability/nolint,-readability/check,-whitespace/braces
-filter=-readability/casting
+filter=-readability/casting,-whitespace/parens

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,9 @@ v1.0.0-alpha.X
   provide more context when using it as a starting point for an
   OpenAssetIO integration.
 
+- Made `BatchElementError` a copyable type in the C++ API.
+  [#849](https://github.com/OpenAssetIO/OpenAssetIO/issues/849)
+
 ### Bug fixes
 
 - Removed `nodiscard` from `TraitsData::getTraitProperty`, and

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,11 +13,21 @@ v1.0.0-alpha.X
 - Changed the host identifier, and removed the custom locale from the
   `simpleResolver` example as they did not follow best practice.
 
+- `BatchElementErrorCallback` moved from the top level `openassetio`
+   namespace to the `openassetio::hostApi::Manager` namespace.
+   [#849](https://github.com/OpenAssetIO/OpenAssetIO/issues/849)
+
 ### New features
 
 - Added `TraitBase.isImbuedTo` static/class method, giving a cheaper
   mechanism for testing whether a `TraitsData` is imbued with a trait.
   [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)
+
+- Added C++ `resolve` overloads for convenience, providing alternatives
+  to the core callback-based workflow. Includes a more direct method for
+  resolving a single entity reference, and exception vs. result object
+  workflows.
+  [#849](https://github.com/OpenAssetIO/OpenAssetIO/issues/849)
 
 ### Improvements
 

--- a/src/openassetio-core/include/openassetio/BatchElementError.hpp
+++ b/src/openassetio-core/include/openassetio/BatchElementError.hpp
@@ -105,9 +105,9 @@ class BatchElementError final {
   };
 
   /// Error code indicating the class of error.
-  const ErrorCode code;
+  ErrorCode code;
   /// Human-readable error message.
-  const Str message;
+  Str message;
 };
 
 /**

--- a/src/openassetio-core/include/openassetio/BatchElementError.hpp
+++ b/src/openassetio-core/include/openassetio/BatchElementError.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <functional>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -12,6 +13,11 @@
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
+/**
+ * @name Batch element errors
+ *
+ * @{
+ */
 /**
  * Structure representing per-element batch operation errors.
  *
@@ -111,16 +117,71 @@ class BatchElementError final {
 };
 
 /**
- * Callback signature used for an unsuccessful operation on an
- * element in a batch.
+ * Exception base that ties together a @ref BatchElementError and an
+ * index.
  *
- * This should be called for errors that are specific to a particular
- * reference in a batch. Exceptions can be thrown to indicate a
- * whole-batch error.
- *
- * The appropriate error code should be used for these errors. See
- * @fqref{BatchElementError.ErrorCode} "ErrorCode".
+ * When thrown from a function, indicates that a particular
+ * element has caused an error. The specific element that has errored
+ * is indicated by the index attribute, relative to the input container.
  */
-using BatchElementErrorCallback = std::function<void(std::size_t, const BatchElementError&)>;
+struct OPENASSETIO_CORE_EXPORT BatchElementException : std::runtime_error {
+  BatchElementException(std::size_t idx, BatchElementError err)
+      : std::runtime_error{err.message}, index{idx}, error{std::move(err)} {}
+
+  /**
+   * Index describing which batch element has caused an error.
+   */
+  std::size_t index;
+
+  /**
+   * Object describing the nature of the specific error.
+   */
+  BatchElementError error;
+};
+
+/**
+ * Exception equivalent of
+ * @ref BatchElementError.ErrorCode.kUnknown
+ */
+struct OPENASSETIO_CORE_EXPORT UnknownBatchElementException : BatchElementException {
+  using BatchElementException::BatchElementException;
+};
+
+/**
+ * Exception equivalent of
+ * @ref BatchElementError.ErrorCode.kInvalidEntityReference
+ */
+struct OPENASSETIO_CORE_EXPORT InvalidEntityReferenceBatchElementException
+    : BatchElementException {
+  using BatchElementException::BatchElementException;
+};
+
+/**
+ * Exception equivalent of
+ * @ref BatchElementError.ErrorCode.kMalformedEntityReference
+ */
+struct OPENASSETIO_CORE_EXPORT MalformedEntityReferenceBatchElementException
+    : BatchElementException {
+  using BatchElementException::BatchElementException;
+};
+
+/**
+ * Exception equivalent of
+ * @ref BatchElementError.ErrorCode.kEntityAccessError
+ */
+struct OPENASSETIO_CORE_EXPORT EntityAccessErrorBatchElementException : BatchElementException {
+  using BatchElementException::BatchElementException;
+};
+
+/**
+ * Exception equivalent of
+ * @ref BatchElementError.ErrorCode.kEntityResolutionError
+ */
+struct OPENASSETIO_CORE_EXPORT EntityResolutionErrorBatchElementException : BatchElementException {
+  using BatchElementException::BatchElementException;
+};
+/**
+ * @}
+ */
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -575,6 +575,27 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    */
 
   /**
+   * @name Batch element error handling
+   *
+   * @{
+   */
+  /**
+   * Callback signature used for an unsuccessful operation on an
+   * element in a batch.
+   *
+   * This should be called for errors that are specific to a particular
+   * reference in a batch. Exceptions can be thrown to indicate a
+   * whole-batch error.
+   *
+   * The appropriate error code should be used for these errors. See
+   * @fqref{BatchElementError.ErrorCode} "ErrorCode".
+   */
+  using BatchElementErrorCallback = std::function<void(std::size_t, const BatchElementError&)>;
+  /**
+   * @}
+   */
+
+  /**
    * @name Entity Reference Resolution
    *
    * The concept of resolution is turning an @ref entity_reference into

--- a/src/openassetio-core/tests/BatchElementErrorTest.cpp
+++ b/src/openassetio-core/tests/BatchElementErrorTest.cpp
@@ -17,9 +17,8 @@ SCENARIO("BatchElementError usage") {
     WHEN("a BatchElementError is constructed wrapping the code and message") {
       BatchElementError error{code, message};
 
-      THEN("code and message cannot be modified") {
-        STATIC_REQUIRE(std::is_const_v<decltype(error.code)>);
-        STATIC_REQUIRE(std::is_const_v<decltype(error.message)>);
+      THEN("BatchElementError is copyable") {
+        STATIC_REQUIRE(std::is_copy_assignable_v<decltype(error)>);
       }
 
       THEN("code and message are available for querying") {

--- a/src/openassetio-core/tests/hostApi/ManagerTest.cpp
+++ b/src/openassetio-core/tests/hostApi/ManagerTest.cpp
@@ -1,14 +1,415 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 The Foundry Visionmongers Ltd
 #include <type_traits>
+#include <variant>
+
+#include <openassetio/export.h>
 
 #include <catch2/catch.hpp>
+#include <catch2/trompeloeil.hpp>
 
+#include <openassetio/Context.hpp>
+#include <openassetio/TraitsData.hpp>
+#include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/hostApi/Manager.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/managerApi/Host.hpp>
+#include <openassetio/managerApi/HostSession.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+// Equality comparison for BatchElementError, useful in tests.
+// TODO(DF): implement in main codebase
+//  https://github.com/OpenAssetIO/OpenAssetIO/issues/862
+bool operator==(const BatchElementError& lhs, const BatchElementError& rhs) {
+  return lhs.code == rhs.code && lhs.message == rhs.message;
+}
 
-OPENASSETIO_FWD_DECLARE(managerApi, ManagerInterface)
+namespace {
+/**
+ * Mock implementation of a ManagerInterface.
+ *
+ * Used as constructor parameter to the Manager under test.
+ */
+struct MockManagerInterface : trompeloeil::mock_interface<managerApi::ManagerInterface> {
+  IMPLEMENT_CONST_MOCK0(identifier);
+  IMPLEMENT_CONST_MOCK0(displayName);
+  IMPLEMENT_CONST_MOCK0(info);
+  IMPLEMENT_MOCK2(initialize);
+  IMPLEMENT_CONST_MOCK3(managementPolicy);
+  IMPLEMENT_CONST_MOCK2(isEntityReferenceString);
+  IMPLEMENT_MOCK6(resolve);
+  IMPLEMENT_MOCK6(preflight);
+  IMPLEMENT_MOCK6(register_);  // NOLINT(readability-identifier-naming)
+};
+/**
+ * Mock implementation of a HostInterface.
+ *
+ * Used as constructor parameter to Host classes required as part of these tests
+ */
+struct MockHostInterface : trompeloeil::mock_interface<hostApi::HostInterface> {
+  IMPLEMENT_CONST_MOCK0(identifier);
+  IMPLEMENT_CONST_MOCK0(displayName);
+  IMPLEMENT_CONST_MOCK0(info);
+};
+/**
+ * Mock implementation of a LoggerInterface
+ *
+ * Used as constructor parameter to Host classes required as part of these tests
+ */
+struct MockLoggerInterface : trompeloeil::mock_interface<log::LoggerInterface> {
+  IMPLEMENT_MOCK2(log);
+};
+}  // namespace
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio
 
 SCENARIO("Manager constructor is private") {
   STATIC_REQUIRE_FALSE(std::is_constructible_v<openassetio::hostApi::Manager,
                                                openassetio::managerApi::ManagerInterfacePtr>);
+}
+
+SCENARIO("Resolving entities") {
+  namespace managerApi = openassetio::managerApi;
+  namespace hostApi = openassetio::hostApi;
+  using trompeloeil::_;
+
+  GIVEN("a configured Manager instance") {
+    const std::shared_ptr<managerApi::ManagerInterface> managerInterface =
+        std::make_shared<openassetio::MockManagerInterface>();
+
+    auto mockManagerInterfacePtr =
+        std::static_pointer_cast<openassetio::MockManagerInterface>(managerInterface);
+
+    // Create a HostSession with our mock HostInterface
+    const managerApi::HostSessionPtr hostSessionPtr = managerApi::HostSession::make(
+        managerApi::Host::make(std::make_shared<openassetio::MockHostInterface>()),
+        std::make_shared<openassetio::MockLoggerInterface>());
+
+    // Create the Manager under test.
+    const hostApi::ManagerPtr manager =
+        hostApi::Manager::make(mockManagerInterfacePtr, hostSessionPtr);
+
+    const openassetio::trait::TraitSet traits = {"fakeTrait", "secondFakeTrait"};
+    auto context = openassetio::Context::make();
+
+    GIVEN("manager plugin successfully resolves a single entity reference") {
+      const openassetio::EntityReference ref = openassetio::EntityReference{"testReference"};
+      const openassetio::EntityReferences refs = {ref};
+
+      const openassetio::TraitsDataPtr expected = openassetio::TraitsData::make();
+      expected->addTrait("aTestTrait");
+
+      // With success callback side effect
+      REQUIRE_CALL(*mockManagerInterfacePtr, resolve(refs, traits, context, hostSessionPtr, _, _))
+          .LR_SIDE_EFFECT(_5(0, expected));
+
+      WHEN("singular resolve is called with default errorPolicyTag") {
+        const openassetio::TraitsDataPtr actual = manager->resolve(ref, traits, context);
+        THEN("returned TraitsData is as expected") { CHECK(expected.get() == actual.get()); }
+      }
+      WHEN("singular resolve is called with kException errorPolicyTag") {
+        const openassetio::TraitsDataPtr actual = manager->resolve(
+            ref, traits, context, hostApi::Manager::BatchElementErrorPolicyTag::kException);
+        THEN("returned TraitsData is as expected") { CHECK(expected.get() == actual.get()); }
+      }
+      WHEN("singular resolve is called with kVariant errorPolicyTag") {
+        std::variant<openassetio::TraitsDataPtr, openassetio::BatchElementError> actual =
+            manager->resolve(ref, traits, context,
+                             hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
+        THEN("returned variant contains the expected TraitsData") {
+          CHECK(std::holds_alternative<openassetio::TraitsDataPtr>(actual));
+          auto actualVal = std::get<openassetio::TraitsDataPtr>(actual);
+          CHECK(expected.get() == actualVal.get());
+        }
+      }
+    }
+    GIVEN("manager plugin successfully resolves multiple entity references") {
+      const openassetio::EntityReferences refs = {openassetio::EntityReference{"testReference1"},
+                                                  openassetio::EntityReference{"testReference2"},
+                                                  openassetio::EntityReference{"testReference3"}};
+
+      const openassetio::TraitsDataPtr expected1 = openassetio::TraitsData::make();
+      expected1->addTrait("aTestTrait1");
+      const openassetio::TraitsDataPtr expected2 = openassetio::TraitsData::make();
+      expected2->addTrait("aTestTrait2");
+      const openassetio::TraitsDataPtr expected3 = openassetio::TraitsData::make();
+      expected3->addTrait("aTestTrait3");
+      std::vector<openassetio::TraitsDataPtr> expectedVec{expected1, expected2, expected3};
+
+      // With success callback side effect
+      REQUIRE_CALL(*mockManagerInterfacePtr, resolve(refs, traits, context, hostSessionPtr, _, _))
+          .LR_SIDE_EFFECT(_5(0, expectedVec[0]))
+          .LR_SIDE_EFFECT(_5(1, expectedVec[1]))
+          .LR_SIDE_EFFECT(_5(2, expectedVec[2]));
+
+      WHEN("batch resolve is called with default errorPolicyTag") {
+        const std::vector<openassetio::TraitsDataPtr> actualVec =
+            manager->resolve(refs, traits, context);
+        THEN("returned list of TraitsDatas is as expected") { CHECK(expectedVec == actualVec); }
+      }
+      WHEN("batch resolve is called with kException errorPolicyTag") {
+        const std::vector<openassetio::TraitsDataPtr> actualVec = manager->resolve(
+            refs, traits, context, hostApi::Manager::BatchElementErrorPolicyTag::kException);
+        THEN("returned list of TraitsDatas is as expected") { CHECK(expectedVec == actualVec); }
+      }
+      WHEN("batch resolve is called with kVariant errorPolicyTag") {
+        std::vector<std::variant<openassetio::TraitsDataPtr, openassetio::BatchElementError>>
+            actualVec = manager->resolve(refs, traits, context,
+                                         hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
+        THEN("returned lists of variants contains the expected TraitsDatas") {
+          CHECK(expectedVec.size() == actualVec.size());
+          for (size_t i = 0; i < actualVec.size(); ++i) {
+            CHECK(std::holds_alternative<openassetio::TraitsDataPtr>(actualVec[i]));
+            auto actualVal = std::get<openassetio::TraitsDataPtr>(actualVec[i]);
+            CHECK(expectedVec[i].get() == actualVal.get());
+          }
+        }
+      }
+    }
+    GIVEN("manager plugin successfully resolves multiple entity references in a non-index order") {
+      const openassetio::EntityReferences refs = {openassetio::EntityReference{"testReference1"},
+                                                  openassetio::EntityReference{"testReference2"},
+                                                  openassetio::EntityReference{"testReference3"}};
+
+      const openassetio::TraitsDataPtr expected1 = openassetio::TraitsData::make();
+      expected1->addTrait("aTestTrait1");
+      const openassetio::TraitsDataPtr expected2 = openassetio::TraitsData::make();
+      expected2->addTrait("aTestTrait2");
+      const openassetio::TraitsDataPtr expected3 = openassetio::TraitsData::make();
+      expected3->addTrait("aTestTrait3");
+      std::vector<openassetio::TraitsDataPtr> expectedVec{expected1, expected2, expected3};
+
+      // With success callback side effect, given out of order.
+      REQUIRE_CALL(*mockManagerInterfacePtr, resolve(refs, traits, context, hostSessionPtr, _, _))
+          .LR_SIDE_EFFECT(_5(2, expectedVec[2]))
+          .LR_SIDE_EFFECT(_5(0, expectedVec[0]))
+          .LR_SIDE_EFFECT(_5(1, expectedVec[1]));
+
+      WHEN("batch resolve is called with default errorPolicyTag") {
+        const std::vector<openassetio::TraitsDataPtr> actualVec =
+            manager->resolve(refs, traits, context);
+        THEN("returned list of TraitsDatas is ordered in index order") {
+          CHECK(expectedVec == actualVec);
+        }
+      }
+      WHEN("batch resolve is called with kException errorPolicyTag") {
+        const std::vector<openassetio::TraitsDataPtr> actualVec = manager->resolve(
+            refs, traits, context, hostApi::Manager::BatchElementErrorPolicyTag::kException);
+        THEN("returned list of TraitsDatas is ordered in index order") {
+          CHECK(expectedVec == actualVec);
+        }
+      }
+      WHEN("batch resolve is called with kVariant errorPolicyTag") {
+        std::vector<std::variant<openassetio::TraitsDataPtr, openassetio::BatchElementError>>
+            actualVec = manager->resolve(refs, traits, context,
+                                         hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
+        THEN("returned lists of variants is ordered in index order") {
+          CHECK(expectedVec.size() == actualVec.size());
+          for (size_t i = 0; i < actualVec.size(); ++i) {
+            CHECK(std::holds_alternative<openassetio::TraitsDataPtr>(actualVec[i]));
+            auto actualVal = std::get<openassetio::TraitsDataPtr>(actualVec[i]);
+            CHECK(expectedVec[i].get() == actualVal.get());
+          }
+        }
+      }
+    }
+    GIVEN(
+        "manager plugin will encounter an entity-specific error when next resolving a reference") {
+      const openassetio::EntityReference ref = openassetio::EntityReference{"testReference"};
+      const openassetio::EntityReferences refs = {ref};
+
+      openassetio::BatchElementError expected{
+          openassetio::BatchElementError::ErrorCode::kMalformedEntityReference, "Error Message"};
+
+      // With success callback side effect
+      REQUIRE_CALL(*mockManagerInterfacePtr, resolve(refs, traits, context, hostSessionPtr, _, _))
+          .LR_SIDE_EFFECT(_6(0, expected));
+
+      WHEN("singular resolve is called with default errorPolicyTag") {
+        THEN("an exception is thrown") {
+          CHECK_THROWS_MATCHES(manager->resolve(ref, traits, context),
+                               openassetio::MalformedEntityReferenceBatchElementException,
+                               Catch::Message("Error Message"));
+        }
+      }
+      WHEN("singular resolve is called with kException errorPolicyTag") {
+        THEN("an exception is thrown") {
+          CHECK_THROWS_MATCHES(
+              manager->resolve(ref, traits, context,
+                               hostApi::Manager::BatchElementErrorPolicyTag::kException),
+              openassetio::MalformedEntityReferenceBatchElementException,
+              Catch::Message("Error Message"));
+        }
+      }
+      WHEN("singular resolve is called with kVariant errorPolicyTag") {
+        std::variant<openassetio::TraitsDataPtr, openassetio::BatchElementError> actual =
+            manager->resolve(ref, traits, context,
+                             hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
+        THEN("returned variant contains the expected BatchElementError") {
+          CHECK(std::holds_alternative<openassetio::BatchElementError>(actual));
+          const auto& actualVal = std::get<openassetio::BatchElementError>(actual);
+          CHECK(expected == actualVal);
+          // TODO(EM): BatchElementError is currently copied, but we
+          //  may switch this to move semantics.
+          // https://github.com/OpenAssetIO/OpenAssetIO/issues/858
+          CHECK_FALSE(expected.message.data() == actualVal.message.data());
+        }
+      }
+    }
+    GIVEN(
+        "manager plugin will encounter entity-specific errors when next resolving multiple "
+        "references") {
+      const openassetio::EntityReferences refs = {openassetio::EntityReference{"testReference1"},
+                                                  openassetio::EntityReference{"testReference2"},
+                                                  openassetio::EntityReference{"testReference3"}};
+
+      const openassetio::TraitsDataPtr expectedValue2 = openassetio::TraitsData::make();
+      expectedValue2->addTrait("aTestTrait");
+      const openassetio::BatchElementError expectedError0{
+          openassetio::BatchElementError::ErrorCode::kMalformedEntityReference,
+          "Malformed Mock Error🤖"};
+      const openassetio::BatchElementError expectedError1{
+          openassetio::BatchElementError::ErrorCode::kEntityAccessError,
+          "Entity Access Error Message"};
+
+      // With success callback side effect
+      REQUIRE_CALL(*mockManagerInterfacePtr, resolve(refs, traits, context, hostSessionPtr, _, _))
+          .LR_SIDE_EFFECT(_5(2, expectedValue2))
+          .LR_SIDE_EFFECT(_6(0, expectedError0))
+          .LR_SIDE_EFFECT(_6(1, expectedError1));
+
+      WHEN("batch resolve is called with default errorPolicyTag") {
+        THEN("an exception is thrown") {
+          CHECK_THROWS_MATCHES(manager->resolve(refs, traits, context),
+                               openassetio::MalformedEntityReferenceBatchElementException,
+                               Catch::Message("Malformed Mock Error🤖"));
+        }
+      }
+      WHEN("batch resolve is called with kException errorPolicyTag") {
+        THEN("an exception is thrown") {
+          CHECK_THROWS_MATCHES(
+              manager->resolve(refs, traits, context,
+                               hostApi::Manager::BatchElementErrorPolicyTag::kException),
+              openassetio::MalformedEntityReferenceBatchElementException,
+              Catch::Message("Malformed Mock Error🤖"));
+        }
+      }
+      WHEN("batch resolve is called with kVariant errorPolicyTag") {
+        std::vector<std::variant<openassetio::TraitsDataPtr, openassetio::BatchElementError>>
+            actualVec = manager->resolve(refs, traits, context,
+                                         hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
+        THEN("returned lists of variants contains the expected objects") {
+          auto error0 = std::get<openassetio::BatchElementError>(actualVec[0]);
+          CHECK(error0 == expectedError0);
+
+          auto error1 = std::get<openassetio::BatchElementError>(actualVec[1]);
+          CHECK(error1 == expectedError1);
+
+          CHECK(std::get<openassetio::TraitsDataPtr>(actualVec[2]) == expectedValue2);
+        }
+      }
+    }
+  }
+}
+
+using ErrorCode = openassetio::BatchElementError::ErrorCode;
+
+template <class T, ErrorCode C>
+struct BatchElementErrorMapping {
+  using ExceptionType = T;
+  static constexpr ErrorCode kErrorCode = C;
+};
+
+TEMPLATE_TEST_CASE(
+    "BatchElementError conversion to exceptions when resolving", "",
+    (BatchElementErrorMapping<openassetio::UnknownBatchElementException, ErrorCode::kUnknown>),
+    (BatchElementErrorMapping<openassetio::InvalidEntityReferenceBatchElementException,
+                              ErrorCode::kInvalidEntityReference>),
+    (BatchElementErrorMapping<openassetio::MalformedEntityReferenceBatchElementException,
+                              ErrorCode::kMalformedEntityReference>),
+    (BatchElementErrorMapping<openassetio::EntityAccessErrorBatchElementException,
+                              ErrorCode::kEntityAccessError>),
+    (BatchElementErrorMapping<openassetio::EntityResolutionErrorBatchElementException,
+                              ErrorCode::kEntityResolutionError>)) {
+  namespace managerApi = openassetio::managerApi;
+  namespace hostApi = openassetio::hostApi;
+  using trompeloeil::_;
+
+  using ExpectedExceptionType = typename TestType::ExceptionType;
+  static constexpr ErrorCode kExpectedErrorCode = TestType::kErrorCode;
+
+  GIVEN("a configured Manager instance") {
+    const std::shared_ptr<managerApi::ManagerInterface> managerInterface =
+        std::make_shared<openassetio::MockManagerInterface>();
+
+    auto mockManagerInterfacePtr =
+        std::static_pointer_cast<openassetio::MockManagerInterface>(managerInterface);
+
+    // Create a HostSession with our mock HostInterface
+    const managerApi::HostSessionPtr hostSessionPtr = managerApi::HostSession::make(
+        managerApi::Host::make(std::make_shared<openassetio::MockHostInterface>()),
+        std::make_shared<openassetio::MockLoggerInterface>());
+
+    // Create the Manager under test.
+    const hostApi::ManagerPtr manager =
+        hostApi::Manager::make(mockManagerInterfacePtr, hostSessionPtr);
+
+    const openassetio::trait::TraitSet traits = {"fakeTrait", "secondFakeTrait"};
+    auto context = openassetio::Context::make();
+
+    AND_GIVEN(
+        "manager plugin will encounter an entity-specific error when next resolving a reference") {
+      const openassetio::EntityReference ref = openassetio::EntityReference{"testReference"};
+      const openassetio::EntityReferences refs = {ref};
+
+      const openassetio::BatchElementError expectedError{kExpectedErrorCode, "Some error message"};
+
+      // With success callback side effect
+      REQUIRE_CALL(*mockManagerInterfacePtr, resolve(refs, traits, context, hostSessionPtr, _, _))
+          .LR_SIDE_EFFECT(_6(123, expectedError));
+
+      WHEN("resolve is called with kException errorPolicyTag") {
+        THEN("an exception is thrown") {
+          try {
+            manager->resolve(ref, traits, context,
+                             hostApi::Manager::BatchElementErrorPolicyTag::kException);
+            FAIL_CHECK("Exception not thrown");
+          } catch (const ExpectedExceptionType& exc) {
+            CHECK(exc.what() == expectedError.message);
+            CHECK(exc.error == expectedError);
+            CHECK(exc.index == 123);
+          }
+        }
+      }
+    }
+
+    AND_GIVEN(
+        "manager plugin will encounter entity-specific errors when next resolving multiple "
+        "references") {
+      const openassetio::EntityReferences refs = {openassetio::EntityReference{"testReference1"},
+                                                  openassetio::EntityReference{"testReference2"}};
+
+      const openassetio::BatchElementError expectedError{kExpectedErrorCode, "Some error"};
+
+      // With success callback side effect
+      REQUIRE_CALL(*mockManagerInterfacePtr, resolve(refs, traits, context, hostSessionPtr, _, _))
+          .LR_SIDE_EFFECT(_6(123, expectedError))
+          .LR_SIDE_EFFECT(FAIL_CHECK("Exception should have short-circuited this"));
+
+      WHEN("resolve is called with kException errorPolicyTag") {
+        THEN("an exception is thrown") {
+          try {
+            manager->resolve(refs, traits, context,
+                             hostApi::Manager::BatchElementErrorPolicyTag::kException);
+            FAIL_CHECK("Exception not thrown");
+          } catch (const ExpectedExceptionType& exc) {
+            CHECK(exc.what() == expectedError.message);
+            CHECK(exc.error == expectedError);
+            CHECK(exc.index == 123);
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -5,6 +5,7 @@
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
+#include <openassetio/BatchElementError.hpp>
 #include <openassetio/Context.hpp>
 #include <openassetio/TraitsData.hpp>
 #include <openassetio/hostApi/Manager.hpp>
@@ -45,8 +46,13 @@ void registerManager(const py::module& mod) {
            py::arg("entityReferenceString"))
       .def("createEntityReferenceIfValid", &Manager::createEntityReferenceIfValid,
            py::arg("entityReferenceString"))
-      .def("resolve", &Manager::resolve, py::arg("entityReferences"), py::arg("traitSet"),
-           py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"))
+      .def("resolve",
+           static_cast<void (Manager::*)(
+               const EntityReferences&, const trait::TraitSet&, const ContextConstPtr&,
+               const Manager::ResolveSuccessCallback&, const Manager::BatchElementErrorCallback&)>(
+               &Manager::resolve),
+           py::arg("entityReferences"), py::arg("traitSet"), py::arg("context").none(false),
+           py::arg("successCallback"), py::arg("errorCallback"))
       .def("preflight", &Manager::preflight, py::arg("entityReferences"), py::arg("traitSet"),
            py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"))
       .def(
@@ -54,7 +60,7 @@ void registerManager(const py::module& mod) {
           [](Manager& self, const EntityReferences& entityReferences,
              const trait::TraitsDatas& entityTraitsDatas, const ContextConstPtr& context,
              const Manager::RegisterSuccessCallback& successCallback,
-             const openassetio::BatchElementErrorCallback& errorCallback) {
+             const Manager::BatchElementErrorCallback& errorCallback) {
             // Pybind has no built-in way to assert that a collection
             // does not contain any `None` elements, so we must add our
             // own check here.


### PR DESCRIPTION
## Description

Closes https://github.com/OpenAssetIO/OpenAssetIO/issues/849. 

Previously, the only interface to `resolve` assumed a batch of entity references with success/error callbacks executed for
each element. This is somewhat clunky when only resolving a single reference in particular, and requires significant boilerplate.

So add convenience overloads that present the API in a friendlier and more versatile manner.

As resolve conveniences in C++ and Python are going to be somewhat distinct, add C++ tests to verify behaviour of `variant` and exception error modes.
