### PR TITLE
Python `resolve` method host conveniences

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,11 +23,12 @@ v1.0.0-alpha.X
   mechanism for testing whether a `TraitsData` is imbued with a trait.
   [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)
 
-- Added C++ `resolve` overloads for convenience, providing alternatives
+- Added `resolve` overloads for convenience, providing alternatives
   to the core callback-based workflow. Includes a more direct method for
   resolving a single entity reference, and exception vs. result object
   workflows.
   [#849](https://github.com/OpenAssetIO/OpenAssetIO/issues/849)
+  [#850](https://github.com/OpenAssetIO/OpenAssetIO/issues/850)
 
 ### Improvements
 

--- a/doc/doxygen/src/Examples.dox
+++ b/doc/doxygen/src/Examples.dox
@@ -169,8 +169,8 @@
  * # We can now resolve a token we may have if it is a reference. In
  * # this example, we'll attempt to resolve the LocatableContent trait
  * # for the entity.
- * [resolved_asset] = manager.resolve(
- *         [entity_reference], {locatableContentTrait.kId}, context)
+ * resolved_asset = manager.resolve(
+ *         entity_reference, {locatableContentTrait.kId}, context)
  * url = LocatableContentTrait(resolved_asset).getLocation()  # May be None
  * @endcode
  *
@@ -213,7 +213,7 @@
  * # We then check if the manager can tell us where to save the file.
  * if ResolvesFutureEntitiesTrait.isImbuedTo(policy):
  *     working_data = manager.resolve(
- *             [working_ref], TextFileSpecification.kTraitSet, context)[0]
+ *             working_ref, TextFileSpecification.kTraitSet, context)
  *     working_spec = TextFileSpecification(working_data)
  *     if save_url := working_spec.locatableContentTrait().getLocation():
  *         save_path = pathFromURL(save_url)  # URL decode etc
@@ -270,7 +270,7 @@
  * # See if the manager can tell us where to put it, and what it should be like
  * if ResolvesFutureEntitiesTrait.isImbuedTo(policy):
  *     requested = manager.resolve(
- *             [thumbnail_ref], ThumbnailFileSpecification.kTraitSet, context)[0]
+ *             thumbnail_ref, ThumbnailFileSpecification.kTraitSet, context)
  *     requested_spec = ThumbnailFileSpecification(requested)
  *     if requested_path := requested_spec.locatableContentTrait().getLocation():
  *         thumbnail_path = pathFromURL(requested_path)

--- a/doc/doxygen/src/ManagerState.dox
+++ b/doc/doxygen/src/ManagerState.dox
@@ -107,7 +107,7 @@
  *     Manager --> worker : context
  *     worker -> worker : context.access = context.kWrite
  *     worker -> worker : working_reference = ref_map["ref://asset"]
- *     worker -> Manager : [spec] = resolve([working_reference], {FileTrait.id}, context)
+ *     worker -> Manager : spec = resolve(working_reference, {FileTrait.id}, context)
  *     Manager --> worker : Specification({"file": {"url": "file:///out.####.exr"}})
  *     worker -> worker : write_data(FileTrait(spec).url())
  *     worker --> scheduler
@@ -124,7 +124,7 @@
  * Manager --> worker : context
  * worker -> worker : context.access = context.kWrite
  * worker -> worker : working_reference = ref_map["ref://asset"]
- * worker -> Manager : path = resolve([working_reference], FileTrait.id, context)[0]
+ * worker -> Manager : path = resolve(working_reference, FileTrait.id, context)
  * Manager --> worker : "file://out.####.exr"
  * worker -> Manager : final_reference = register([working_reference], [path], context)[0]
  * Manager --> worker : "ref://asset=v4"

--- a/src/openassetio-python/cmodule/src/BatchElementErrorBinding.cpp
+++ b/src/openassetio-python/cmodule/src/BatchElementErrorBinding.cpp
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <string_view>
+
+#include <pybind11/eval.h>
 #include <pybind11/pybind11.h>
 
 #include <openassetio/BatchElementError.hpp>
 
 #include "_openassetio.hpp"
 
-void registerBatchElementError(const py::module &mod) {
+void registerBatchElementError(py::module &mod) {
   using openassetio::BatchElementError;
 
   py::class_<BatchElementError> batchElementError{mod, "BatchElementError", py::is_final()};
@@ -23,4 +26,95 @@ void registerBatchElementError(const py::module &mod) {
            py::arg("message"))
       .def_readonly("code", &BatchElementError::code)
       .def_readonly("message", &BatchElementError::message);
+
+  // Pybind has very limited support for custom exception types. This is
+  // a well-known tricky issue and is apparently not on the roadmap to
+  // fix. The only direct support is for an exception type that takes a
+  // single string parameter (message). However, we need `index` and
+  // `error` parameters to mirror C++.
+  //
+  // A way forward is provided by the sketch in:
+  // https://github.com/pybind/pybind11/issues/1281#issuecomment-1375950333
+  //
+  // We execute a Python string literal to create our base exception
+  // type. The `globals` and `locals` dict parameters dictate the scope
+  // of execution, so we use this to ensure the definition is scoped to
+  // our `_openassetio` module.
+  //
+  // We can then retrieve this base exception type as a pybind object
+  // and use it as the base class for pybind's limited exception
+  // registration API.
+
+  py::exec(R"pybind(
+class BatchElementException(RuntimeError):
+    def __init__(self, index: int, error):
+        self.index = index
+        self.error = error
+        super().__init__(error.message))pybind",
+           mod.attr("__dict__"), mod.attr("__dict__"));
+
+  // Retrieve a handle the the exception type just created by executing
+  // the string literal above.
+  const py::object pyBatchElementException = mod.attr("BatchElementException");
+
+  using openassetio::BatchElementException;
+  using openassetio::EntityAccessErrorBatchElementException;
+  using openassetio::EntityResolutionErrorBatchElementException;
+  using openassetio::InvalidEntityReferenceBatchElementException;
+  using openassetio::MalformedEntityReferenceBatchElementException;
+  using openassetio::UnknownBatchElementException;
+
+  // Register a new exception type using `BatchElementException` base
+  // class created above. Note that this is not sufficient to cause C++
+  // exceptions to be translated. See `register_exception_translator`
+  // below.
+  const auto registerPyException = [&mod, &pyBatchElementException](const char *pyTypeName) {
+    py::exception<void /* unused */>{mod, pyTypeName, pyBatchElementException};
+  };
+
+  // Register each of our BatchElement exception types.
+  registerPyException("UnknownBatchElementException");
+  registerPyException("InvalidEntityReferenceBatchElementException");
+  registerPyException("MalformedEntityReferenceBatchElementException");
+  registerPyException("EntityAccessErrorBatchElementException");
+  registerPyException("EntityResolutionErrorBatchElementException");
+
+  // Register a function that will translate our C++ exceptions to the
+  // appropriate Python exception type.
+  //
+  // Note that capturing lambdas are not allowed here, so we must
+  // `import` the exception type in the body of the function.
+  py::register_exception_translator([](std::exception_ptr pexc) {
+    if (!pexc) {
+      return;
+    }
+    const py::module_ pyModule = py::module_::import("openassetio._openassetio");
+
+    // Use CPython's PyErr_SetObject to set a custom exception type as
+    // the currently active Python exception in this thread.
+    const auto setPyException = [&pyModule](const char *pyTypeName, const auto &exc) {
+      const py::object pyClass = pyModule.attr(pyTypeName);
+      const py::object pyInstance = pyClass(exc.index, exc.error);
+      PyErr_SetObject(pyClass.ptr(), pyInstance.ptr());
+    };
+
+    // Handle the different possible C++ exceptions, creating the
+    // corresponding Python exception and setting it as the active
+    // exception in this thread.
+    try {
+      std::rethrow_exception(std::move(pexc));
+    } catch (const UnknownBatchElementException &exc) {
+      setPyException("UnknownBatchElementException", exc);
+    } catch (const InvalidEntityReferenceBatchElementException &exc) {
+      setPyException("InvalidEntityReferenceBatchElementException", exc);
+    } catch (const MalformedEntityReferenceBatchElementException &exc) {
+      setPyException("MalformedEntityReferenceBatchElementException", exc);
+    } catch (const EntityAccessErrorBatchElementException &exc) {
+      setPyException("EntityAccessErrorBatchElementException", exc);
+    } catch (const EntityResolutionErrorBatchElementException &exc) {
+      setPyException("EntityResolutionErrorBatchElementException", exc);
+    } catch (const BatchElementException &exc) {
+      setPyException("BatchElementException", exc);
+    }
+  });
 }

--- a/src/openassetio-python/cmodule/src/_openassetio.hpp
+++ b/src/openassetio-python/cmodule/src/_openassetio.hpp
@@ -84,4 +84,4 @@ void registerManagerStateBase(const py::module& mod);
 void registerEntityReference(const py::module& mod);
 
 /// Register the BatchElementError type with Python.
-void registerBatchElementError(const py::module& mod);
+void registerBatchElementError(py::module& mod);

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -25,7 +25,24 @@ void registerManager(const py::module& mod) {
   using openassetio::managerApi::HostSessionPtr;
   using openassetio::managerApi::ManagerInterfacePtr;
 
-  py::class_<Manager, ManagerPtr>(mod, "Manager")
+  py::class_<Manager, ManagerPtr> pyManager{mod, "Manager"};
+
+  // BatchElementErrorPolicy tags for tag dispatch overload resolution
+  // idiom.
+  py::class_<Manager::BatchElementErrorPolicyTag> pyBatchElementErrorPolicyTag{
+      pyManager, "BatchElementErrorPolicyTag"};
+  // NOLINTNEXTLINE(bugprone-unused-raii)
+  py::class_<Manager::BatchElementErrorPolicyTag::Exception>{pyBatchElementErrorPolicyTag,
+                                                             "Exception"};
+  // NOLINTNEXTLINE(bugprone-unused-raii)
+  py::class_<Manager::BatchElementErrorPolicyTag::Variant>{pyBatchElementErrorPolicyTag,
+                                                           "Variant"};
+
+  pyBatchElementErrorPolicyTag
+      .def_readonly_static("kException", &Manager::BatchElementErrorPolicyTag::kException)
+      .def_readonly_static("kVariant", &Manager::BatchElementErrorPolicyTag::kVariant);
+
+  pyManager
       .def(py::init(RetainCommonPyArgs::forFn<&Manager::make>()),
            py::arg("managerInterface").none(false), py::arg("hostSession").none(false))
       .def("identifier", &Manager::identifier)

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -18,6 +18,7 @@
 void registerManager(const py::module& mod) {
   namespace trait = openassetio::trait;
   using openassetio::ContextConstPtr;
+  using openassetio::EntityReference;
   using openassetio::EntityReferences;
   using openassetio::TraitsDataPtr;
   using openassetio::hostApi::Manager;
@@ -70,6 +71,55 @@ void registerManager(const py::module& mod) {
                &Manager::resolve),
            py::arg("entityReferences"), py::arg("traitSet"), py::arg("context").none(false),
            py::arg("successCallback"), py::arg("errorCallback"))
+      .def("resolve",
+           static_cast<TraitsDataPtr (Manager::*)(
+               const EntityReference&, const trait::TraitSet&, const ContextConstPtr&,
+               const Manager::BatchElementErrorPolicyTag::Exception&)>(&Manager::resolve),
+           py::arg("entityReference"), py::arg("traitSet"), py::arg("context").none(false),
+           py::arg("errorPolicyTag"))
+      .def("resolve",
+           static_cast<std::variant<TraitsDataPtr, openassetio::BatchElementError> (Manager::*)(
+               const EntityReference&, const trait::TraitSet&, const ContextConstPtr&,
+               const Manager::BatchElementErrorPolicyTag::Variant&)>(&Manager::resolve),
+           py::arg("entityReference"), py::arg("traitSet"), py::arg("context").none(false),
+           py::arg("errorPolicyTag"))
+      .def(
+          "resolve",
+          // TODO(DF): Technically we shouldn't need this overload,
+          // since we can use a similar trick to C++ to default the
+          // appropriate overload's tag parameter, e.g.
+          // `py::arg("errorPolicyTag") = {}`. However, this causes a
+          // memory leak in pybind11.
+          [](Manager& self, const EntityReference& entityReference,
+             const trait::TraitSet& traitSet, const ContextConstPtr& context) {
+            return self.resolve(entityReference, traitSet, context);
+          },
+          py::arg("entityReference"), py::arg("traitSet"), py::arg("context").none(false))
+      .def("resolve",
+           static_cast<std::vector<TraitsDataPtr> (Manager::*)(
+               const EntityReferences&, const trait::TraitSet&, const ContextConstPtr&,
+               const Manager::BatchElementErrorPolicyTag::Exception&)>(&Manager::resolve),
+           py::arg("entityReferences"), py::arg("traitSet"), py::arg("context").none(false),
+           py::arg("errorPolicyTag"))
+      .def(
+          "resolve",
+          static_cast<std::vector<std::variant<TraitsDataPtr, openassetio::BatchElementError>> (
+              Manager::*)(const EntityReferences&, const trait::TraitSet&, const ContextConstPtr&,
+                          const Manager::BatchElementErrorPolicyTag::Variant&)>(&Manager::resolve),
+          py::arg("entityReferences"), py::arg("traitSet"), py::arg("context").none(false),
+          py::arg("errorPolicyTag"))
+      .def(
+          "resolve",
+          // TODO(DF): Technically we shouldn't need this overload,
+          // since we can use a similar trick to C++ to default the
+          // appropriate overload's tag parameter, e.g.
+          // `py::arg("errorPolicyTag") = {}`. However, this causes a
+          // memory leak in pybind11.
+          [](Manager& self, const EntityReferences& entityReferences,
+             const trait::TraitSet& traitSet, const ContextConstPtr& context) {
+            return self.resolve(entityReferences, traitSet, context);
+          },
+          py::arg("entityReferences"), py::arg("traitSet"), py::arg("context").none(false))
       .def("preflight", &Manager::preflight, py::arg("entityReferences"), py::arg("traitSet"),
            py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"))
       .def(

--- a/src/openassetio-python/package/openassetio/__init__.py
+++ b/src/openassetio-python/package/openassetio/__init__.py
@@ -76,6 +76,12 @@ from ._openassetio import (  # pylint: disable=import-error
     Context,
     EntityReference,
     BatchElementError,
+    BatchElementException,
+    UnknownBatchElementException,
+    InvalidEntityReferenceBatchElementException,
+    MalformedEntityReferenceBatchElementException,
+    EntityAccessErrorBatchElementException,
+    EntityResolutionErrorBatchElementException,
 )
 
 # pylint: disable=wrong-import-position

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -547,6 +547,14 @@ class Test_Manager_getRelatedReferences:
         )
 
 
+class Test_Manager_BatchElementErrorPolicyTag:
+    def test_unique(self):
+        assert (
+            Manager.BatchElementErrorPolicyTag.kVariant
+            is not Manager.BatchElementErrorPolicyTag.kException
+        )
+
+
 class Test_Manager_resolve:
     def test_method_defined_in_cpp(self, method_introspector):
         assert not method_introspector.is_defined_in_python(Manager.resolve)


### PR DESCRIPTION
## Description

Closes #850. Follows on from #849 (not just numerically).

For parity with C++ methods, bind `resolve` convenience overloads to Python.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.

## Test Instructions

Python unit tests added.
