### PR TITLE
Fix clang-tidy v15 warnings

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,6 +44,10 @@ v1.0.0-alpha.X
 - Made `BatchElementError` a copyable type in the C++ API.
   [#849](https://github.com/OpenAssetIO/OpenAssetIO/issues/849)
 
+- Made the C++ codebase compliant with Clang-Tidy v15. Note that this is
+  not yet enforced on CI.
+  https://github.com/OpenAssetIO/OpenAssetIO/pull/874
+
 ### Bug fixes
 
 - Removed `nodiscard` from `TraitsData::getTraitProperty`, and

--- a/cmake/StaticAnalyzers.cmake
+++ b/cmake/StaticAnalyzers.cmake
@@ -11,6 +11,7 @@ macro(enable_clang_tidy)
         # Ignore unknown compiler flag check, otherwise e.g. GCC-only
         # compiler warning flags will cause the build to fail.
         list(APPEND CMAKE_CXX_CLANG_TIDY -extra-arg=-Wno-unknown-warning-option)
+        list(APPEND CMAKE_CXX_CLANG_TIDY -extra-arg=-Wno-ignored-optimization-argument)
 
         # Set standard
         if (NOT "${CMAKE_CXX_STANDARD}" STREQUAL "")

--- a/src/openassetio-core-c/.clang-tidy
+++ b/src/openassetio-core-c/.clang-tidy
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2013-2022 The Foundry Visionmongers Ltd
+
+InheritParentConfig: true
+
+# -bugprone-easily-swappable-parameters:
+#   Hard to avoid in a C API.
+Checks: >
+    -bugprone-easily-swappable-parameters

--- a/src/openassetio-core-c/src/InfoDictionary.cpp
+++ b/src/openassetio-core-c/src/InfoDictionary.cpp
@@ -27,15 +27,15 @@ template <class... T>
  *
  * @tparam Fn Type of callable to wrap.
  * @param err Storage for error message, if any.
- * @param fn Callable to wrap.
+ * @param callable Callable to wrap.
  * @return Error code.
  */
 template <typename Fn>
-oa_ErrorCode catchCommonExceptionAsCode(oa_StringView *err, Fn &&fn) {
+oa_ErrorCode catchCommonExceptionAsCode(oa_StringView *err, Fn &&callable) {
   // TODO(DF): @exception messages.
   return errors::catchUnknownExceptionAsCode(err, [&] {
     try {
-      return fn();
+      return callable();
     } catch (const std::out_of_range &exc) {
       // Default exception message:
       // VS 2019: "invalid unordered_map<K, T> key"

--- a/src/openassetio-core-c/src/errors.hpp
+++ b/src/openassetio-core-c/src/errors.hpp
@@ -55,13 +55,13 @@ void extractExceptionMessage(oa_StringView *err, const Exception &exc) {
  *
  * @tparam Fn Type of callable to wrap.
  * @param err Storage for error message, if any.
- * @param fn Callable to wrap.
+ * @param callable Callable to wrap.
  * @return Error code.
  */
 template <typename Fn>
-auto catchUnknownExceptionAsCode(oa_StringView *err, Fn &&fn) {
+auto catchUnknownExceptionAsCode(oa_StringView *err, Fn &&callable) {
   try {
-    return fn();
+    return callable();
   } catch (std::exception &exc) {
     extractExceptionMessage(err, exc);
     return oa_ErrorCode_kException;

--- a/src/openassetio-core-c/src/hostApi/Manager.cpp
+++ b/src/openassetio-core-c/src/hostApi/Manager.cpp
@@ -32,10 +32,10 @@ oa_ErrorCode oa_hostApi_Manager_ctor(oa_StringView* err, oa_hostApi_Manager_h* h
                                      oa_managerApi_SharedManagerInterface_h managerInterfaceHandle,
                                      oa_managerApi_SharedHostSession_h hostSessionHandle) {
   return errors::catchUnknownExceptionAsCode(err, [&] {
-    managerApi::ManagerInterfacePtr& managerInterfacePtr =
+    const managerApi::ManagerInterfacePtr& managerInterfacePtr =
         *handles::managerApi::SharedManagerInterface::toInstance(managerInterfaceHandle);
 
-    managerApi::HostSessionPtr& hostSessionPtr =
+    const managerApi::HostSessionPtr& hostSessionPtr =
         *handles::managerApi::SharedHostSession::toInstance(hostSessionHandle);
 
     auto* manager = new hostApi::ManagerPtr;

--- a/src/openassetio-core-c/tests/.clang-tidy
+++ b/src/openassetio-core-c/tests/.clang-tidy
@@ -3,6 +3,12 @@
 
 InheritParentConfig: true
 
-# Disable "cognitive complexity" check: Catch2 test macros trigger this.
+# -readability-function-cognitive-complexity
+#   Catch2 test macros trigger this.
+# -bugprone-infinite-loop
+#   clang-tidy v12 flags false positives for Catch2 CHECK macro.
+#   TODO(DF): Remove once clang-tidy version updated.
 Checks: >
-    -readability-function-cognitive-complexity
+    -readability-function-cognitive-complexity,
+     -bugprone-infinite-loop
+

--- a/src/openassetio-core-c/tests/InfoDictionaryTest.cpp
+++ b/src/openassetio-core-c/tests/InfoDictionaryTest.cpp
@@ -34,7 +34,8 @@ SCENARIO("InfoDictionary construction, conversion and destruction") {
     //  a pain to simulate for testing.
 
     oa_InfoDictionary_h infoDictionaryHandle;
-    oa_ErrorCode actualErrorCode = oa_InfoDictionary_ctor(&actualErrorMsg, &infoDictionaryHandle);
+    const oa_ErrorCode actualErrorCode =
+        oa_InfoDictionary_ctor(&actualErrorMsg, &infoDictionaryHandle);
     CHECK(actualErrorCode == oa_ErrorCode_kOK);
 
     WHEN("handle is converted to a C++ instance") {
@@ -155,10 +156,10 @@ TEMPLATE_TEST_CASE_METHOD(TypeOfFixture,
     oa_StringView actualErrorMsg{errStorage.size(), errStorage.data(), 0};
 
     WHEN("the type of an entry is queried") {
-      oa_ConstStringView key{keyStr.data(), keyStr.size()};
+      const oa_ConstStringView key{keyStr.data(), keyStr.size()};
       oa_InfoDictionary_ValueType actualValueType;
 
-      oa_ErrorCode actualErrorCode =
+      const oa_ErrorCode actualErrorCode =
           oa_InfoDictionary_typeOf(&actualErrorMsg, &actualValueType, infoDictionaryHandle, key);
 
       THEN("returned type matches expected type") {
@@ -171,13 +172,13 @@ TEMPLATE_TEST_CASE_METHOD(TypeOfFixture,
 
 SCENARIO("Attempting to retrieve the type of a non-existent InfoDictionary entry via C API") {
   GIVEN("a populated C++ InfoDictionary and its C handle") {
-    InfoDictionaryFixture fixture{};
+    const InfoDictionaryFixture fixture{};
     const auto& infoDictionaryHandle = fixture.infoDictionaryHandle_;
 
     WHEN("the type of a non-existent entry is queried") {
       // Key to non-existent entry.
       const auto& nonExistentKey = InfoDictionaryFixture::kNonExistentKeyStr;
-      oa_ConstStringView key{nonExistentKey.data(), nonExistentKey.size()};
+      const oa_ConstStringView key{nonExistentKey.data(), nonExistentKey.size()};
       // Storage for error message.
       openassetio::Str errStorage(kStrStorageCapacity, '\0');
       oa_StringView actualErrorMsg{errStorage.size(), errStorage.data(), 0};
@@ -186,7 +187,7 @@ SCENARIO("Attempting to retrieve the type of a non-existent InfoDictionary entry
       // Storage for return value.
       oa_InfoDictionary_ValueType actualValueType = initialValueType;
 
-      oa_ErrorCode actualErrorCode =
+      const oa_ErrorCode actualErrorCode =
           oa_InfoDictionary_typeOf(&actualErrorMsg, &actualValueType, infoDictionaryHandle, key);
 
       THEN("error code and message is set") {
@@ -309,7 +310,7 @@ TEMPLATE_TEST_CASE_METHOD(AccessorFixture, "InfoDictionary accessed via C API", 
     // Opaque handle to map.
     const auto& infoDictionaryHandle = Fixture::infoDictionaryHandle_;
     // Function for type under test.
-    const auto& fn = Fixture::fn_;
+    const auto& func = Fixture::fn_;
 
     // Storage for return (out-parameter) value.
     auto& actualValue = Fixture::actualValue_;
@@ -334,9 +335,10 @@ TEMPLATE_TEST_CASE_METHOD(AccessorFixture, "InfoDictionary accessed via C API", 
     oa_StringView actualErrorMsg{errStorage.size(), errStorage.data(), 0};
 
     WHEN("existing value is retrieved through C API") {
-      oa_ConstStringView key{keyStr.data(), keyStr.size()};
+      const oa_ConstStringView key{keyStr.data(), keyStr.size()};
 
-      oa_ErrorCode actualErrorCode = fn(&actualErrorMsg, &actualValue, infoDictionaryHandle, key);
+      const oa_ErrorCode actualErrorCode =
+          func(&actualErrorMsg, &actualValue, infoDictionaryHandle, key);
 
       THEN("value is retrieved successfully") {
         CHECK(actualErrorCode == oa_ErrorCode_kOK);
@@ -345,10 +347,11 @@ TEMPLATE_TEST_CASE_METHOD(AccessorFixture, "InfoDictionary accessed via C API", 
     }
 
     WHEN("value is updated in C++ and retrieved through C API again") {
-      oa_ConstStringView key{keyStr.data(), keyStr.size()};
+      const oa_ConstStringView key{keyStr.data(), keyStr.size()};
       infoDictionary.at(keyStr) = alternativeValue;
 
-      oa_ErrorCode actualErrorCode = fn(&actualErrorMsg, &actualValue, infoDictionaryHandle, key);
+      const oa_ErrorCode actualErrorCode =
+          func(&actualErrorMsg, &actualValue, infoDictionaryHandle, key);
 
       THEN("updated value is retrieved successfully") {
         CHECK(actualErrorCode == oa_ErrorCode_kOK);
@@ -357,9 +360,10 @@ TEMPLATE_TEST_CASE_METHOD(AccessorFixture, "InfoDictionary accessed via C API", 
     }
 
     WHEN("attempting to retrieve a non-existent value through C API") {
-      oa_ConstStringView key{nonExistentKeyStr.data(), nonExistentKeyStr.size()};
+      const oa_ConstStringView key{nonExistentKeyStr.data(), nonExistentKeyStr.size()};
 
-      oa_ErrorCode actualErrorCode = fn(&actualErrorMsg, &actualValue, infoDictionaryHandle, key);
+      const oa_ErrorCode actualErrorCode =
+          func(&actualErrorMsg, &actualValue, infoDictionaryHandle, key);
 
       THEN("error code and message is set and out-param is unmodified") {
         CHECK(actualErrorCode == oa_ErrorCode_kOutOfRange);
@@ -369,9 +373,10 @@ TEMPLATE_TEST_CASE_METHOD(AccessorFixture, "InfoDictionary accessed via C API", 
     }
 
     WHEN("attempting to retrieve an incorrect value type through C API") {
-      oa_ConstStringView key{wrongValueTypeKeyStr.data(), wrongValueTypeKeyStr.size()};
+      const oa_ConstStringView key{wrongValueTypeKeyStr.data(), wrongValueTypeKeyStr.size()};
 
-      oa_ErrorCode actualErrorCode = fn(&actualErrorMsg, &actualValue, infoDictionaryHandle, key);
+      const oa_ErrorCode actualErrorCode =
+          func(&actualErrorMsg, &actualValue, infoDictionaryHandle, key);
 
       THEN("error code and message is set and out-param is unmodified") {
         CHECK(actualErrorCode == oa_ErrorCode_kBadVariantAccess);
@@ -384,9 +389,9 @@ TEMPLATE_TEST_CASE_METHOD(AccessorFixture, "InfoDictionary accessed via C API", 
       oa_StringView lowCapacityErr{3, errStorage.data(), 0};
 
       WHEN("attempting to retrieve a non-existent value through C API") {
-        oa_ConstStringView key{nonExistentKeyStr.data(), nonExistentKeyStr.size()};
+        const oa_ConstStringView key{nonExistentKeyStr.data(), nonExistentKeyStr.size()};
 
-        fn(&lowCapacityErr, &actualValue, infoDictionaryHandle, key);
+        func(&lowCapacityErr, &actualValue, infoDictionaryHandle, key);
 
         THEN("error message is truncated to fit storage capacity") {
           CHECK(lowCapacityErr == "Inv");
@@ -394,9 +399,9 @@ TEMPLATE_TEST_CASE_METHOD(AccessorFixture, "InfoDictionary accessed via C API", 
       }
 
       WHEN("attempting to retrieve an incorrect value type through C API") {
-        oa_ConstStringView key{wrongValueTypeKeyStr.data(), wrongValueTypeKeyStr.size()};
+        const oa_ConstStringView key{wrongValueTypeKeyStr.data(), wrongValueTypeKeyStr.size()};
 
-        fn(&lowCapacityErr, &actualValue, infoDictionaryHandle, key);
+        func(&lowCapacityErr, &actualValue, infoDictionaryHandle, key);
 
         THEN("error message is truncated to fit storage capacity") {
           CHECK(lowCapacityErr == "Inv");
@@ -408,7 +413,7 @@ TEMPLATE_TEST_CASE_METHOD(AccessorFixture, "InfoDictionary accessed via C API", 
 
 SCENARIO("InfoDictionary string return with insufficient buffer capacity") {
   GIVEN("a populated C++ InfoDictionary and its C handle") {
-    InfoDictionaryFixture fixture{};
+    const InfoDictionaryFixture fixture{};
     // Opaque handle to map.
     const auto& infoDictionaryHandle = fixture.infoDictionaryHandle_;
 
@@ -425,9 +430,9 @@ SCENARIO("InfoDictionary string return with insufficient buffer capacity") {
 
       WHEN("string is retrieved into insufficient-capacity StringView") {
         openassetio::Str keyStr = "aStr";
-        oa_ConstStringView key{keyStr.data(), keyStr.size()};
+        const oa_ConstStringView key{keyStr.data(), keyStr.size()};
 
-        oa_ErrorCode actualErrorCode =
+        const oa_ErrorCode actualErrorCode =
             oa_InfoDictionary_getStr(&actualErrorMsg, &actualValue, infoDictionaryHandle, key);
 
         THEN("truncated string is stored and error code and message is set") {
@@ -496,7 +501,7 @@ TEMPLATE_TEST_CASE_METHOD(MutatorFixture, "InfoDictionary mutated via C API", ""
     // Opaque handle to map.
     const auto& infoDictionaryHandle = Fixture::infoDictionaryHandle_;
     // C API function for type under test.
-    const auto& fn = Fixture::fn_;
+    const auto& func = Fixture::fn_;
 
     // Valid value to set in map that is not equal to initial value.
     const auto& expectedValue = Fixture::kExpectedValue;
@@ -516,8 +521,8 @@ TEMPLATE_TEST_CASE_METHOD(MutatorFixture, "InfoDictionary mutated via C API", ""
     oa_StringView actualErrorMsg{errStorage.size(), errStorage.data(), 0};
 
     WHEN("an existing value of the same type is updated") {
-      const oa_ErrorCode actualErrorCode =
-          fn(&actualErrorMsg, infoDictionaryHandle, {keyStr.data(), keyStr.size()}, expectedValue);
+      const oa_ErrorCode actualErrorCode = func(&actualErrorMsg, infoDictionaryHandle,
+                                                {keyStr.data(), keyStr.size()}, expectedValue);
 
       THEN("value is updated successfully") {
         const TestType actualValue = std::get<TestType>(infoDictionary.at(keyStr));
@@ -529,8 +534,8 @@ TEMPLATE_TEST_CASE_METHOD(MutatorFixture, "InfoDictionary mutated via C API", ""
 
     WHEN("an existing value of a different type is updated") {
       const oa_ErrorCode actualErrorCode =
-          fn(&actualErrorMsg, infoDictionaryHandle,
-             {otherValueTypeKeyStr.data(), otherValueTypeKeyStr.size()}, expectedValue);
+          func(&actualErrorMsg, infoDictionaryHandle,
+               {otherValueTypeKeyStr.data(), otherValueTypeKeyStr.size()}, expectedValue);
 
       THEN("value is updated successfully") {
         const TestType actualValue = std::get<TestType>(infoDictionary.at(otherValueTypeKeyStr));
@@ -542,8 +547,8 @@ TEMPLATE_TEST_CASE_METHOD(MutatorFixture, "InfoDictionary mutated via C API", ""
 
     WHEN("a non-existent entry is updated") {
       const oa_ErrorCode actualErrorCode =
-          fn(&actualErrorMsg, infoDictionaryHandle,
-             {nonExistentKeyStr.data(), nonExistentKeyStr.size()}, expectedValue);
+          func(&actualErrorMsg, infoDictionaryHandle,
+               {nonExistentKeyStr.data(), nonExistentKeyStr.size()}, expectedValue);
 
       THEN("entry is created and value set successfully") {
         const TestType actualValue = std::get<TestType>(infoDictionary.at(nonExistentKeyStr));

--- a/src/openassetio-core-c/tests/StringViewReporting.hpp
+++ b/src/openassetio-core-c/tests/StringViewReporting.hpp
@@ -35,13 +35,13 @@ inline bool operator==(const oa_ConstStringView& lhs, const Str& rhs) {
 }
 
 /// Support printing StringView in case assertions fail.
-inline std::ostream& operator<<(std::ostream& os, const oa_StringView& rhs) {
-  os << "\"" << std::string_view{rhs.data, rhs.size} << "\"";
-  return os;
+inline std::ostream& operator<<(std::ostream& stream, const oa_StringView& rhs) {
+  stream << "\"" << std::string_view{rhs.data, rhs.size} << "\"";
+  return stream;
 }
 
 /// Support printing ConstStringView in case assertions fail.
-inline std::ostream& operator<<(std::ostream& os, const oa_ConstStringView& rhs) {
-  os << "\"" << std::string_view{rhs.data, rhs.size} << "\"";
-  return os;
+inline std::ostream& operator<<(std::ostream& stream, const oa_ConstStringView& rhs) {
+  stream << "\"" << std::string_view{rhs.data, rhs.size} << "\"";
+  return stream;
 }

--- a/src/openassetio-core-c/tests/StringViewTest.cpp
+++ b/src/openassetio-core-c/tests/StringViewTest.cpp
@@ -89,7 +89,7 @@ SCENARIO("Creating and querying a C API immutable ConstStringView") {
     expectedStr = "some string";
 
     WHEN("a ConstStringView is constructed wrapping the buffer") {
-      oa_ConstStringView actualStringView{expectedStr.data(), expectedStr.size()};
+      const oa_ConstStringView actualStringView{expectedStr.data(), expectedStr.size()};
 
       THEN("ConstStringView can be interrogated to reveal the values at construction") {
         CHECK(actualStringView.size == expectedStr.size());

--- a/src/openassetio-core-c/tests/errorsTest.cpp
+++ b/src/openassetio-core-c/tests/errorsTest.cpp
@@ -26,7 +26,7 @@ SCENARIO("throwIfError error code/message handling") {
     const auto code = oa_ErrorCode_kUnknown;
     openassetio::Str message = "some error";
 
-    oa_StringView cmessage{
+    const oa_StringView cmessage{
         message.size(),
         message.data(),
         message.size(),
@@ -79,7 +79,8 @@ SCENARIO("Decorating an exception-throwing C++ function to instead return an err
     auto const callable = [&] { return oa_ErrorCode_kOK; };
 
     WHEN("callable is executed whilst decorated") {
-      oa_ErrorCode actualErrorCode = catchUnknownExceptionAsCode(&actualErrorMessage, callable);
+      const oa_ErrorCode actualErrorCode =
+          catchUnknownExceptionAsCode(&actualErrorMessage, callable);
 
       THEN("exception is caught and the error code and message is as expected") {
         CHECK(actualErrorCode == oa_ErrorCode_kOK);
@@ -94,7 +95,8 @@ SCENARIO("Decorating an exception-throwing C++ function to instead return an err
     auto const callable = [&]() -> oa_ErrorCode { throw std::length_error{expectedErrorMessage}; };
 
     WHEN("callable is executed whilst decorated") {
-      oa_ErrorCode actualErrorCode = catchUnknownExceptionAsCode(&actualErrorMessage, callable);
+      const oa_ErrorCode actualErrorCode =
+          catchUnknownExceptionAsCode(&actualErrorMessage, callable);
 
       THEN("exception is caught and the error code and message is as expected") {
         CHECK(actualErrorCode == oa_ErrorCode_kException);
@@ -109,7 +111,8 @@ SCENARIO("Decorating an exception-throwing C++ function to instead return an err
     auto const callable = [&]() -> oa_ErrorCode { throw "some error"; };
 
     WHEN("callable is executed whilst decorated") {
-      oa_ErrorCode actualErrorCode = catchUnknownExceptionAsCode(&actualErrorMessage, callable);
+      const oa_ErrorCode actualErrorCode =
+          catchUnknownExceptionAsCode(&actualErrorMessage, callable);
 
       THEN("exception is caught and the error code and message is as expected") {
         CHECK(actualErrorCode == oa_ErrorCode_kUnknown);

--- a/src/openassetio-core-c/tests/hostApi/ManagerTest.cpp
+++ b/src/openassetio-core-c/tests/hostApi/ManagerTest.cpp
@@ -100,7 +100,7 @@ SCENARIO("A Manager is constructed and destructed") {
         // C handle for Manager
         oa_hostApi_Manager_h managerHandle;
         // Construct Manager through C API.
-        oa_ErrorCode actualErrorCode = oa_hostApi_Manager_ctor(
+        const oa_ErrorCode actualErrorCode = oa_hostApi_Manager_ctor(
             &actualErrorMsg, &managerHandle, mockManagerInterfaceHandle, hostSessionHandle);
         CHECK(actualErrorCode == oa_ErrorCode_kOK);
 
@@ -162,7 +162,7 @@ SCENARIO("A Manager is constructed and destructed") {
         // C handle for Manager
         oa_hostApi_Manager_h managerHandle;
         // Construct Manager through C API.
-        oa_ErrorCode actualErrorCode = oa_hostApi_Manager_ctor(
+        const oa_ErrorCode actualErrorCode = oa_hostApi_Manager_ctor(
             &actualErrorMsg, &managerHandle, mockManagerInterfaceHandle, hostSessionHandle);
         CHECK(actualErrorCode == oa_ErrorCode_kOK);
 
@@ -183,11 +183,11 @@ SCENARIO("A Manager is constructed and destructed") {
 SCENARIO("A host calls Manager::identifier") {
   GIVEN("a Manager and its C handle") {
     // Create mock ManagerInterface to inject and assert on.
-    managerApi::ManagerInterfacePtr mockManagerInterfacePtr =
+    const managerApi::ManagerInterfacePtr mockManagerInterfacePtr =
         std::make_shared<MockManagerInterface>();
     auto& mockManagerInterface = static_cast<MockManagerInterface&>(*mockManagerInterfacePtr);
     // Create a HostSession with our mock HostInterface
-    managerApi::HostSessionPtr hostSessionPtr = managerApi::HostSession::make(
+    const managerApi::HostSessionPtr hostSessionPtr = managerApi::HostSession::make(
         managerApi::Host::make(std::make_shared<MockHostInterface>()),
         std::make_shared<MockLoggerInterface>());
 
@@ -214,7 +214,7 @@ SCENARIO("A host calls Manager::identifier") {
 
       WHEN("the Manager C API is queried for the identifier") {
         // C API call.
-        oa_ErrorCode code =
+        const oa_ErrorCode code =
             oa_hostApi_Manager_identifier(&actualErrorMsg, &actualIdentifier, managerHandle);
 
         THEN("the returned identifier matches expected identifier") {
@@ -230,7 +230,7 @@ SCENARIO("A host calls Manager::identifier") {
 
       WHEN("the Manager C API is queried for the identifier") {
         // C API call.
-        oa_ErrorCode code =
+        const oa_ErrorCode code =
             oa_hostApi_Manager_identifier(&actualErrorMsg, &actualIdentifier, managerHandle);
 
         THEN("generic exception error code and message is set and identifier is unmodified") {
@@ -246,11 +246,11 @@ SCENARIO("A host calls Manager::identifier") {
 SCENARIO("A host calls Manager::displayName") {
   GIVEN("a Manager and its C handle") {
     // Create mock ManagerInterface to inject and assert on.
-    managerApi::ManagerInterfacePtr mockManagerInterfacePtr =
+    const managerApi::ManagerInterfacePtr mockManagerInterfacePtr =
         std::make_shared<MockManagerInterface>();
     auto& mockManagerInterface = static_cast<MockManagerInterface&>(*mockManagerInterfacePtr);
     // Create a HostSession with our mock HostInterface
-    managerApi::HostSessionPtr hostSessionPtr = managerApi::HostSession::make(
+    const managerApi::HostSessionPtr hostSessionPtr = managerApi::HostSession::make(
         managerApi::Host::make(std::make_shared<MockHostInterface>()),
         std::make_shared<MockLoggerInterface>());
 
@@ -277,7 +277,7 @@ SCENARIO("A host calls Manager::displayName") {
 
       WHEN("the Manager C API is queried for the displayName") {
         // C API call.
-        oa_ErrorCode code =
+        const oa_ErrorCode code =
             oa_hostApi_Manager_displayName(&actualErrorMsg, &actualDisplayName, managerHandle);
 
         THEN("the returned displayName matches expected displayName") {
@@ -293,7 +293,7 @@ SCENARIO("A host calls Manager::displayName") {
 
       WHEN("the Manager C API is queried for the displayName") {
         // C API call.
-        oa_ErrorCode code =
+        const oa_ErrorCode code =
             oa_hostApi_Manager_displayName(&actualErrorMsg, &actualDisplayName, managerHandle);
 
         THEN("generic exception error code and message is set and displayName is unmodified") {
@@ -309,11 +309,11 @@ SCENARIO("A host calls Manager::displayName") {
 SCENARIO("A host calls Manager::info") {
   GIVEN("a Manager and its C handle") {
     // Create mock ManagerInterface to inject and assert on.
-    managerApi::ManagerInterfacePtr mockManagerInterfacePtr =
+    const managerApi::ManagerInterfacePtr mockManagerInterfacePtr =
         std::make_shared<MockManagerInterface>();
     auto& mockManagerInterface = static_cast<MockManagerInterface&>(*mockManagerInterfacePtr);
     // Create a HostSession with our mock HostInterface
-    managerApi::HostSessionPtr hostSessionPtr = managerApi::HostSession::make(
+    const managerApi::HostSessionPtr hostSessionPtr = managerApi::HostSession::make(
         managerApi::Host::make(std::make_shared<MockHostInterface>()),
         std::make_shared<MockLoggerInterface>());
 
@@ -342,7 +342,7 @@ SCENARIO("A host calls Manager::info") {
         oa_InfoDictionary_h actualInfoHandle = handles::InfoDictionary::toHandle(&actualInfo);
 
         // C API call.
-        oa_ErrorCode code =
+        const oa_ErrorCode code =
             oa_hostApi_Manager_info(&actualErrorMsg, actualInfoHandle, managerHandle);
 
         THEN("the returned info matches expected info") {
@@ -360,7 +360,7 @@ SCENARIO("A host calls Manager::info") {
         oa_InfoDictionary_h actualInfoHandle = handles::InfoDictionary::toHandle(&actualInfo);
 
         // C API call.
-        oa_ErrorCode code =
+        const oa_ErrorCode code =
             oa_hostApi_Manager_info(&actualErrorMsg, actualInfoHandle, managerHandle);
 
         THEN("generic exception error code and message is set and info is unmodified") {

--- a/src/openassetio-core-c/tests/managerApi/CManagerInterfaceAdapterTest.cpp
+++ b/src/openassetio-core-c/tests/managerApi/CManagerInterfaceAdapterTest.cpp
@@ -33,7 +33,7 @@ SCENARIO("A CManagerInterfaceAdapter is destroyed") {
     THEN("CManagerInterfaceAdapter's destructor calls the suite's dtor") {
       REQUIRE_CALL(mockImpl, dtor(handle));
 
-      openassetio::managerApi::CManagerInterfaceAdapter cManagerInterface{handle, suite};
+      const openassetio::managerApi::CManagerInterfaceAdapter cManagerInterface{handle, suite};
     }
   }
 }
@@ -51,7 +51,7 @@ SCENARIO("A host calls CManagerInterfaceAdapter::identifier") {
     // of cManagerInterface...
     REQUIRE_CALL(mockImpl, dtor(handle));
 
-    openassetio::managerApi::CManagerInterfaceAdapter cManagerInterface{handle, suite};
+    const openassetio::managerApi::CManagerInterfaceAdapter cManagerInterface{handle, suite};
 
     AND_GIVEN("the C suite's identifier() call succeeds") {
       const std::string_view expectedIdentifier = "my.id";
@@ -117,7 +117,7 @@ SCENARIO("A host calls CManagerInterfaceAdapter::displayName") {
     // goes out of scope.
     REQUIRE_CALL(mockImpl, dtor(handle));
 
-    openassetio::managerApi::CManagerInterfaceAdapter cManagerInterface{handle, suite};
+    const openassetio::managerApi::CManagerInterfaceAdapter cManagerInterface{handle, suite};
 
     AND_GIVEN("the C suite's displayName() call succeeds") {
       const std::string_view expectedDisplayName = "My Display Name";
@@ -184,7 +184,7 @@ SCENARIO("A host calls CManagerInterfaceAdapter::info") {
     // goes out of scope.
     REQUIRE_CALL(mockImpl, dtor(handle));
 
-    openassetio::managerApi::CManagerInterfaceAdapter cManagerInterface{handle, suite};
+    const openassetio::managerApi::CManagerInterfaceAdapter cManagerInterface{handle, suite};
 
     AND_GIVEN("the C suite's info() call succeeds") {
       const openassetio::Str expectedInfoKey = "info key";

--- a/src/openassetio-core-c/tests/managerApi/MockManagerInterfaceSuite.hpp
+++ b/src/openassetio-core-c/tests/managerApi/MockManagerInterfaceSuite.hpp
@@ -46,26 +46,27 @@ using MockCManagerInterfaceHandleConverter =
  * provided `handle` is a `MockCManagerInterfaceImpl` instance.
  */
 inline oa_managerApi_CManagerInterface_s mockManagerInterfaceSuite() {
-  return {// dtor
-          [](oa_managerApi_CManagerInterface_h h) {
-            MockCManagerInterfaceImpl *api = MockCManagerInterfaceHandleConverter::toInstance(h);
-            api->dtor(h);
-          },
-          // identifier
-          [](oa_StringView *err, oa_StringView *out, oa_managerApi_CManagerInterface_h h) {
-            MockCManagerInterfaceImpl *api = MockCManagerInterfaceHandleConverter::toInstance(h);
-            return api->identifier(err, out, h);
-          },
-          // displayName
-          [](oa_StringView *err, oa_StringView *out, oa_managerApi_CManagerInterface_h h) {
-            MockCManagerInterfaceImpl *api = MockCManagerInterfaceHandleConverter::toInstance(h);
-            return api->displayName(err, out, h);
-          },
-          // info
-          [](oa_StringView *err, oa_InfoDictionary_h out, oa_managerApi_CManagerInterface_h h) {
-            MockCManagerInterfaceImpl *api = MockCManagerInterfaceHandleConverter::toInstance(h);
-            return api->info(err, out, h);
-          }};
+  return {
+      // dtor
+      [](oa_managerApi_CManagerInterface_h handle) {
+        MockCManagerInterfaceImpl *api = MockCManagerInterfaceHandleConverter::toInstance(handle);
+        api->dtor(handle);
+      },
+      // identifier
+      [](oa_StringView *err, oa_StringView *out, oa_managerApi_CManagerInterface_h handle) {
+        MockCManagerInterfaceImpl *api = MockCManagerInterfaceHandleConverter::toInstance(handle);
+        return api->identifier(err, out, handle);
+      },
+      // displayName
+      [](oa_StringView *err, oa_StringView *out, oa_managerApi_CManagerInterface_h handle) {
+        MockCManagerInterfaceImpl *api = MockCManagerInterfaceHandleConverter::toInstance(handle);
+        return api->displayName(err, out, handle);
+      },
+      // info
+      [](oa_StringView *err, oa_InfoDictionary_h out, oa_managerApi_CManagerInterface_h handle) {
+        MockCManagerInterfaceImpl *api = MockCManagerInterfaceHandleConverter::toInstance(handle);
+        return api->info(err, out, handle);
+      }};
 }
 }  // namespace test
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-core/include/openassetio/errors.h
+++ b/src/openassetio-core/include/openassetio/errors.h
@@ -17,6 +17,7 @@
  * This macro defines the starting error code that should be used for
  * exception-like errors.
  */
+// NOLINTNEXTLINE(modernize-macro-to-enum)
 #define OPENASSETIO_ErrorCode_BEGIN 1
 
 /**

--- a/src/openassetio-core/src/hostApi/ManagerFactory.cpp
+++ b/src/openassetio-core/src/hostApi/ManagerFactory.cpp
@@ -82,7 +82,8 @@ ManagerPtr ManagerFactory::defaultManagerForInterface(
   const char* configPath = std::getenv(kDefaultManagerConfigEnvVarName.c_str());
 
   if (!configPath) {
-    Str msg = kDefaultManagerConfigEnvVarName + " not set, unable to instantiate default manager.";
+    const Str msg =
+        kDefaultManagerConfigEnvVarName + " not set, unable to instantiate default manager.";
     // We leave this as a debug message, as it is expected may hosts
     // will call this by default, and handle a null return manager, vs
     // it being a warning/error.
@@ -132,7 +133,7 @@ ManagerPtr ManagerFactory::defaultManagerForInterface(
     }
   }
 
-  managerApi::HostSessionPtr hostSession =
+  const managerApi::HostSessionPtr hostSession =
       managerApi::HostSession::make(managerApi::Host::make(hostInterface), logger);
 
   ManagerPtr manager = Manager::make(

--- a/src/openassetio-core/src/log/SeverityFilter.cpp
+++ b/src/openassetio-core/src/log/SeverityFilter.cpp
@@ -21,8 +21,8 @@ SeverityFilter::SeverityFilter(LoggerInterfacePtr upstreamLogger)
   if (const char* envSeverityStr = std::getenv("OPENASSETIO_LOGGING_SEVERITY")) {
     const int envSeverity = std::atoi(envSeverityStr);
     const bool exactConversion = std::to_string(envSeverity) == envSeverityStr;
-    if (!exactConversion || envSeverity < int(Severity::kDebugApi) ||
-        envSeverity > int(Severity::kCritical)) {
+    if (!exactConversion || envSeverity < static_cast<int>(Severity::kDebugApi) ||
+        envSeverity > static_cast<int>(Severity::kCritical)) {
       Str msg = "SeverityFilter: Invalid OPENASSETIO_LOGGING_SEVERITY value '";
       msg += envSeverityStr;
       msg += "' - ignoring.";

--- a/src/openassetio-core/tests/BatchElementErrorTest.cpp
+++ b/src/openassetio-core/tests/BatchElementErrorTest.cpp
@@ -10,16 +10,16 @@
 using openassetio::BatchElementError;
 
 SCENARIO("BatchElementError usage") {
+  GIVEN("BatchElementError is copyable") {
+    STATIC_REQUIRE(std::is_copy_assignable_v<BatchElementError>);
+  }
+
   GIVEN("an error code and message") {
     const auto code = BatchElementError::ErrorCode::kUnknown;
     const openassetio::Str message = "some message";
 
     WHEN("a BatchElementError is constructed wrapping the code and message") {
-      BatchElementError error{code, message};
-
-      THEN("BatchElementError is copyable") {
-        STATIC_REQUIRE(std::is_copy_assignable_v<decltype(error)>);
-      }
+      const BatchElementError error{code, message};
 
       THEN("code and message are available for querying") {
         CHECK(error.code == BatchElementError::ErrorCode::kUnknown);

--- a/src/openassetio-core/tests/TraitsDataTest.cpp
+++ b/src/openassetio-core/tests/TraitsDataTest.cpp
@@ -28,27 +28,27 @@ SCENARIO("TraitsData copy constructor is private") {
 
 SCENARIO("TraitsData make from other creates a deep copy") {
   GIVEN("an instance with existing data") {
-    TraitsDataPtr data = TraitsData::make();
-    data->setTraitProperty("a", "a", Int(1));
+    const TraitsDataPtr data = TraitsData::make();
+    data->setTraitProperty("a", "a", Int{1});
     WHEN("a copy is made using the make copy constructor") {
-      TraitsDataPtr copy = TraitsData::make(data);
+      const TraitsDataPtr copy = TraitsData::make(data);
       WHEN("existing values are queried") {
         THEN("property data has been copied") {
           Value someValue;
           Int value;
           REQUIRE(copy->getTraitProperty(&someValue, "a", "a"));
           value = *std::get_if<Int>(&someValue);
-          CHECK(value == Int(1));
+          CHECK(value == Int{1});
         }
       }
       AND_WHEN("the data is modified") {
-        data->setTraitProperty("a", "a", Int(3));
+        data->setTraitProperty("a", "a", Int{3});
         THEN("the copy is unchanged") {
           Value someValue;
           Int value;
           REQUIRE(copy->getTraitProperty(&someValue, "a", "a"));
           value = *std::get_if<Int>(&someValue);
-          CHECK(value == Int(1));
+          CHECK(value == Int{1});
         }
       }
     }

--- a/src/openassetio-core/tests/managerApi/ManagerStateBaseTest.cpp
+++ b/src/openassetio-core/tests/managerApi/ManagerStateBaseTest.cpp
@@ -14,4 +14,4 @@ struct TestState : ManagerStateBase {
 
 }  // namespace
 
-SCENARIO("Instantiating a custom state class") { [[maybe_unused]] auto _ = TestState{}; }
+SCENARIO("Instantiating a custom state class") { [[maybe_unused]] auto state = TestState{}; }

--- a/src/openassetio-core/tests/trait/TraitBaseTest.cpp
+++ b/src/openassetio-core/tests/trait/TraitBaseTest.cpp
@@ -37,7 +37,7 @@ struct TestTrait : trait::TraitBase<TestTrait> {
 
 SCENARIO("Retrieving the undelying data") {
   GIVEN("Some known traits data") {
-    TraitsDataPtr data = TraitsData::make();
+    const TraitsDataPtr data = TraitsData::make();
 
     WHEN("a trait instance is constructed with data") {
       TestTrait trait(data);
@@ -99,8 +99,8 @@ SCENARIO("Checking a trait is imbued") {
 
 SCENARIO("Imbuing a trait to the traits data held by a trait instance") {
   GIVEN("Some known traits data held by a trait") {
-    TraitsDataPtr data = TraitsData::make();
-    TestTrait trait(data);
+    const TraitsDataPtr data = TraitsData::make();
+    const TestTrait trait(data);
 
     AND_GIVEN("the data does not have the trait set") {
       WHEN("the trait is imbued") {
@@ -114,7 +114,7 @@ SCENARIO("Imbuing a trait to the traits data held by a trait instance") {
 
       WHEN("the trait is imbued") {
         THEN("is a noop") {
-          TraitsDataPtr oldData = TraitsData::make(data);
+          const TraitsDataPtr oldData = TraitsData::make(data);
           trait.imbue();
           CHECK(*data == *oldData);
         }
@@ -125,7 +125,7 @@ SCENARIO("Imbuing a trait to the traits data held by a trait instance") {
 
 SCENARIO("Imbuing a trait to an arbitrary traits data instance") {
   GIVEN("Some known traits data") {
-    TraitsDataPtr data = TraitsData::make();
+    const TraitsDataPtr data = TraitsData::make();
 
     AND_GIVEN("the data does not have the trait set") {
       WHEN("the trait is imbued to the data") {
@@ -137,7 +137,7 @@ SCENARIO("Imbuing a trait to an arbitrary traits data instance") {
       data->addTrait(TestTrait::kId);
       WHEN("the trait is imbued to the data") {
         THEN("is a noop") {
-          TraitsDataPtr oldData = TraitsData::make(data);
+          const TraitsDataPtr oldData = TraitsData::make(data);
           TestTrait::imbueTo(data);
           CHECK(*data == *oldData);
         }

--- a/src/openassetio-python/bridge/src/python/hostApi.cpp
+++ b/src/openassetio-python/bridge/src/python/hostApi.cpp
@@ -23,16 +23,16 @@ using openassetio::hostApi::ManagerImplementationFactoryInterfacePtr;
 ManagerImplementationFactoryInterfacePtr createPythonPluginSystemManagerImplementationFactory(
     log::LoggerInterfacePtr logger) {  // NOLINT(performance-unnecessary-value-param)
   // Caller might not hold the GIL, which is required for `import`s.
-  py::gil_scoped_acquire gil{};
+  const py::gil_scoped_acquire gil{};
 
   // Get Python class.
-  py::object pyClass =
+  const py::object pyClass =
       py::module_::import(
           "openassetio.pluginSystem.PythonPluginSystemManagerImplementationFactory")
           .attr("PythonPluginSystemManagerImplementationFactory");
 
   // Instantiate Python object.
-  py::object pyInstance = pyClass(std::move(logger));
+  const py::object pyInstance = pyClass(std::move(logger));
 
   // Extract the underlying C++ base class pointer.
   auto* cppInstancePtr = py::cast<ManagerImplementationFactoryInterface*>(pyInstance);

--- a/src/openassetio-python/cmodule/src/_openassetio.cpp
+++ b/src/openassetio-python/cmodule/src/_openassetio.cpp
@@ -12,9 +12,9 @@ PYBIND11_MODULE(_openassetio, mod) {
   // pybind11 will properly report type names in its docstring/error
   // output.
 
-  py::module managerApi = mod.def_submodule("managerApi");
-  py::module hostApi = mod.def_submodule("hostApi");
-  py::module log = mod.def_submodule("log");
+  const py::module managerApi = mod.def_submodule("managerApi");
+  const py::module hostApi = mod.def_submodule("hostApi");
+  const py::module log = mod.def_submodule("log");
 
   registerLoggerInterface(log);
   registerConsoleLogger(log);

--- a/src/openassetio-python/private/include/openassetio/private/python/pointers.hpp
+++ b/src/openassetio-python/private/include/openassetio/private/python/pointers.hpp
@@ -59,7 +59,7 @@ Ptr createPyRetainingPtr(const py::object& pyInstance,
       //  object, and yet it is possible that pybind11 will throw an
       //  exception here trying to acquire the GIL (though only in
       //  catastrophic cases). Tricky to test, though.
-      py::gil_scoped_acquire gil;
+      const py::gil_scoped_acquire gil;
       delete pyObjectPtr;
     }
   };

--- a/src/openassetio-python/tests/bridge/main.cpp
+++ b/src/openassetio-python/tests/bridge/main.cpp
@@ -7,6 +7,10 @@
 namespace py = pybind11;
 
 int main(int argc, char* argv[]) {
-  py::scoped_interpreter guard{};
-  return Catch::Session().run(argc, argv);
+  try {
+    const py::scoped_interpreter guard{};
+    return Catch::Session().run(argc, argv);
+  } catch (...) {
+    return 1;
+  }
 }

--- a/src/openassetio-python/tests/bridge/python/test_hostApi.cpp
+++ b/src/openassetio-python/tests/bridge/python/test_hostApi.cpp
@@ -19,9 +19,9 @@ using trompeloeil::_;
 SCENARIO("Accessing the Python plugin system from C++") {
   GIVEN("a logger") {
     // Release the GIL to ensure GIL-safe handling of Python import.
-    pybind11::gil_scoped_release gil{};
+    const pybind11::gil_scoped_release gil{};
 
-    openassetio::log::LoggerInterfacePtr logger = std::make_shared<MockLogger>();
+    const openassetio::log::LoggerInterfacePtr logger = std::make_shared<MockLogger>();
     auto& mockLogger = static_cast<MockLogger&>(*logger);
 
     ALLOW_CALL(mockLogger, log(_, _));


### PR DESCRIPTION
Although we have yet to move to the newer `clang-tidy` on CI, we aim to support devs using a newer `clang-tidy` than v12.

## Test Instructions

We seem to be getting cross-platform differences coming from a `std::rethrow_exception` call in `src/openassetio-python/cmodule/src/BatchElementErrorBinding.cpp`.  That is, MacOS gives a warning that the `std::exception_ptr` cannot be `std::move`d, for some reason.  See also https://github.com/OpenAssetIO/OpenAssetIO/pull/867#issuecomment-1492211562
