### PR TITLE
Default to `BatchElementError` in `variant` returns

### DIFF
--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -664,7 +664,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * @return Object containing either the populated data or an error
    * object.
    */
-  std::variant<TraitsDataPtr, BatchElementError> resolve(
+  std::variant<BatchElementError, TraitsDataPtr> resolve(
       const EntityReference& entityReference, const trait::TraitSet& traitSet,
       const ContextConstPtr& context, const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
 
@@ -743,7 +743,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * @return List of objects, each containing either the populated data
    * or an error.
    */
-  std::vector<std::variant<TraitsDataPtr, BatchElementError>> resolve(
+  std::vector<std::variant<BatchElementError, TraitsDataPtr>> resolve(
       const EntityReferences& entityReferences, const trait::TraitSet& traitSet,
       const ContextConstPtr& context, const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
 

--- a/src/openassetio-core/src/hostApi/Manager.cpp
+++ b/src/openassetio-core/src/hostApi/Manager.cpp
@@ -143,11 +143,11 @@ TraitsDataPtr hostApi::Manager::resolve(
 }
 
 // Singular variant
-std::variant<TraitsDataPtr, BatchElementError> hostApi::Manager::resolve(
+std::variant<BatchElementError, TraitsDataPtr> hostApi::Manager::resolve(
     const EntityReference &entityReference, const trait::TraitSet &traitSet,
     const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
-  std::variant<TraitsDataPtr, BatchElementError> resolveResult;
+  std::variant<BatchElementError, TraitsDataPtr> resolveResult;
   resolve(
       {entityReference}, traitSet, context,
       [&resolveResult]([[maybe_unused]] std::size_t index, const TraitsDataPtr &data) {
@@ -182,11 +182,11 @@ std::vector<TraitsDataPtr> hostApi::Manager::resolve(
 }
 
 // Multi variant
-std::vector<std::variant<TraitsDataPtr, BatchElementError>> hostApi::Manager::resolve(
+std::vector<std::variant<BatchElementError, TraitsDataPtr>> hostApi::Manager::resolve(
     const EntityReferences &entityReferences, const trait::TraitSet &traitSet,
     const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
-  std::vector<std::variant<TraitsDataPtr, BatchElementError>> resolveResult;
+  std::vector<std::variant<BatchElementError, TraitsDataPtr>> resolveResult;
   resolveResult.resize(entityReferences.size());
   resolve(
       entityReferences, traitSet, context,

--- a/src/openassetio-core/tests/hostApi/ManagerTest.cpp
+++ b/src/openassetio-core/tests/hostApi/ManagerTest.cpp
@@ -114,7 +114,7 @@ SCENARIO("Resolving entities") {
         THEN("returned TraitsData is as expected") { CHECK(expected.get() == actual.get()); }
       }
       WHEN("singular resolve is called with kVariant errorPolicyTag") {
-        std::variant<openassetio::TraitsDataPtr, openassetio::BatchElementError> actual =
+        std::variant<openassetio::BatchElementError, openassetio::TraitsDataPtr> actual =
             manager->resolve(ref, traits, context,
                              hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
         THEN("returned variant contains the expected TraitsData") {
@@ -154,7 +154,7 @@ SCENARIO("Resolving entities") {
         THEN("returned list of TraitsDatas is as expected") { CHECK(expectedVec == actualVec); }
       }
       WHEN("batch resolve is called with kVariant errorPolicyTag") {
-        std::vector<std::variant<openassetio::TraitsDataPtr, openassetio::BatchElementError>>
+        std::vector<std::variant<openassetio::BatchElementError, openassetio::TraitsDataPtr>>
             actualVec = manager->resolve(refs, traits, context,
                                          hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
         THEN("returned lists of variants contains the expected TraitsDatas") {
@@ -201,7 +201,7 @@ SCENARIO("Resolving entities") {
         }
       }
       WHEN("batch resolve is called with kVariant errorPolicyTag") {
-        std::vector<std::variant<openassetio::TraitsDataPtr, openassetio::BatchElementError>>
+        std::vector<std::variant<openassetio::BatchElementError, openassetio::TraitsDataPtr>>
             actualVec = manager->resolve(refs, traits, context,
                                          hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
         THEN("returned lists of variants is ordered in index order") {
@@ -243,7 +243,7 @@ SCENARIO("Resolving entities") {
         }
       }
       WHEN("singular resolve is called with kVariant errorPolicyTag") {
-        std::variant<openassetio::TraitsDataPtr, openassetio::BatchElementError> actual =
+        std::variant<openassetio::BatchElementError, openassetio::TraitsDataPtr> actual =
             manager->resolve(ref, traits, context,
                              hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
         THEN("returned variant contains the expected BatchElementError") {
@@ -296,7 +296,7 @@ SCENARIO("Resolving entities") {
         }
       }
       WHEN("batch resolve is called with kVariant errorPolicyTag") {
-        std::vector<std::variant<openassetio::TraitsDataPtr, openassetio::BatchElementError>>
+        std::vector<std::variant<openassetio::BatchElementError, openassetio::TraitsDataPtr>>
             actualVec = manager->resolve(refs, traits, context,
                                          hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
         THEN("returned lists of variants contains the expected objects") {

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -78,7 +78,7 @@ void registerManager(const py::module& mod) {
            py::arg("entityReference"), py::arg("traitSet"), py::arg("context").none(false),
            py::arg("errorPolicyTag"))
       .def("resolve",
-           static_cast<std::variant<TraitsDataPtr, openassetio::BatchElementError> (Manager::*)(
+           static_cast<std::variant<openassetio::BatchElementError, TraitsDataPtr> (Manager::*)(
                const EntityReference&, const trait::TraitSet&, const ContextConstPtr&,
                const Manager::BatchElementErrorPolicyTag::Variant&)>(&Manager::resolve),
            py::arg("entityReference"), py::arg("traitSet"), py::arg("context").none(false),
@@ -103,7 +103,7 @@ void registerManager(const py::module& mod) {
            py::arg("errorPolicyTag"))
       .def(
           "resolve",
-          static_cast<std::vector<std::variant<TraitsDataPtr, openassetio::BatchElementError>> (
+          static_cast<std::vector<std::variant<openassetio::BatchElementError, TraitsDataPtr>> (
               Manager::*)(const EntityReferences&, const trait::TraitSet&, const ContextConstPtr&,
                           const Manager::BatchElementErrorPolicyTag::Variant&)>(&Manager::resolve),
           py::arg("entityReferences"), py::arg("traitSet"), py::arg("context").none(false),


### PR DESCRIPTION
Closes #876. Currently `variant`s returned from `resolve` seem the wrong way around, in particular when default-constructed, where the current formulation would create a variant holding a `nullptr` `TraitsDataPtr`, which is dangerous and less informative than a `BatchElementError` with a default error code.

## Description

Closes # (issue)

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~

## Reviewer Notes

Does the volume of changes, and the fact that it's easy to get the ordering wrong, lend some weight to the idea of having a `typedef` for this?