### PR TITLE
Python bindings for `preflight` conveniences

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,13 +28,14 @@ v1.0.0-alpha.X
   mechanism for testing whether a `TraitsData` is imbued with a trait.
   [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)
 
-- Added `resolve` and (C++-only) `preflight` and `register_` overloads
+- Added `resolve`, `preflight` and (C++-only) `register_` overloads
   for convenience, providing alternatives to the core callback-based
   workflow. Includes a more direct method for resolving a single entity
   reference, and exception vs. result object workflows.
   [#849](https://github.com/OpenAssetIO/OpenAssetIO/issues/849)
   [#850](https://github.com/OpenAssetIO/OpenAssetIO/issues/850)
   [#851](https://github.com/OpenAssetIO/OpenAssetIO/issues/851)
+  [#852](https://github.com/OpenAssetIO/OpenAssetIO/issues/852)
   [#853](https://github.com/OpenAssetIO/OpenAssetIO/issues/853)
 
 ### Improvements

--- a/doc/doxygen/src/Examples.dox
+++ b/doc/doxygen/src/Examples.dox
@@ -208,7 +208,7 @@
  * # This allows it to create a placeholder version or similar.
  * # NOTE: It is critical to always use the working_ref from now on.
  * working_ref = manager.preflight(
- *         [entity_ref], TextFileSpecification.kTraitSet, context)[0]
+ *         entity_ref, TextFileSpecification.kTraitSet, context)
  *
  * # We then check if the manager can tell us where to save the file.
  * if ResolvesFutureEntitiesTrait.isImbuedTo(policy):
@@ -262,7 +262,7 @@
  * # reference, this gives us a reference we can now use for all
  * # interactions relating to the thumbnail itself.
  * thumbnail_ref = manager.preflight(
- *         [final_ref], ThumbnailFileSpecification.kTraitSet, context)[0]
+ *         final_ref, ThumbnailFileSpecification.kTraitSet, context)
  *
  * thumbnail_path = os.path.join(os.path.expanduser('~'), 'greeting.preview.png')
  * thumbnail_attr = {"width": 128, "height": 128}

--- a/doc/doxygen/src/ManagerState.dox
+++ b/doc/doxygen/src/ManagerState.dox
@@ -88,7 +88,7 @@
  * worker -> Manager : createContext()
  * Manager --> worker : context
  * worker -> worker : context.access = context.kWrite
- * worker -> Manager : working_reference = preflight(["ref://asset"], context)[0]
+ * worker -> Manager : working_reference = preflight("ref://asset", context)
  * Manager --> worker : "ref://asset=v4&state=inflight"
  * worker -> Manager : persistenceTokenForContext(context)
  * Manager --> worker : token

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -127,6 +127,45 @@ void registerManager(const py::module& mod) {
                const Manager::BatchElementErrorCallback&)>(&Manager::preflight),
            py::arg("entityReferences"), py::arg("traitSet"), py::arg("context").none(false),
            py::arg("successCallback"), py::arg("errorCallback"))
+      .def("preflight",
+           static_cast<EntityReference (Manager::*)(
+               const EntityReference&, const trait::TraitSet&, const ContextConstPtr&,
+               const Manager::BatchElementErrorPolicyTag::Exception&)>(&Manager::preflight),
+           py::arg("entityReference"), py::arg("traitSet"), py::arg("context").none(false),
+           py::arg("errorPolicyTag"))
+      .def("preflight",
+           static_cast<std::variant<openassetio::BatchElementError, EntityReference> (Manager::*)(
+               const EntityReference&, const trait::TraitSet&, const ContextConstPtr&,
+               const Manager::BatchElementErrorPolicyTag::Variant&)>(&Manager::preflight),
+           py::arg("entityReference"), py::arg("traitSet"), py::arg("context").none(false),
+           py::arg("errorPolicyTag"))
+      .def(
+          "preflight",
+          [](Manager& self, const EntityReference& entityReference,
+             const trait::TraitSet& traitSet, const ContextConstPtr& context) {
+            return self.preflight(entityReference, traitSet, context);
+          },
+          py::arg("entityReference"), py::arg("traitSet"), py::arg("context").none(false))
+      .def("preflight",
+           static_cast<std::vector<EntityReference> (Manager::*)(
+               const EntityReferences&, const trait::TraitSet&, const ContextConstPtr&,
+               const Manager::BatchElementErrorPolicyTag::Exception&)>(&Manager::preflight),
+           py::arg("entityReferences"), py::arg("traitSet"), py::arg("context").none(false),
+           py::arg("errorPolicyTag"))
+      .def("preflight",
+           static_cast<std::vector<std::variant<openassetio::BatchElementError, EntityReference>> (
+               Manager::*)(const EntityReferences&, const trait::TraitSet&, const ContextConstPtr&,
+                           const Manager::BatchElementErrorPolicyTag::Variant&)>(
+               &Manager::preflight),
+           py::arg("entityReferences"), py::arg("traitSet"), py::arg("context").none(false),
+           py::arg("errorPolicyTag"))
+      .def(
+          "preflight",
+          [](Manager& self, const EntityReferences& entityReferences,
+             const trait::TraitSet& traitSet, const ContextConstPtr& context) {
+            return self.preflight(entityReferences, traitSet, context);
+          },
+          py::arg("entityReferences"), py::arg("traitSet"), py::arg("context").none(false))
       .def(
           "register",
           [](Manager& self, const EntityReferences& entityReferences,

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -101,8 +101,18 @@ def a_ref(manager):
 
 
 @pytest.fixture
+def a_different_ref(manager):
+    return manager.createEntityReference("asset://b")
+
+
+@pytest.fixture
 def some_refs(manager):
-    return [manager.createEntityReference("asset://a"), manager.createEntityReference("asset://b")]
+    return [manager.createEntityReference("asset://c"), manager.createEntityReference("asset://d")]
+
+
+@pytest.fixture
+def some_different_refs(manager):
+    return [manager.createEntityReference("asset://e"), manager.createEntityReference("asset://f")]
 
 
 # __str__ and __repr__ aren't tested as they're debug tricks that need
@@ -1213,7 +1223,7 @@ class Test_Manager_managementPolicy:
         method.assert_called_once_with(some_entity_trait_sets, a_context, a_host_session)
 
 
-class Test_Manager_preflight:
+class Test_Manager_preflight_callback_signature:
     def test_method_defined_in_cpp(self, method_introspector):
         assert not method_introspector.is_defined_in_python(Manager.preflight)
         assert method_introspector.is_implemented_once(Manager, "preflight")
@@ -1254,6 +1264,588 @@ class Test_Manager_preflight:
 
         success_callback.assert_called_once_with(123, some_refs[0])
         error_callback.assert_called_once_with(456, a_batch_element_error)
+
+
+class Test_Manager_preflight_with_singular_default_overload:
+    def test_when_success_then_single_EntityReference_returned(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        a_ref,
+        an_entity_trait_set,
+        a_context,
+        a_different_ref,
+    ):
+        method = mock_manager_interface.mock.preflight
+
+        def call_callbacks(*_args):
+            # Success
+            callback = method.call_args[0][4]
+            callback(0, a_different_ref)
+
+        method.side_effect = call_callbacks
+
+        actual_ref = manager.preflight(a_ref, an_entity_trait_set, a_context)
+
+        method.assert_called_once_with(
+            [a_ref], an_entity_trait_set, a_context, a_host_session, mock.ANY, mock.ANY
+        )
+
+        assert actual_ref == a_different_ref
+
+    @pytest.mark.parametrize(
+        "error_code,expected_exception", batch_element_error_code_exception_pairs
+    )
+    def test_when_BatchElementError_then_appropriate_exception_raised(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        a_ref,
+        an_entity_trait_set,
+        a_context,
+        error_code,
+        expected_exception,
+    ):
+        method = mock_manager_interface.mock.preflight
+
+        expected_index = 213
+        batch_element_error = BatchElementError(error_code, "some string ✨")
+
+        def call_callbacks(*_args):
+            # Success
+            callback = method.call_args[0][5]
+            callback(expected_index, batch_element_error)
+            pytest.fail("Exception should have short-circuited this")
+
+        method.side_effect = call_callbacks
+
+        with pytest.raises(expected_exception, match=batch_element_error.message) as exc:
+            manager.preflight(a_ref, an_entity_trait_set, a_context)
+
+        method.assert_called_once_with(
+            [a_ref], an_entity_trait_set, a_context, a_host_session, mock.ANY, mock.ANY
+        )
+
+        assert exc.value.index == expected_index
+        assert_BatchElementError_eq(exc.value.error, batch_element_error)
+
+
+class Test_Manager_preflight_with_singular_throwing_overload:
+    def test_when_preflight_success_then_single_EntityReference_returned(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        a_ref,
+        an_entity_trait_set,
+        a_context,
+        a_different_ref,
+    ):
+        method = mock_manager_interface.mock.preflight
+
+        def call_callbacks(*_args):
+            # Success
+            callback = method.call_args[0][4]
+            callback(0, a_different_ref)
+
+        method.side_effect = call_callbacks
+
+        actual_ref = manager.preflight(
+            a_ref,
+            an_entity_trait_set,
+            a_context,
+            Manager.BatchElementErrorPolicyTag.kException,
+        )
+
+        method.assert_called_once_with(
+            [a_ref], an_entity_trait_set, a_context, a_host_session, mock.ANY, mock.ANY
+        )
+
+        assert actual_ref == a_different_ref
+
+    @pytest.mark.parametrize(
+        "error_code,expected_exception", batch_element_error_code_exception_pairs
+    )
+    def test_when_BatchElementError_then_appropriate_exception_raised(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        a_ref,
+        an_entity_trait_set,
+        a_context,
+        error_code,
+        expected_exception,
+    ):
+        method = mock_manager_interface.mock.preflight
+
+        expected_index = 213
+        batch_element_error = BatchElementError(error_code, "some string ✨")
+
+        def call_callbacks(*_args):
+            # Success
+            callback = method.call_args[0][5]
+            callback(expected_index, batch_element_error)
+            pytest.fail("Exception should have short-circuited this")
+
+        method.side_effect = call_callbacks
+
+        with pytest.raises(expected_exception, match=batch_element_error.message) as exc:
+            manager.preflight(
+                a_ref,
+                an_entity_trait_set,
+                a_context,
+                Manager.BatchElementErrorPolicyTag.kException,
+            )
+
+        method.assert_called_once_with(
+            [a_ref], an_entity_trait_set, a_context, a_host_session, mock.ANY, mock.ANY
+        )
+
+        assert exc.value.index == expected_index
+        assert_BatchElementError_eq(exc.value.error, batch_element_error)
+
+
+class Test_Manager_preflight_with_singular_variant_overload:
+    def test_when_preflight_success_then_single_EntityReference_returned(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        a_ref,
+        an_entity_trait_set,
+        a_context,
+        a_different_ref,
+    ):
+        method = mock_manager_interface.mock.preflight
+
+        def call_callbacks(*_args):
+            # Success
+            callback = method.call_args[0][4]
+            callback(0, a_different_ref)
+
+        method.side_effect = call_callbacks
+
+        actual_ref = manager.preflight(
+            a_ref,
+            an_entity_trait_set,
+            a_context,
+            Manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        method.assert_called_once_with(
+            [a_ref], an_entity_trait_set, a_context, a_host_session, mock.ANY, mock.ANY
+        )
+
+        assert actual_ref == a_different_ref
+
+    @pytest.mark.parametrize("error_code", batch_element_error_codes)
+    def test_when_BatchElementError_then_BatchElementError_returned(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        a_ref,
+        an_entity_trait_set,
+        a_context,
+        error_code,
+    ):
+        method = mock_manager_interface.mock.preflight
+
+        expected_index = 213
+        batch_element_error = BatchElementError(error_code, "some string ✨")
+
+        def call_callbacks(*_args):
+            # Success
+            callback = method.call_args[0][5]
+            callback(expected_index, batch_element_error)
+
+        method.side_effect = call_callbacks
+
+        actual = manager.preflight(
+            a_ref,
+            an_entity_trait_set,
+            a_context,
+            Manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        method.assert_called_once_with(
+            [a_ref], an_entity_trait_set, a_context, a_host_session, mock.ANY, mock.ANY
+        )
+
+        assert_BatchElementError_eq(actual, batch_element_error)
+
+
+class Test_Manager_preflight_with_batch_default_overload:
+    def test_when_success_then_multiple_EntityReferences_returned(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        some_refs,
+        an_entity_trait_set,
+        a_context,
+        some_different_refs,
+    ):
+        method = mock_manager_interface.mock.preflight
+
+        def call_callbacks(*_args):
+            # Success
+            callback = method.call_args[0][4]
+            callback(0, some_different_refs[0])
+
+            callback = method.call_args[0][4]
+            callback(1, some_different_refs[1])
+
+        method.side_effect = call_callbacks
+
+        actual_refs = manager.preflight(some_refs, an_entity_trait_set, a_context)
+
+        method.assert_called_once_with(
+            some_refs,
+            an_entity_trait_set,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert len(actual_refs) == 2
+        assert actual_refs[0] == some_different_refs[0]
+        assert actual_refs[1] == some_different_refs[1]
+
+    def test_when_success_out_of_order_then_EntityReferences_returned_in_order(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        some_refs,
+        an_entity_trait_set,
+        a_context,
+        some_different_refs,
+    ):
+        method = mock_manager_interface.mock.preflight
+
+        def call_callbacks(*_args):
+            # Success
+            callback = method.call_args[0][4]
+            callback(1, some_different_refs[1])
+
+            callback = method.call_args[0][4]
+            callback(0, some_different_refs[0])
+
+        method.side_effect = call_callbacks
+
+        actual_refs = manager.preflight(some_refs, an_entity_trait_set, a_context)
+
+        method.assert_called_once_with(
+            some_refs,
+            an_entity_trait_set,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert len(actual_refs) == 2
+        assert actual_refs[0] == some_different_refs[0]
+        assert actual_refs[1] == some_different_refs[1]
+
+    @pytest.mark.parametrize(
+        "error_code,expected_exception", batch_element_error_code_exception_pairs
+    )
+    def test_when_BatchElementError_then_appropriate_exception_raised(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        some_refs,
+        an_entity_trait_set,
+        a_context,
+        error_code,
+        a_different_ref,
+        expected_exception,
+    ):
+        method = mock_manager_interface.mock.preflight
+        expected_index = 123
+
+        batch_element_error = BatchElementError(error_code, "some string ✨")
+
+        def call_callbacks(*_args):
+            # Success
+            callback = method.call_args[0][4]
+            callback(0, a_different_ref)
+
+            # Error
+            callback = method.call_args[0][5]
+            callback(expected_index, batch_element_error)
+
+            pytest.fail("Exception should have short-circuited this")
+
+        method.side_effect = call_callbacks
+
+        with pytest.raises(expected_exception, match=batch_element_error.message) as exc:
+            manager.preflight(some_refs, an_entity_trait_set, a_context)
+
+        method.assert_called_once_with(
+            some_refs,
+            an_entity_trait_set,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert exc.value.index == expected_index
+        assert_BatchElementError_eq(exc.value.error, batch_element_error)
+
+
+class Test_Manager_preflight_with_batch_throwing_overload:
+    def test_when_success_then_multiple_EntityReferences_returned(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        some_refs,
+        an_entity_trait_set,
+        a_context,
+        some_different_refs,
+    ):
+        method = mock_manager_interface.mock.preflight
+
+        def call_callbacks(*_args):
+            # Success
+            callback = method.call_args[0][4]
+            callback(0, some_different_refs[0])
+
+            callback = method.call_args[0][4]
+            callback(1, some_different_refs[1])
+
+        method.side_effect = call_callbacks
+
+        actual_refs = manager.preflight(
+            some_refs,
+            an_entity_trait_set,
+            a_context,
+            Manager.BatchElementErrorPolicyTag.kException,
+        )
+
+        method.assert_called_once_with(
+            some_refs,
+            an_entity_trait_set,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert len(actual_refs) == 2
+        assert actual_refs[0] == some_different_refs[0]
+        assert actual_refs[1] == some_different_refs[1]
+
+    def test_when_success_out_of_order_then_EntityReferences_returned_in_order(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        some_refs,
+        an_entity_trait_set,
+        a_context,
+        some_different_refs,
+    ):
+        method = mock_manager_interface.mock.preflight
+
+        def call_callbacks(*_args):
+            # Success
+            callback = method.call_args[0][4]
+            callback(1, some_different_refs[1])
+
+            callback = method.call_args[0][4]
+            callback(0, some_different_refs[0])
+
+        method.side_effect = call_callbacks
+
+        actual_refs = manager.preflight(
+            some_refs,
+            an_entity_trait_set,
+            a_context,
+            Manager.BatchElementErrorPolicyTag.kException,
+        )
+
+        method.assert_called_once_with(
+            some_refs,
+            an_entity_trait_set,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert len(actual_refs) == 2
+        assert actual_refs[0] == some_different_refs[0]
+        assert actual_refs[1] == some_different_refs[1]
+
+    @pytest.mark.parametrize(
+        "error_code,expected_exception", batch_element_error_code_exception_pairs
+    )
+    def test_when_BatchElementError_then_appropriate_exception_raised(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        some_refs,
+        an_entity_trait_set,
+        a_context,
+        error_code,
+        a_different_ref,
+        expected_exception,
+    ):
+        method = mock_manager_interface.mock.preflight
+        expected_index = 123
+
+        batch_element_error = BatchElementError(error_code, "some string ✨")
+
+        def call_callbacks(*_args):
+            # Success
+            callback = method.call_args[0][4]
+            callback(0, a_different_ref)
+
+            # Error
+            callback = method.call_args[0][5]
+            callback(expected_index, batch_element_error)
+
+            pytest.fail("Exception should have short-circuited this")
+
+        method.side_effect = call_callbacks
+
+        with pytest.raises(expected_exception, match=batch_element_error.message) as exc:
+            manager.preflight(
+                some_refs,
+                an_entity_trait_set,
+                a_context,
+                Manager.BatchElementErrorPolicyTag.kException,
+            )
+
+        method.assert_called_once_with(
+            some_refs,
+            an_entity_trait_set,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert exc.value.index == expected_index
+        assert_BatchElementError_eq(exc.value.error, batch_element_error)
+
+
+class Test_Manager_preflight_with_batch_variant_overload:
+    @pytest.mark.parametrize("error_code", batch_element_error_codes)
+    def test_when_mixed_output_then_returned_list_contains_output(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        some_refs,
+        an_entity_trait_set,
+        a_context,
+        a_different_ref,
+        error_code,
+    ):
+        method = mock_manager_interface.mock.preflight
+        batch_element_error = BatchElementError(error_code, "some string ✨")
+
+        def call_callbacks(*_args):
+            # Success
+            callback = method.call_args[0][4]
+            callback(0, a_different_ref)
+
+            callback = method.call_args[0][5]
+            callback(1, batch_element_error)
+
+        method.side_effect = call_callbacks
+
+        actual_ref_or_error = manager.preflight(
+            some_refs,
+            an_entity_trait_set,
+            a_context,
+            Manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        method.assert_called_once_with(
+            some_refs,
+            an_entity_trait_set,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert len(actual_ref_or_error) == 2
+        assert actual_ref_or_error[0] == a_different_ref
+        assert_BatchElementError_eq(actual_ref_or_error[1], batch_element_error)
+
+    def test_when_mixed_output_out_of_order_then_output_returned_in_order(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        a_ref,
+        an_entity_trait_set,
+        a_context,
+    ):
+        method = mock_manager_interface.mock.preflight
+
+        entity_refs = [a_ref] * 4
+
+        batch_element_error0 = BatchElementError(
+            BatchElementError.ErrorCode.kEntityResolutionError, "0 some string ✨"
+        )
+        entity_ref1 = EntityReference("ref1")
+        batch_element_error2 = BatchElementError(
+            BatchElementError.ErrorCode.kEntityResolutionError, "2 some string ✨"
+        )
+        entity_ref3 = EntityReference("ref3")
+
+        def call_callbacks(*_args):
+            # Success
+            callback = method.call_args[0][4]
+            callback(1, entity_ref1)
+
+            callback = method.call_args[0][5]
+            callback(0, batch_element_error0)
+
+            callback = method.call_args[0][4]
+            callback(3, entity_ref3)
+
+            callback = method.call_args[0][5]
+            callback(2, batch_element_error2)
+
+        method.side_effect = call_callbacks
+
+        actual_ref_or_error = manager.preflight(
+            entity_refs,
+            an_entity_trait_set,
+            a_context,
+            Manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        method.assert_called_once_with(
+            entity_refs,
+            an_entity_trait_set,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert len(actual_ref_or_error) == 4
+        assert_BatchElementError_eq(actual_ref_or_error[0], batch_element_error0)
+        assert actual_ref_or_error[1] == entity_ref1
+        assert_BatchElementError_eq(actual_ref_or_error[2], batch_element_error2)
+        assert actual_ref_or_error[3] == entity_ref3
 
 
 class Test_Manager_register:

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -1126,6 +1126,7 @@ class Test_Manager_resolve_with_batch_variant_overload:
             mock.ANY,
         )
 
+        assert len(actual_traitsdata_and_error) == 2
         assert actual_traitsdata_and_error[0] is a_traitsdata
         assert_BatchElementError_eq(actual_traitsdata_and_error[1], batch_element_error)
 
@@ -1183,6 +1184,7 @@ class Test_Manager_resolve_with_batch_variant_overload:
             mock.ANY,
         )
 
+        assert len(actual_traitsdata_and_error) == 4
         assert_BatchElementError_eq(actual_traitsdata_and_error[0], batch_element_error0)
         assert actual_traitsdata_and_error[1] is traitsdata1
         assert_BatchElementError_eq(actual_traitsdata_and_error[2], batch_element_error2)


### PR DESCRIPTION
## Description

Closes #852

Add Python bindings to `preflight` overloads that allow single-element and/or exception-less workflows.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.
