### PR TITLE
Python bindings for `register` conveniences

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,8 +28,8 @@ v1.0.0-alpha.X
   mechanism for testing whether a `TraitsData` is imbued with a trait.
   [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)
 
-- Added `resolve`, `preflight` and (C++-only) `register_` overloads
-  for convenience, providing alternatives to the core callback-based
+- Added `resolve`, `preflight` and `register` overloads for
+  convenience, providing alternatives to the core callback-based
   workflow. Includes a more direct method for resolving a single entity
   reference, and exception vs. result object workflows.
   [#849](https://github.com/OpenAssetIO/OpenAssetIO/issues/849)
@@ -37,6 +37,7 @@ v1.0.0-alpha.X
   [#851](https://github.com/OpenAssetIO/OpenAssetIO/issues/851)
   [#852](https://github.com/OpenAssetIO/OpenAssetIO/issues/852)
   [#853](https://github.com/OpenAssetIO/OpenAssetIO/issues/853)
+  [#854](https://github.com/OpenAssetIO/OpenAssetIO/issues/854)
 
 ### Improvements
 

--- a/doc/doxygen/src/Examples.dox
+++ b/doc/doxygen/src/Examples.dox
@@ -234,7 +234,7 @@
  * # is complete. Update the context retention to denote that we're going
  * # to save a reference to this entity in our user's history.
  * context.retention = context.kPermanent
- * final_ref = manager.register([working_ref], [file_spec.traitsData()], context)[0]
+ * final_ref = manager.register(working_ref, file_spec.traitsData(), context)
  *
  * # We can persist this reference as we used the kPermanent retention
  * with open(os.path.join(os.path.expanduser('~'), 'history', 'a') as f:
@@ -293,6 +293,6 @@
  * raster_trait.setHeight(thumbnail_attr["height"])
  *
  * context.retention = context.kTransient
- * manager.register([thumbnail_ref], [thumbnail_spec.traitsData()], context)
+ * manager.register(thumbnail_ref, thumbnail_spec.traitsData(), context)
  * @endcode
  */

--- a/doc/doxygen/src/ManagerState.dox
+++ b/doc/doxygen/src/ManagerState.dox
@@ -126,7 +126,7 @@
  * worker -> worker : working_reference = ref_map["ref://asset"]
  * worker -> Manager : path = resolve(working_reference, FileTrait.id, context)
  * Manager --> worker : "file://out.####.exr"
- * worker -> Manager : final_reference = register([working_reference], [path], context)[0]
+ * worker -> Manager : final_reference = register(working_reference, path, context)
  * Manager --> worker : "ref://asset=v4"
  * worker -> worker : update_state_file({"ref://asset": final_reference})
  * worker --> scheduler

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -57,7 +57,11 @@ def an_empty_traitsdata():
 
 @pytest.fixture
 def some_entity_traitsdatas():
-    return [TraitsData(set()), TraitsData(set())]
+    first = TraitsData({"a_trait"})
+    second = TraitsData({"a_trait"})
+    first.setTraitProperty("a_trait", "a_prop", 123)
+    second.setTraitProperty("a_trait", "a_prop", 456)
+    return [first, second]
 
 
 @pytest.fixture
@@ -1848,7 +1852,7 @@ class Test_Manager_preflight_with_batch_variant_overload:
         assert actual_ref_or_error[3] == entity_ref3
 
 
-class Test_Manager_register:
+class Test_Manager_register_callback_overload:
     def test_method_defined_in_cpp(self, method_introspector):
         assert not method_introspector.is_defined_in_python(Manager.register)
         assert method_introspector.is_implemented_once(Manager, "register")
@@ -1914,6 +1918,595 @@ class Test_Manager_register:
     ):
         with pytest.raises(TypeError):
             manager.register(some_refs, [a_traitsdata, None], a_context, mock.Mock(), mock.Mock())
+
+
+class Test_Manager_register_with_singular_default_overload:
+    def test_when_success_then_single_EntityReference_returned(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        a_ref,
+        a_context,
+        a_different_ref,
+        a_traitsdata,
+    ):
+        method = mock_manager_interface.mock.register
+
+        def call_callbacks(*_args):
+            callback = method.call_args[0][4]
+            callback(0, a_different_ref)
+
+        method.side_effect = call_callbacks
+
+        actual_ref = manager.register(a_ref, a_traitsdata, a_context)
+
+        method.assert_called_once_with(
+            [a_ref],
+            [a_traitsdata],
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert actual_ref == a_different_ref
+
+    @pytest.mark.parametrize(
+        "error_code,expected_exception", batch_element_error_code_exception_pairs
+    )
+    def test_when_BatchElementError_then_appropriate_exception_raised(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        a_ref,
+        a_context,
+        error_code,
+        expected_exception,
+        a_traitsdata,
+    ):
+        method = mock_manager_interface.mock.register
+
+        expected_index = 213
+        batch_element_error = BatchElementError(error_code, "some string ✨")
+
+        def call_callbacks(*_args):
+            callback = method.call_args[0][5]
+            callback(expected_index, batch_element_error)
+            pytest.fail("Exception should have short-circuited this")
+
+        method.side_effect = call_callbacks
+
+        with pytest.raises(expected_exception, match=batch_element_error.message) as exc:
+            manager.register(a_ref, a_traitsdata, a_context)
+
+        method.assert_called_once_with(
+            [a_ref],
+            [a_traitsdata],
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert exc.value.index == expected_index
+        assert_BatchElementError_eq(exc.value.error, batch_element_error)
+
+
+class Test_Manager_register_with_singular_throwing_overload:
+    def test_when_register_success_then_single_EntityReference_returned(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        a_ref,
+        a_context,
+        a_different_ref,
+        a_traitsdata,
+    ):
+        method = mock_manager_interface.mock.register
+
+        def call_callbacks(*_args):
+            callback = method.call_args[0][4]
+            callback(0, a_different_ref)
+
+        method.side_effect = call_callbacks
+
+        actual_ref = manager.register(
+            a_ref,
+            a_traitsdata,
+            a_context,
+            Manager.BatchElementErrorPolicyTag.kException,
+        )
+
+        method.assert_called_once_with(
+            [a_ref],
+            [a_traitsdata],
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert actual_ref == a_different_ref
+
+    @pytest.mark.parametrize(
+        "error_code,expected_exception", batch_element_error_code_exception_pairs
+    )
+    def test_when_BatchElementError_then_appropriate_exception_raised(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        a_ref,
+        a_context,
+        error_code,
+        expected_exception,
+        a_traitsdata,
+    ):
+        method = mock_manager_interface.mock.register
+
+        expected_index = 213
+        batch_element_error = BatchElementError(error_code, "some string ✨")
+
+        def call_callbacks(*_args):
+            callback = method.call_args[0][5]
+            callback(expected_index, batch_element_error)
+            pytest.fail("Exception should have short-circuited this")
+
+        method.side_effect = call_callbacks
+
+        with pytest.raises(expected_exception, match=batch_element_error.message) as exc:
+            manager.register(
+                a_ref,
+                a_traitsdata,
+                a_context,
+                Manager.BatchElementErrorPolicyTag.kException,
+            )
+
+        method.assert_called_once_with(
+            [a_ref],
+            [a_traitsdata],
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert exc.value.index == expected_index
+        assert_BatchElementError_eq(exc.value.error, batch_element_error)
+
+
+class Test_Manager_register_with_singular_variant_overload:
+    def test_when_register_success_then_single_EntityReference_returned(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        a_ref,
+        a_context,
+        a_different_ref,
+        a_traitsdata,
+    ):
+        method = mock_manager_interface.mock.register
+
+        def call_callbacks(*_args):
+            callback = method.call_args[0][4]
+            callback(0, a_different_ref)
+
+        method.side_effect = call_callbacks
+
+        actual_ref = manager.register(
+            a_ref,
+            a_traitsdata,
+            a_context,
+            Manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        method.assert_called_once_with(
+            [a_ref],
+            [a_traitsdata],
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert actual_ref == a_different_ref
+
+    @pytest.mark.parametrize("error_code", batch_element_error_codes)
+    def test_when_BatchElementError_then_BatchElementError_returned(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        a_ref,
+        a_context,
+        error_code,
+        a_traitsdata,
+    ):
+        method = mock_manager_interface.mock.register
+
+        expected_index = 213
+        batch_element_error = BatchElementError(error_code, "some string ✨")
+
+        def call_callbacks(*_args):
+            callback = method.call_args[0][5]
+            callback(expected_index, batch_element_error)
+
+        method.side_effect = call_callbacks
+
+        actual = manager.register(
+            a_ref,
+            a_traitsdata,
+            a_context,
+            Manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        method.assert_called_once_with(
+            [a_ref],
+            [a_traitsdata],
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert_BatchElementError_eq(actual, batch_element_error)
+
+
+class Test_Manager_register_with_batch_default_overload:
+    def test_when_success_then_multiple_EntityReferences_returned(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        some_refs,
+        a_context,
+        some_different_refs,
+        some_entity_traitsdatas,
+    ):
+        method = mock_manager_interface.mock.register
+
+        def call_callbacks(*_args):
+            callback = method.call_args[0][4]
+            callback(0, some_different_refs[0])
+
+            callback = method.call_args[0][4]
+            callback(1, some_different_refs[1])
+
+        method.side_effect = call_callbacks
+
+        actual_refs = manager.register(some_refs, some_entity_traitsdatas, a_context)
+
+        method.assert_called_once_with(
+            some_refs,
+            some_entity_traitsdatas,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert actual_refs == some_different_refs
+
+    def test_when_success_out_of_order_then_EntityReferences_returned_in_order(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        some_refs,
+        a_context,
+        some_different_refs,
+        some_entity_traitsdatas,
+    ):
+        method = mock_manager_interface.mock.register
+
+        def call_callbacks(*_args):
+            callback = method.call_args[0][4]
+            callback(1, some_different_refs[1])
+
+            callback = method.call_args[0][4]
+            callback(0, some_different_refs[0])
+
+        method.side_effect = call_callbacks
+
+        actual_refs = manager.register(some_refs, some_entity_traitsdatas, a_context)
+
+        method.assert_called_once_with(
+            some_refs,
+            some_entity_traitsdatas,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert actual_refs == some_different_refs
+
+    @pytest.mark.parametrize(
+        "error_code,expected_exception", batch_element_error_code_exception_pairs
+    )
+    def test_when_BatchElementError_then_appropriate_exception_raised(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        some_refs,
+        some_entity_traitsdatas,
+        a_context,
+        error_code,
+        a_different_ref,
+        expected_exception,
+    ):
+        method = mock_manager_interface.mock.register
+        expected_index = 123
+
+        batch_element_error = BatchElementError(error_code, "some string ✨")
+
+        def call_callbacks(*_args):
+            callback = method.call_args[0][4]
+            callback(0, a_different_ref)
+
+            callback = method.call_args[0][5]
+            callback(expected_index, batch_element_error)
+
+            pytest.fail("Exception should have short-circuited this")
+
+        method.side_effect = call_callbacks
+
+        with pytest.raises(expected_exception, match=batch_element_error.message) as exc:
+            manager.register(some_refs, some_entity_traitsdatas, a_context)
+
+        method.assert_called_once_with(
+            some_refs,
+            some_entity_traitsdatas,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert exc.value.index == expected_index
+        assert_BatchElementError_eq(exc.value.error, batch_element_error)
+
+
+class Test_Manager_register_with_batch_throwing_overload:
+    def test_when_success_then_multiple_EntityReferences_returned(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        some_refs,
+        some_entity_traitsdatas,
+        a_context,
+        some_different_refs,
+    ):
+        method = mock_manager_interface.mock.register
+
+        def call_callbacks(*_args):
+            callback = method.call_args[0][4]
+            callback(0, some_different_refs[0])
+
+            callback = method.call_args[0][4]
+            callback(1, some_different_refs[1])
+
+        method.side_effect = call_callbacks
+
+        actual_refs = manager.register(
+            some_refs,
+            some_entity_traitsdatas,
+            a_context,
+            Manager.BatchElementErrorPolicyTag.kException,
+        )
+
+        method.assert_called_once_with(
+            some_refs,
+            some_entity_traitsdatas,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert actual_refs == some_different_refs
+
+    def test_when_success_out_of_order_then_EntityReferences_returned_in_order(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        some_refs,
+        some_entity_traitsdatas,
+        a_context,
+        some_different_refs,
+    ):
+        method = mock_manager_interface.mock.register
+
+        def call_callbacks(*_args):
+            callback = method.call_args[0][4]
+            callback(1, some_different_refs[1])
+
+            callback = method.call_args[0][4]
+            callback(0, some_different_refs[0])
+
+        method.side_effect = call_callbacks
+
+        actual_refs = manager.register(
+            some_refs,
+            some_entity_traitsdatas,
+            a_context,
+            Manager.BatchElementErrorPolicyTag.kException,
+        )
+
+        method.assert_called_once_with(
+            some_refs,
+            some_entity_traitsdatas,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert actual_refs == some_different_refs
+
+    @pytest.mark.parametrize(
+        "error_code,expected_exception", batch_element_error_code_exception_pairs
+    )
+    def test_when_BatchElementError_then_appropriate_exception_raised(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        some_refs,
+        some_entity_traitsdatas,
+        a_context,
+        error_code,
+        a_different_ref,
+        expected_exception,
+    ):
+        method = mock_manager_interface.mock.register
+        expected_index = 123
+
+        batch_element_error = BatchElementError(error_code, "some string ✨")
+
+        def call_callbacks(*_args):
+            callback = method.call_args[0][4]
+            callback(0, a_different_ref)
+
+            callback = method.call_args[0][5]
+            callback(expected_index, batch_element_error)
+
+            pytest.fail("Exception should have short-circuited this")
+
+        method.side_effect = call_callbacks
+
+        with pytest.raises(expected_exception, match=batch_element_error.message) as exc:
+            manager.register(
+                some_refs,
+                some_entity_traitsdatas,
+                a_context,
+                Manager.BatchElementErrorPolicyTag.kException,
+            )
+
+        method.assert_called_once_with(
+            some_refs,
+            some_entity_traitsdatas,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert exc.value.index == expected_index
+        assert_BatchElementError_eq(exc.value.error, batch_element_error)
+
+
+class Test_Manager_register_with_batch_variant_overload:
+    @pytest.mark.parametrize("error_code", batch_element_error_codes)
+    def test_when_mixed_output_then_returned_list_contains_output(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        some_refs,
+        some_entity_traitsdatas,
+        a_context,
+        a_different_ref,
+        error_code,
+    ):
+        method = mock_manager_interface.mock.register
+        batch_element_error = BatchElementError(error_code, "some string ✨")
+
+        def call_callbacks(*_args):
+            callback = method.call_args[0][4]
+            callback(0, a_different_ref)
+
+            callback = method.call_args[0][5]
+            callback(1, batch_element_error)
+
+        method.side_effect = call_callbacks
+
+        actual_ref_or_error = manager.register(
+            some_refs,
+            some_entity_traitsdatas,
+            a_context,
+            Manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        method.assert_called_once_with(
+            some_refs,
+            some_entity_traitsdatas,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert len(actual_ref_or_error) == 2
+        assert actual_ref_or_error[0] == a_different_ref
+        assert_BatchElementError_eq(actual_ref_or_error[1], batch_element_error)
+
+    def test_when_mixed_output_out_of_order_then_output_returned_in_order(
+        self,
+        manager,
+        mock_manager_interface,
+        a_host_session,
+        a_ref,
+        a_traitsdata,
+        a_context,
+    ):
+        method = mock_manager_interface.mock.register
+
+        entity_refs = [a_ref] * 4
+        entity_traitsdatas = [a_traitsdata] * 4
+
+        batch_element_error0 = BatchElementError(
+            BatchElementError.ErrorCode.kEntityResolutionError, "0 some string ✨"
+        )
+        entity_ref1 = EntityReference("ref1")
+        batch_element_error2 = BatchElementError(
+            BatchElementError.ErrorCode.kEntityResolutionError, "2 some string ✨"
+        )
+        entity_ref3 = EntityReference("ref3")
+
+        def call_callbacks(*_args):
+            callback = method.call_args[0][4]
+            callback(1, entity_ref1)
+
+            callback = method.call_args[0][5]
+            callback(0, batch_element_error0)
+
+            callback = method.call_args[0][4]
+            callback(3, entity_ref3)
+
+            callback = method.call_args[0][5]
+            callback(2, batch_element_error2)
+
+        method.side_effect = call_callbacks
+
+        actual_ref_or_error = manager.register(
+            entity_refs,
+            entity_traitsdatas,
+            a_context,
+            Manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        method.assert_called_once_with(
+            entity_refs,
+            entity_traitsdatas,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        assert len(actual_ref_or_error) == 4
+        assert_BatchElementError_eq(actual_ref_or_error[0], batch_element_error0)
+        assert actual_ref_or_error[1] == entity_ref1
+        assert_BatchElementError_eq(actual_ref_or_error[2], batch_element_error2)
+        assert actual_ref_or_error[3] == entity_ref3
 
 
 class Test_Manager_createContext:


### PR DESCRIPTION
## Description

Closes #854 Add Python bindings to `register` overloads that allow single-element and/or exception-less workflows.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.

## Reviewer Notes

Tests will be tidied somewhat as part of #886

Also related is #881, which at time of writing is awaiting review/merge, so may prompt an update of this PR if it is merged first.

