### PR TITLE
[Docs] Add additional commit message components

### DIFF
--- a/doc/contributing/COMMITS.md
+++ b/doc/contributing/COMMITS.md
@@ -258,7 +258,9 @@ These components should be used in commit message titles:
 
 - `Build` For `Makefile`, `CMake`, `setup.py`, etc. use by all builds.
 - `CI` For work solely on GitHub Actions or similar deployments.
-- `Core` For work within the core, non-interactive API.
+- `Core` For work within the core c++, non-interactive API.
+- `Python` For work solely focused on the Python API.
+- `C` For work solely focused on the C API.
 - `Docs` For work in the (distribution) Doxygen documentation or
   in-repository Markdown files.
 - `Examples` For work included under the `examples` directory.


### PR DESCRIPTION

## Description
From action item from last weeks retro.

As `Core` was becoming a bit of a catch all, and there is a fair bit of utility to be gained by being able to see whether a commit is solely python focused or not, add additional code components for other api types.

Given the nature of OpenAssetIO being C++ first, and internal work also normally being C++ api work, i decided not to explicitly have a `C++` tag, and leave that under the auspices of `Core`, since to do so I fear would create situation where you need more than 1 tag to describe something properly.

~- [ ] I have updated the release notes.~
~- [ ] I have updated all relevant user documentation.~

