### PR TITLE
Deep-copy locale in `createChildContext`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,16 @@ Release Notes
 v1.0.0-alpha.x
 --------------
 
+### Breaking changes
+
+- `Manager.createChildContext` now deep-copies the parent locale to
+  prevent subsequent modifications of the locale of one context
+  from affecting the other.
+  [#896](https://github.com/OpenAssetIO/OpenAssetIO/issues/896)
+
+- Removed `ManagerInterface.setRelatedReferences` pending re-design.
+  [#16](https://github.com/OpenAssetIO/OpenAssetIO/issues/16)
+
 ### Improvements
 
 - Added support for running `ctest` when a python venv is used to
@@ -12,11 +22,6 @@ v1.0.0-alpha.x
 - `HostSession.logger()` now returns a const reference to the held
   logger pointer rather than a copy.
   [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)
-
-### Breaking changes
-
-- Removed `ManagerInterface.setRelatedReferences` pending re-design.
-  [#16](https://github.com/OpenAssetIO/OpenAssetIO/issues/16)
 
 v1.0.0-alpha.10
 --------------

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,8 @@
 Release Notes
 =============
 
-v1.0.0-alpha.x
---------------
+v1.0.0-alpha.xx
+---------------
 
 ### Breaking changes
 
@@ -24,7 +24,7 @@ v1.0.0-alpha.x
   [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)
 
 v1.0.0-alpha.10
---------------
+---------------
 
 ### Breaking changes
 

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -278,6 +278,14 @@ class OPENASSETIO_CORE_EXPORT Manager {
    *
    *  Creates a child Context for use with the manager.
    *
+   *  The new context will have the same configuration as the parent and
+   *  be considered to be part of the same logical group, but may be
+   *  modified independently. Useful when performing multiple operations
+   *  in parallel.
+   *
+   *  @note The locale is deep-copied so that the child's locale can be
+   *  freely modified without affecting the parent.
+   *
    *  @warning Contexts should never be directly constructed, always
    *  use this method or @ref createContext to create a new one.
    *

--- a/src/openassetio-core/src/hostApi/Manager.cpp
+++ b/src/openassetio-core/src/hostApi/Manager.cpp
@@ -72,8 +72,10 @@ ContextPtr Manager::createContext() {
 }
 
 ContextPtr Manager::createChildContext(const ContextPtr &parentContext) {
-  ContextPtr context =
-      Context::make(parentContext->access, parentContext->retention, parentContext->locale);
+  // Copy-construct the locale so changes made to the child context don't
+  // affect the parent (and visa versa).
+  ContextPtr context = Context::make(parentContext->access, parentContext->retention,
+                                     TraitsData::make(parentContext->locale));
   if (parentContext->managerState) {
     context->managerState =
         managerInterface_->createChildState(parentContext->managerState, hostSession_);

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -2554,7 +2554,7 @@ class Test_Manager_createChildContext:
         assert context_b.managerState is state_b
         assert context_b.access == context_a.access
         assert context_b.retention == context_a.retention
-        assert context_b.locale == context_b.locale
+        assert context_b.locale == context_a.locale
         mock_manager_interface.mock.createChildState.assert_called_once_with(
             state_a, a_host_session
         )

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -502,7 +502,6 @@ class Test_Manager_getRelatedReferences:
         an_entity_trait_set,
         a_context,
     ):
-
         # pylint: disable=too-many-locals
 
         method = mock_manager_interface.mock.getRelatedReferences
@@ -2559,6 +2558,26 @@ class Test_Manager_createChildContext:
             state_a, a_host_session
         )
         mock_manager_interface.mock.createState.assert_not_called()
+
+    def test_when_called_with_parent_then_locale_is_deep_copied(
+        self, manager, mock_manager_interface, a_host_session
+    ):
+        original_locale = TraitsData()
+        original_locale.setTraitProperty("a", "v", 1)
+
+        state_a = managerApi.ManagerStateBase()
+        mock_manager_interface.mock.createState.return_value = state_a
+        mock_manager_interface.mock.createChildState.return_value = state_a
+        context_a = manager.createContext()
+        context_a.access = Context.Access.kWrite
+        context_a.retention = Context.Retention.kSession
+        context_a.locale = original_locale
+
+        context_b = manager.createChildContext(context_a)
+
+        assert context_b.locale == context_a.locale
+        original_locale.setTraitProperty("a", "v", 2)
+        assert context_b.locale != context_a.locale
 
     def test_when_called_with_parent_with_no_managerState_then_createChildState_is_not_called(
         self, manager, mock_manager_interface


### PR DESCRIPTION
Closes #896 