### PR TITLE
Remove `setRelatedReferences`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,11 @@ v1.0.0-alpha.x
   logger pointer rather than a copy.
   [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)
 
+### Breaking changes
+
+- Removed `ManagerInterface.setRelatedReferences` pending re-design.
+  [#16](https://github.com/OpenAssetIO/OpenAssetIO/issues/16)
+
 v1.0.0-alpha.10
 --------------
 

--- a/doc/doxygen/src/ForManagers.dox
+++ b/doc/doxygen/src/ForManagers.dox
@@ -193,14 +193,6 @@
  * places any constraints on the implementation of any given asset
  * management system.
  *
- * There are however times when a host will explicitly add a
- * relationship to an entity. Generally speaking, this is when an
- * existing entity is known to be relevant to a newly created
- * one. For example, if an image has been rendered from an assetized
- * script. The host may call @ref openassetio.managerApi.ManagerInterface.ManagerInterface.setRelatedReferences
- * "setRelatedReferences", to add the script's reference to the newly
- * registered image, using the SourceDocumentRelationship trait set.
- *
  * In order to support entity relationships:
  *
  * - Implement
@@ -210,18 +202,6 @@
  *   use these relationships to simplify common pipeline integration
  *   tasks. For example, loading multiple AOVs for a render, or
  *   determining data dependencies when transferring assets.
- *
- * - If appropriate, implement
- *   @ref openassetio.managerApi.ManagerInterface.ManagerInterface.setRelatedReferences
- *   "setRelatedReferences" to update any internal relationships that
- *   may be affected by the registered change.
- *
- * @note It is currently in flux as to whether relationship creation
- * should be a hard requirement of the API, or considered hints as set
- * by the host. There is even question as to the validity of the API
- * allowing sets at all, please contribute to the discussion here if you
- * have any opinion on the matter:
- * https://github.com/OpenAssetIO/OpenAssetIO/discussions/18
  *
  * @subsection manager_todo_ui Embedding Custom UI Within the Host
  *

--- a/src/openassetio-python/package/openassetio/hostApi/Manager.py
+++ b/src/openassetio-python/package/openassetio/hostApi/Manager.py
@@ -472,8 +472,6 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         length, ie: not a 1:1 mapping of entities to relationships.
 
         @unstable
-
-        @todo Implement missing setRelatedReferences()
         """
         if not isinstance(references, (list, tuple)):
             references = [

--- a/src/openassetio-python/package/openassetio/managerApi/ManagerInterface.py
+++ b/src/openassetio-python/package/openassetio/managerApi/ManagerInterface.py
@@ -30,7 +30,6 @@ import abc
 
 # TODO(DF): Remove pylint disable once CI is fixed.
 from openassetio import _openassetio  # pylint: disable=no-name-in-module
-from .. import exceptions
 
 
 __all__ = [
@@ -557,66 +556,8 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         cursory validation that this is the case before calling this
         function.
 
-        @see @ref setRelatedReferences
-
         @unstable
         """
         raise NotImplementedError
-
-    def setRelatedReferences(
-        self, entityRef, relationshipTraitsData, relatedRefs, context, hostSession, append=True
-    ):
-        """
-        Creates a new relationship between the referenced entities.
-
-        Though getRelatedReferences is an essential call, there is some
-        asymmetry here, as it is not necessarily required to be able to
-        setRelatedReferences directly. For example, in the case of a
-        'shot' (as illustrated in the docs for getRelatedReferences) -
-        any new shots would be created by registering a new entity with
-        the traits of a ShotSpecification under the parent, rather than
-        using this call. The best way to think of it is that this call
-        is reserved for defining relationships between existing assets
-        (such as connecting the script used to define a render, with the
-        image sequences it creates) and 'register' as being defining the
-        relationship between a new asset and some existing one.
-
-        In systems that don't support post-creation adjustment of
-        relationships, this can simply be a no-op.
-
-        @param entityRef @fqref{EntityReference} "EntityReference" The
-        entity to which the relationship should be established.
-
-        @param relationshipTraitsData @fqref{TraitsData} "TraitsData",
-        The type of relationship to establish.
-
-        @param relatedRefs List[str], The related entities for the
-        given relationship.
-
-        @param context Context The calling context.
-
-        @param hostSession openassetio.managerApi.HostSession The host
-        session that maps to the caller, this should be used for all
-        logging and provides access to the openassetio.managerApi.Host
-        object representing the process that initiated the API session.
-
-        @param append bool, When True (default) new relationships will
-        be added to any existing ones. If False, then any existing
-        relationships with the supplied traits will first be
-        removed.
-
-        @return None
-
-        @see @ref getRelatedReferences
-        @see @ref register
-
-        @unstable
-        """
-        if not self.entityExists(entityRef, context, hostSession):
-            raise exceptions.InvalidEntityReference(entityReference=entityRef)
-
-        for ref in relatedRefs:
-            if not self.entityExists(ref, context, hostSession):
-                raise exceptions.InvalidEntityReference(entityReference=ref)
 
     ## @}

--- a/src/openassetio-python/tests/conftest.py
+++ b/src/openassetio-python/tests/conftest.py
@@ -178,15 +178,6 @@ class ValidatingMockManagerInterface(ManagerInterface):
             entityRefs, context, hostSession, overrideVersionName
         )
 
-    def setRelatedReferences(
-        self, entityRef, relationshipTraitsData, relatedRefs, context, hostSession, append=True
-    ):
-        assert isinstance(entityRef, EntityReference)
-        self.__assertIsIterableOf(relatedRefs, EntityReference)
-        return self.mock.setRelatedReferences(
-            entityRef, relationshipTraitsData, relatedRefs, context, hostSession, append=append
-        )
-
     def preflight(
         self, targetEntityRefs, traitSet, context, hostSession, successCallback, errorCallback
     ):


### PR DESCRIPTION
Part of #16.

`set` was not well considered, as it has the potential for race conditions in real-world scenarios. A re-design is in the works, so remove for now to avoid dead code in the release.