### PR TITLE
Return a `const&` from `HostSession::logger`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,10 @@ v1.0.0-alpha.x
 - Added support for running `ctest` when a python venv is used to
   determine which Python distribution to build against.
 
+- `HostSession.logger()` now returns a const reference to the held
+  logger pointer rather than a copy.
+  [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)
+
 v1.0.0-alpha.10
 --------------
 

--- a/src/openassetio-core/include/openassetio/managerApi/HostSession.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/HostSession.hpp
@@ -51,7 +51,7 @@ class OPENASSETIO_CORE_EXPORT HostSession final {
   /**
    * @return The logger associated with this session
    */
-  [[nodiscard]] log::LoggerInterfacePtr logger() const;
+  [[nodiscard]] const log::LoggerInterfacePtr& logger() const;
 
  private:
   explicit HostSession(HostPtr host, log::LoggerInterfacePtr logger);

--- a/src/openassetio-core/src/managerApi/HostSession.cpp
+++ b/src/openassetio-core/src/managerApi/HostSession.cpp
@@ -17,7 +17,7 @@ HostSession::HostSession(HostPtr host, log::LoggerInterfacePtr logger)
     : host_{std::move(host)}, logger_{std::move(logger)} {}
 
 HostPtr HostSession::host() const { return host_; }
-log::LoggerInterfacePtr HostSession::logger() const { return logger_; }
+const log::LoggerInterfacePtr& HostSession::logger() const { return logger_; }
 
 }  // namespace managerApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-core/tests/managerApi/HostSessionTest.cpp
+++ b/src/openassetio-core/tests/managerApi/HostSessionTest.cpp
@@ -1,16 +1,58 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2023 The Foundry Visionmongers Ltd
 #include <type_traits>
 
-#include <catch2/catch.hpp>
+#include <openassetio/export.h>
 
+#include <catch2/catch.hpp>
+#include <catch2/trompeloeil.hpp>
+
+#include <openassetio/hostApi/HostInterface.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/managerApi/Host.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 
-OPENASSETIO_FWD_DECLARE(LoggerInterface)
-OPENASSETIO_FWD_DECLARE(managerApi, Host)
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace {
+
+/**
+ * Mock implementation of a HostInterface
+ */
+struct MockHostInterface : trompeloeil::mock_interface<hostApi::HostInterface> {
+  IMPLEMENT_CONST_MOCK0(identifier);
+  IMPLEMENT_CONST_MOCK0(displayName);
+};
+
+/**
+ * Mock implementation of a LoggerInterface
+ */
+struct MockLoggerInterface : trompeloeil::mock_interface<log::LoggerInterface> {
+  IMPLEMENT_MOCK2(log);
+};
+
+}  // namespace
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio
 
 SCENARIO("HostSession constructor is private") {
   STATIC_REQUIRE_FALSE(std::is_constructible_v<openassetio::managerApi::HostSession,
                                                openassetio::managerApi::HostPtr,
                                                openassetio::log::LoggerInterfacePtr>);
+}
+
+SCENARIO("HostSession::logger method returns held pointer by reference") {
+  GIVEN("a configured HostSession") {
+    const openassetio::managerApi::HostSessionPtr session =
+        openassetio::managerApi::HostSession::make(
+            openassetio::managerApi::Host::make(
+                std::make_shared<openassetio::MockHostInterface>()),
+            std::make_shared<openassetio::MockLoggerInterface>());
+
+    WHEN("logger is called multiple times") {
+      THEN("returned values are references to the same object") {
+        CHECK(&session->logger() == &session->logger());
+      }
+    }
+  }
 }


### PR DESCRIPTION
Avoids unneccesary copies when invoked as follows:

```
session->logger()->warning("Something bad")
```

Closes #814.