### PR TITLE
[Python] Always require Development

### DIFF
--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -10,14 +10,8 @@ if (OPENASSETIO_ENABLE_PYTHON)
     #-------------------------------------------------------------------
     # Locate packages
 
-    list(APPEND _components Interpreter)
-    list(APPEND _components Development.Module)
-    if (OPENASSETIO_ENABLE_TESTS)
-        list(APPEND _components Development.Embed)
-    endif ()
-
     # Locate the Python package.
-    find_package(Python REQUIRED COMPONENTS ${_components})
+    find_package(Python REQUIRED COMPONENTS Interpreter Development)
 
     # Debug log some outputs expected from the built-in FindPython.
     message(TRACE "Python_EXECUTABLE = ${Python_EXECUTABLE}")


### PR DESCRIPTION
Ideally, we would only require Development.Embed when it is really needed. This is when running the OpenAssetIO tests.

However, FindPython.cmake may have a bug when using this module with this configuration. It would find Python 2.7 for some reason, which does not have some symbols that we use.

    error: use of undeclared identifier '_Py_IsFinalizing'

Please refer to:

https://gitlab.kitware.com/cmake/cmake/-/issues/24834

So, the workaround is to require the whole of Development for now until we have a working way to customise and modularise it further down.

The downside of the fix is only that we require a bit more than necessary, but this probably does not have such a big impact as the current code, which does not work in certain scenarios.

I have also tried to make sure that it picks up Python 3 by being explicit about it, but in the end, it seems to have suffered from the same issue.

## Description

Closes # (issue)

- [ ] I have updated the release notes.
- [ ] I have updated all relevant user documentation.

## Reviewer Notes

<!--- Provide any notes to the reviewer that might help them more easily
      understand the changeset. --->

## Test Instructions

<!--- Provide instructions to the reviewer on how to explicitly test
      these changes. --->
