### PR TITLE
Create new Contexts with pre-initialized locale

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,6 +39,11 @@ v1.0.0-alpha.xx
   [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)
   [#904](https://github.com/OpenAssetIO/OpenAssetIO/issues/904)
 
+- Contexts are now created with an empty `TraitsData` in their locale,
+  this makes testing for imbued traits easier as it can be assumed that
+  the pointer is never null.
+  [#903](https://github.com/OpenAssetIO/OpenAssetIO/issues/903)
+
 v1.0.0-alpha.10
 ---------------
 

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -266,6 +266,9 @@ class OPENASSETIO_CORE_EXPORT Manager {
   /**
    *  Creates a new Context for use with the manager.
    *
+   *  The @fqref{Context.locale} "locale" will be initialized with an
+   *  empty @fqref{TraitsData} "TraitsData" instance.
+   *
    *  @warning Contexts should never be directly constructed, always
    *  use this method or @ref createChildContext to create a new one.
    *

--- a/src/openassetio-core/src/hostApi/Manager.cpp
+++ b/src/openassetio-core/src/hostApi/Manager.cpp
@@ -68,6 +68,7 @@ trait::TraitsDatas Manager::managementPolicy(const trait::TraitSets &traitSets,
 ContextPtr Manager::createContext() {
   ContextPtr context = Context::make();
   context->managerState = managerInterface_->createState(hostSession_);
+  context->locale = TraitsData::make();
   return context;
 }
 

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -2524,7 +2524,8 @@ class Test_Manager_createContext:
         assert context_a.access == Context.Access.kUnknown
         assert context_a.retention == Context.Retention.kTransient
         assert context_a.managerState is state_a
-        assert context_a.locale is None
+        assert isinstance(context_a.locale, TraitsData)
+        assert context_a.locale.traitSet() == set()
         mock_manager_interface.mock.createState.assert_called_once_with(a_host_session)
 
 


### PR DESCRIPTION
It is a lot easier to work with the locale if it is never null. Otherwise, appending to a locale ends up needing branches which adds unneccesary complexity.

Closes #903