### PR TITLE
[Core] Return a `cont&` from `HostSession::host`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,9 +34,10 @@ v1.0.0-alpha.xx
 - Added support for running `ctest` when a python venv is used to
   determine which Python distribution to build against.
 
-- `HostSession.logger()` now returns a const reference to the held
-  logger pointer rather than a copy.
+- `HostSession` methods `logger` and `host` now return a const
+  reference to the held pointer rather than a copy.
   [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)
+  [#904](https://github.com/OpenAssetIO/OpenAssetIO/issues/904)
 
 v1.0.0-alpha.10
 ---------------

--- a/src/openassetio-core/include/openassetio/managerApi/HostSession.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/HostSession.hpp
@@ -46,7 +46,7 @@ class OPENASSETIO_CORE_EXPORT HostSession final {
   /**
    * @return The host that initiated the API session.
    */
-  [[nodiscard]] HostPtr host() const;
+  [[nodiscard]] const HostPtr& host() const;
 
   /**
    * @return The logger associated with this session

--- a/src/openassetio-core/src/managerApi/HostSession.cpp
+++ b/src/openassetio-core/src/managerApi/HostSession.cpp
@@ -16,7 +16,7 @@ HostSessionPtr HostSession::make(HostPtr host, log::LoggerInterfacePtr logger) {
 HostSession::HostSession(HostPtr host, log::LoggerInterfacePtr logger)
     : host_{std::move(host)}, logger_{std::move(logger)} {}
 
-HostPtr HostSession::host() const { return host_; }
+const HostPtr& HostSession::host() const { return host_; }
 const log::LoggerInterfacePtr& HostSession::logger() const { return logger_; }
 
 }  // namespace managerApi

--- a/src/openassetio-core/tests/managerApi/HostSessionTest.cpp
+++ b/src/openassetio-core/tests/managerApi/HostSessionTest.cpp
@@ -56,3 +56,19 @@ SCENARIO("HostSession::logger method returns held pointer by reference") {
     }
   }
 }
+
+SCENARIO("HostSession::host method returns held pointer by reference") {
+  GIVEN("a configured HostSession") {
+    const openassetio::managerApi::HostSessionPtr session =
+        openassetio::managerApi::HostSession::make(
+            openassetio::managerApi::Host::make(
+                std::make_shared<openassetio::MockHostInterface>()),
+            std::make_shared<openassetio::MockLoggerInterface>());
+
+    WHEN("host is called multiple times") {
+      THEN("returned values are references to the same object") {
+        CHECK(&session->host() == &session->host());
+      }
+    }
+  }
+}


### PR DESCRIPTION
Avoids unneccesary copies when used inline.

Closes #904