### PR TITLE
[Python] Add `__str__` implementation for `EntityReference`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,6 +44,10 @@ v1.0.0-alpha.xx
   the pointer is never null.
   [#903](https://github.com/OpenAssetIO/OpenAssetIO/issues/903)
 
+- `EntityReference` objects are now coercible to strings in Python,
+  allowing more intuitive use with `format`, `print`, and others.
+  [#573](https://github.com/OpenAssetIO/OpenAssetIO/issues/573)
+
 v1.0.0-alpha.10
 ---------------
 

--- a/src/openassetio-python/cmodule/src/EntityReferenceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/EntityReferenceBinding.cpp
@@ -13,5 +13,6 @@ void registerEntityReference(const py::module &mod) {
   py::class_<EntityReference>{mod, "EntityReference", py::is_final()}
       .def(py::init<openassetio::Str>(), py::arg("entityReferenceString"))
       .def("toString", &EntityReference::toString)
+      .def("__str__", &EntityReference::toString)
       .def(py::self == py::self);  // NOLINT(misc-redundant-expression)
 }

--- a/src/openassetio-python/tests/package/test_entityreference.py
+++ b/src/openassetio-python/tests/package/test_entityreference.py
@@ -47,3 +47,9 @@ class Test_EntityReference_equality:
 
     def test_when_not_same_then_compares_unequal(self):
         assert EntityReference("something") != EntityReference("something else")
+
+
+class Test_EntityReference_string_equivalence:
+    def test_when_used_with_format_then_result_contains_toString_value(self):
+        a_ref = EntityReference("Some 🍟 with that?")
+        assert f"{a_ref}" == a_ref.toString()


### PR DESCRIPTION
Had a moment to chip away at the backlog a little, so was looking for a small task.

Allows them to be used with fstrings, print, etc. Retains the `toString` method for compatibility and/or more explicit programming.

Part of #573.