### PR TITLE
Provide C++ functions to expose objects to Python

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,13 @@ v1.0.0-alpha.xx
   `ResolveSuccessCallback` from reference types to value types.
   [#858](https://github.com/OpenAssetIO/OpenAssetIO/issues/858)
 
+### New Features
+
+- Added utility methods `castToPyObject` and `castFromPyObject` to
+  `openassetio-python-bridge` to facilitate converting between C++ and
+  Python objects for hosts seeking to support mixed language workflows.
+  [#798](https://github.com/OpenAssetIO/OpenAssetIO/issues/798)
+
 ### Improvements
 
 - Added support for running `ctest` when a python venv is used to

--- a/src/openassetio-python/bridge/CMakeLists.txt
+++ b/src/openassetio-python/bridge/CMakeLists.txt
@@ -55,7 +55,8 @@ endif ()
 # Source file dependencies.
 target_sources(openassetio-python-bridge
     PRIVATE
-    src/python/hostApi.cpp)
+    src/python/hostApi.cpp
+    src/python/converter.cpp)
 
 # Public header dependency.
 target_include_directories(openassetio-python-bridge

--- a/src/openassetio-python/bridge/include/openassetio/python/converter.hpp
+++ b/src/openassetio-python/bridge/include/openassetio/python/converter.hpp
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#pragma once
+
+#include <Python.h>
+
+#include <openassetio/export.h>
+#include <openassetio/python/export.h>
+#include <openassetio/typedefs.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+/**
+ * Converter functionality for going between C++ and CPython objects.
+ */
+namespace python::converter {
+/**
+ * Casts a C++ API object to the equivalent Python object.
+ *
+ * This template is explicitly instantiated to only the OpenAssetIO
+ * types, and is not intended to be a generic converter.
+ *
+ * The purpose of this function is to provide a Python/C++ conversion
+ * without requiring/exposing a particular CPython binding library
+ * implementation.
+ *
+ * The returned `PyObject` owns a hidden reference to the input
+ * `shared_ptr`, ensuring it is kept alive. The reference will be
+ * released when the `PyObject` is destroyed.
+ *
+ * @note This function does not acquire the GIL.
+ *
+ * @warning A Python environment, with `openassetio` imported, must be
+ *          available in order to use this function.
+ *
+ * @throws std::invalid_argument if the input is null.
+ * @throws std::runtime_error if the cast fails.
+ *
+ * @param objectPtr A non-const OpenAssetIO pointer type, (eg, @needsref
+ * ManagerPtr). The returned `PyObject` takes shared ownership of this
+ * input \p objectPtr, and will keep the C++ instance alive until the
+ * `PyObject` is destroyed.
+ * This parameter must be the non-const OpenAssetIO pointer type as
+ * casting to python erases constness.
+ *
+ * @return A `PyObject` pointer to an object of the Python API type
+ * associated with the C++ API object provided. The reference count of
+ * the `PyObject` will be incremented, and must be decremented by the
+ * caller when done.
+ */
+template <typename T>
+OPENASSETIO_PYTHON_BRIDGE_EXPORT PyObject* castToPyObject(const T& objectPtr);
+
+/**
+ * Casts a Python object to the equivalent C++ API object.
+ *
+ * This template is explicitly instantiated to only the OpenAssetIO
+ * types, and is not intended to be a generic converter.
+ *
+ * The purpose of this function is to provide a Python/C++ conversion
+ * without requiring/exposing a particular CPython binding library
+ * implementation.
+ *
+ * The returned `shared_ptr` owns a hidden reference to the input
+ * `PyObject`, ensuring it is kept alive. The reference will be released
+ * when the `shared_ptr` is destroyed.
+ *
+ * Using this function requires specifying the template argument of
+ * the C++ API type equivalent to the type of the object referred to by
+ * the \p pyObject pointer.
+ *
+ * @code{.cpp}
+ * ManagerPtr manager = castFromPyObject<Manager>(pyManager);
+ * @endcode
+ *
+ *
+ * If the types of the template argument and the \p pyObject are not
+ * equivalent, an exception will be thrown due to inability to perform
+ * the cast.
+ *
+ * @note This function does not acquire the GIL.
+ *
+ * @warning A Python environment, with `openassetio` imported, must be
+ *          available in order to use this function.
+ *
+ * @throws std::invalid_argument if the function fails due to inability
+ * to cast between types, or if the input is null.
+ *
+ * @param pyObject A `PyObject` pointer to a Python object that must be
+ * of equivalent type to the template argument.
+ *
+ * @return An OpenAssetIO pointer to a C++ API object cast from the
+ * provided \p pyObject. The lifetime of the PyObject will be extended
+ * to at least the lifetime of the returned `shared_ptr`.
+ */
+template <typename T>
+OPENASSETIO_PYTHON_BRIDGE_EXPORT typename T::Ptr castFromPyObject(PyObject* pyObject);
+
+}  // namespace python::converter
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-python/bridge/src/python/converter.cpp
+++ b/src/openassetio-python/bridge/src/python/converter.cpp
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#include <openassetio/python/converter.hpp>
+
+#include <pybind11/embed.h>
+
+#include <openassetio/Context.hpp>
+#include <openassetio/TraitsData.hpp>
+#include <openassetio/hostApi/HostInterface.hpp>
+#include <openassetio/hostApi/Manager.hpp>
+#include <openassetio/hostApi/ManagerFactory.hpp>
+#include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
+#include <openassetio/log/ConsoleLogger.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/log/SeverityFilter.hpp>
+#include <openassetio/managerApi/Host.hpp>
+#include <openassetio/managerApi/HostSession.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/managerApi/ManagerStateBase.hpp>
+
+// Private headers
+#include <openassetio/private/python/pointers.hpp>
+
+namespace py = pybind11;
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace python::converter {
+
+template <typename T>
+PyObject* castToPyObject(const T& objectPtr) {
+  // Stash the errors for restoring after cast.
+  // An error_scope calls PyErr_Fetch (which clears the active error),
+  // and stashes them, restoring the error state when it falls out of
+  // scope
+  const py::error_scope previousErrorState;
+
+  if (objectPtr == nullptr) {
+    throw std::invalid_argument(
+        "Attempting to cast a nullptr objectPtr in "
+        "openassetio::python::converter::castToPyObject");
+  }
+
+  py::object pybindObj = py::cast(objectPtr);
+
+  // Check to see if the py::cast has spawned a python error
+  // We use another error_scope here for convenience of access, relying
+  // on the fact that the original error scope will be destructed last,
+  // resetting to the initial error.
+  const py::error_scope castErrorState;
+
+  if (castErrorState.value != nullptr) {
+    throw std::runtime_error(py::str(castErrorState.value));
+  }
+
+  // `release()` to avoid decrementing the PyObject refcount on leaving
+  // this function. We explicitly want +1 refcount.
+  return pybindObj.release().ptr();
+}
+
+template <typename T>
+typename T::Ptr castFromPyObject(PyObject* pyObject) {
+  if (pyObject == nullptr) {
+    throw std::invalid_argument(
+        "Attempting to cast a nullptr PyObject in "
+        "openassetio::python::converter::castFromPyObject");
+  }
+
+  // get Python object.
+  const auto pyInstance = py::reinterpret_borrow<py::object>(pyObject);
+
+  try {
+    // Extract the underlying C++ base class pointer.
+    auto* cppInstancePtr = py::cast<T*>(pyInstance);
+
+    // Use aliasing constructor, linking Python instance and C++ instance
+    // lifetimes via PyObject refcount.
+    return pointers::createPyRetainingPtr<typename T::Ptr>(pyInstance, cppInstancePtr);
+  } catch (const py::cast_error& castError) {
+    // Rethrow here to avoid bleeding pybind exception dependencies.
+    throw std::invalid_argument(castError.what());
+  }
+}
+
+// To/from explicit specialization convenience.
+// As these specializations are being used across library boundaries,
+// we must export them to prevent undefined-symbol link errors.
+#define OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(Class)                          \
+  template OPENASSETIO_PYTHON_BRIDGE_EXPORT PyObject* castToPyObject<Class::Ptr>( \
+      const Class::Ptr&);                                                         \
+  template OPENASSETIO_PYTHON_BRIDGE_EXPORT Class::Ptr castFromPyObject<Class>(PyObject*);
+
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(openassetio::Context)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(openassetio::TraitsData)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(hostApi::HostInterface)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(hostApi::Manager)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(hostApi::ManagerFactory)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(hostApi::ManagerImplementationFactoryInterface)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(log::ConsoleLogger)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(log::LoggerInterface)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(log::SeverityFilter)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(managerApi::Host)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(managerApi::HostSession)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(managerApi::ManagerInterface)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(managerApi::ManagerStateBase)
+
+}  // namespace python::converter
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-python/tests/bridge/CMakeLists.txt
+++ b/src/openassetio-python/tests/bridge/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(
     openassetio-python-bridge-test-exe
     PRIVATE
     main.cpp
+    python/test_converter.cpp
     python/test_hostApi.cpp
 )
 
@@ -97,7 +98,7 @@ separate_arguments(_envvars NATIVE_COMMAND ${_envvars})
 
 
 #-----------------------------------------------------------------------
-# Create CTest target.
+# Create CTest target for tests that may import _openassetio
 add_custom_target(
     openassetio.internal.python-bridge-test
     COMMAND
@@ -116,5 +117,33 @@ $<TARGET_FILE_NAME:openassetio-python-bridge-test-exe>"
 openassetio_add_test_target(openassetio.internal.python-bridge-test)
 openassetio_add_test_fixture_dependencies(
     openassetio.internal.python-bridge-test
+    openassetio.internal.install
+)
+
+#-----------------------------------------------------------------------
+# Create CTest target for tests that intentionally exclude _openassetio
+# This came about from wanting to test the error state of functions
+# that use the python interpreter, specifically the errors that happen
+# when `_openassetio` hadn't been imported into the python environment.
+# We can't just rely on ordering for this, as test execution order
+# is non-consitent across platforms.
+add_custom_target(
+    openassetio.internal.python-bridge-no-openassetio-module-test
+    COMMAND
+    # Note: environment variables set in-line here rather than using
+    # `set_tests_properties`. If that function is used then the calling
+    # environment is affected. In particular, PYTHONHOME can interfere
+    # with CMake itself (if installed as a pip package and so
+    # /usr/local/cmake is actually a Python console_script).
+    # Note: as above, we must not have trailing whitespace after setting
+    # an env var on Windows.
+    ${_envvars}&&
+"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/\
+$<TARGET_FILE_NAME:openassetio-python-bridge-test-exe>" "[no_openassetio_module]"
+)
+
+openassetio_add_test_target(openassetio.internal.python-bridge-no-openassetio-module-test)
+openassetio_add_test_fixture_dependencies(
+    openassetio.internal.python-bridge-no-openassetio-module-test
     openassetio.internal.install
 )

--- a/src/openassetio-python/tests/bridge/lsan_suppressions.txt
+++ b/src/openassetio-python/tests/bridge/lsan_suppressions.txt
@@ -1,3 +1,6 @@
 # pybind11 leak when defining enums
 # https://github.com/pybind/pybind11/issues/3865
 leak:pybind11::enum_<
+# Dynamic static initialization avoiding static deinitialization fiasco
+# https://github.com/pybind/pybind11/pull/4192#discussion_r975991726
+leak:pybind11::detail::get_local_internals()

--- a/src/openassetio-python/tests/bridge/python/test_converter.cpp
+++ b/src/openassetio-python/tests/bridge/python/test_converter.cpp
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+
+#include <pybind11/embed.h>
+
+#include <openassetio/export.h>
+
+#include <catch2/catch.hpp>
+#include <catch2/trompeloeil.hpp>
+
+#include <openassetio/python/converter.hpp>
+
+#include <openassetio/Context.hpp>
+#include <openassetio/TraitsData.hpp>
+#include <openassetio/hostApi/HostInterface.hpp>
+#include <openassetio/hostApi/Manager.hpp>
+#include <openassetio/hostApi/ManagerFactory.hpp>
+#include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
+#include <openassetio/log/ConsoleLogger.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/log/SeverityFilter.hpp>
+#include <openassetio/managerApi/Host.hpp>
+#include <openassetio/managerApi/HostSession.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/managerApi/ManagerStateBase.hpp>
+
+/*
+ * The below tests exercise the to/from python converter functions.
+ * These functions are intended to work with raw CPython, and we want
+ * to test them in that manner. However, we occasionally use pybind
+ * to create python objects purely for convenience.
+ */
+namespace py = pybind11;
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace {
+constexpr const char* kTestTraitId = "TestTrait";
+
+// You need an indirect macro argument to have expansion happen.
+#define STRINGIFY2(s) #s
+#define STRINGIFY(s) STRINGIFY2(s)
+
+}  // namespace
+
+SCENARIO("Mutations in one language are reflected in the other") {
+  // Cause the openassetio-python lib to be loaded so pybind can cast.
+  py::module_::import("openassetio");
+
+  GIVEN("A C++ object casted to a Python object") {
+    const TraitsDataPtr traitsData = TraitsData::make();
+    PyObject* pyTraitsData = openassetio::python::converter::castToPyObject(traitsData);
+    REQUIRE(pyTraitsData != nullptr);
+
+    WHEN("data is set via the C++ object") {
+      traitsData->addTrait(kTestTraitId);
+
+      THEN("Python object reflects that data set") {
+        PyObject* resultBool = PyObject_CallMethod(pyTraitsData, "hasTrait", "s", kTestTraitId);
+
+        // Use CHECK rather than REQUIRE in order to ensure the Decrefs
+        // below actually execute.
+        CHECK(PyBool_Check(resultBool));
+        CHECK(PyObject_IsTrue(resultBool));
+        Py_DECREF(resultBool);
+      }
+    }
+
+    WHEN("data is set via the Python object") {
+      PyObject_CallMethod(pyTraitsData, "addTrait", "s", kTestTraitId);
+
+      THEN("C++ object reflects the data set") { CHECK(traitsData->hasTrait(kTestTraitId)); }
+    }
+    Py_DECREF(pyTraitsData);
+  }
+
+  GIVEN("A Python object casted to a C++ object") {
+    // Use pybind to conveniently create a CPython object with a ref count of 1.
+    const py::object pyClass = py::module_::import("openassetio").attr("TraitsData");
+    py::object pyInstance = pyClass();
+    PyObject* pyTraitsData = pyInstance.release().ptr();
+    const TraitsDataPtr traitsData =
+        openassetio::python::converter::castFromPyObject<TraitsData>(pyTraitsData);
+
+    WHEN("data is set via the C++ object") {
+      traitsData->addTrait(kTestTraitId);
+
+      THEN("Python object reflects that data set") {
+        PyObject* resultBool = PyObject_CallMethod(pyTraitsData, "hasTrait", "s", kTestTraitId);
+
+        // Use CHECK rather than REQUIRE in order to ensure the Decrefs
+        // below actually execute.
+        CHECK(PyBool_Check(resultBool));
+        CHECK(PyObject_IsTrue(resultBool));
+        Py_DECREF(resultBool);
+      }
+    }
+
+    WHEN("data is set via the Python object") {
+      PyObject_CallMethod(pyTraitsData, "addTrait", "s", kTestTraitId);
+      THEN("C++ object reflects the data set") { CHECK(traitsData->hasTrait(kTestTraitId)); }
+    }
+    Py_DECREF(pyTraitsData);
+  }
+}
+
+SCENARIO("Casting to PyObject extends object lifetime") {
+  GIVEN("A Python object casted from a C++ object") {
+    TraitsDataPtr traitsData = TraitsData::make();
+    traitsData->addTrait(kTestTraitId);
+    PyObject* pyTraitsData = openassetio::python::converter::castToPyObject(traitsData);
+
+    WHEN("C++ reference is destroyed") {
+      CHECK(Py_REFCNT(pyTraitsData) == 1);  // Initial condition.
+      traitsData.reset();
+
+      THEN("object remains alive and can be operated on via the Python interpreter") {
+        CHECK(Py_REFCNT(pyTraitsData) == 1);
+        PyObject* resultBool = PyObject_CallMethod(pyTraitsData, "hasTrait", "s", kTestTraitId);
+
+        // Use CHECK rather than REQUIRE in order to ensure the Decrefs
+        // below actually execute.
+        CHECK(PyBool_Check(resultBool));
+        CHECK(PyObject_IsTrue(resultBool));
+        Py_DECREF(resultBool);
+      }
+    }
+    Py_DECREF(pyTraitsData);
+  }
+}
+
+SCENARIO("Casting to a C++ object binds object lifetime") {
+  GIVEN("A python object") {
+    py::module_::import("openassetio");
+
+    // Use pybind to conveniently create a CPython object with a ref count of 1.
+    const py::object pyClass = py::module_::import("openassetio").attr("TraitsData");
+    py::object pyInstance = pyClass();
+    PyObject* pyTraitsData = pyInstance.release().ptr();
+    CHECK(Py_REFCNT(pyTraitsData) == 1);
+
+    WHEN("Python object is converted to a C++ object") {
+      TraitsDataPtr traitsData =
+          openassetio::python::converter::castFromPyObject<TraitsData>(pyTraitsData);
+
+      THEN("Python reference is obtained") { CHECK(Py_REFCNT(pyTraitsData) == 2); }
+
+      AND_WHEN("C++ reference is destroyed") {
+        traitsData.reset();
+
+        THEN("Python reference is released") { CHECK(Py_REFCNT(pyTraitsData) == 1); }
+      }
+    }
+
+    Py_DECREF(pyTraitsData);
+  }
+}
+
+SCENARIO("Attempting to cast to an unregistered type") {
+  GIVEN("an invalid for casting Python object") {
+    // Use pybind to conveniently create a CPython object with a ref count of 1.
+    const py::object pyClass = py::module_::import("decimal").attr("Decimal");
+    py::object pyInstance = pyClass(1.0);
+    // PyDecimal is not a type pybind has been registered to convert.
+    PyObject* pyDecimal = pyInstance.release().ptr();
+
+    /*
+     * Pybind error messages vary between release and debug mode:
+     * "Unable to cast Python instance of type <class 'decimal.Decimal'> to C++
+     * type 'openassetio::v1::hostApi::Manager'"
+     * vs.
+     * "Unable to cast Python instance to C++ type (compile in debug
+     * mode for details)"
+     */
+    WHEN("object is converted to a C++ object") {
+      REQUIRE_THROWS_WITH(
+          openassetio::python::converter::castFromPyObject<openassetio::hostApi::Manager>(
+              pyDecimal),
+          Catch::Matchers::StartsWith("Unable to cast Python instance"));
+    }
+
+    Py_DECREF(pyDecimal);
+  }
+}
+
+// NB: This test is excluded by default and is executed by explicitly
+// specifying the [no_openassetio_module] tag to the Catch2 runner
+// executable.
+// This is because we _must not_ have `_openassetio.so` loaded for these
+// tests.
+SCENARIO("Error attempting to convert API objects without openassetio module loaded",
+         "[.][no_openassetio_module]") {
+  GIVEN("A Python environment without openassetio loaded") {
+    REQUIRE_FALSE(py::module_::import("sys").attr("modules").contains("openassetio"));
+
+    AND_GIVEN("an OpenAssetIO C++ API object") {
+      const TraitsDataPtr traitsData = TraitsData::make();
+
+      WHEN("the C++ object is casted to a Python object") {
+        THEN("cast throws expected exception") {
+          REQUIRE_THROWS_WITH(openassetio::python::converter::castToPyObject(traitsData),
+                              std::string("Unregistered type : openassetio::" STRINGIFY(
+                                  OPENASSETIO_CORE_ABI_VERSION) "::TraitsData"));
+        }
+      }
+
+      AND_GIVEN("A CPython error state is already set") {
+        // If the process terminates with a CPython error, pybind will
+        // emit an exception on destruction, causing a terminate call.
+        // As we explicitly set an error in this test, use a scope to
+        // make sure we clean up after ourselves.
+        const py::error_scope errorCleanup;
+
+        const std::string errorString = "Test Error";
+        // Set the CPython exception.
+        PyErr_SetString(PyExc_RuntimeError, errorString.c_str());
+
+        WHEN("the C++ object is casted to a Python object") {
+          THEN("cast throws expected exception") {
+            REQUIRE_THROWS_WITH(openassetio::python::converter::castToPyObject(traitsData),
+                                std::string("Unregistered type : openassetio::" STRINGIFY(
+                                    OPENASSETIO_CORE_ABI_VERSION) "::TraitsData"));
+
+            AND_THEN("CPython error state is maintained") {
+              // castToPyObject, despite messing with the PyErr state
+              // itself, should have correctly reset the exception back.
+              CHECK(PyErr_ExceptionMatches(PyExc_RuntimeError));
+              const py::error_scope errors;
+              CHECK(std::string(py::str(errors.value)) == errorString);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+namespace {
+
+namespace hostApi = openassetio::hostApi;
+namespace log = openassetio::log;
+namespace managerApi = openassetio::managerApi;
+
+// clang-format off
+using CastableClasses = std::tuple<
+    openassetio::Context,
+    openassetio::TraitsData,
+    hostApi::HostInterface,
+    hostApi::Manager,
+    hostApi::ManagerFactory,
+    hostApi::ManagerImplementationFactoryInterface,
+    log::ConsoleLogger,
+    log::LoggerInterface,
+    log::SeverityFilter,
+    managerApi::Host,
+    managerApi::HostSession,
+    managerApi::ManagerInterface,
+    managerApi::ManagerStateBase
+>;
+// clang-format on
+}  // namespace
+
+TEMPLATE_LIST_TEST_CASE("Appropriate classes have castFromPyObject functions", "",
+                        CastableClasses) {
+  // These tests check that the nullptr exception works, but also
+  // serve to verify that the functions exist for all expected types.
+  PyObject* empty = nullptr;
+  REQUIRE_THROWS_WITH(openassetio::python::converter::castFromPyObject<TestType>(empty),
+                      std::string("Attempting to cast a nullptr PyObject in "
+                                  "openassetio::python::converter::castFromPyObject"));
+}
+
+TEMPLATE_LIST_TEST_CASE("Appropriate classes have castToPyObject functions", "", CastableClasses) {
+  // These tests check that the nullptr exception works, but also
+  // serve to verify that the functions exist for all expected types.
+  const typename TestType::Ptr empty = nullptr;
+  REQUIRE_THROWS_WITH(openassetio::python::converter::castToPyObject(empty),
+                      std::string("Attempting to cast a nullptr objectPtr in "
+                                  "openassetio::python::converter::castToPyObject"));
+}
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio


### PR DESCRIPTION
## Description

Closes #798. Adds new `openassetio::python::converter` namespace with functions `castToPyObject` and `castFromPyObject`.

- [x] I have updated the release notes.
- [ ] I have updated all relevant user documentation (TBD see below)

## Reviewer Notes

AC "Documentation examples updated" - other than docstrings (which contain snippets), we don't have C++ example docs to update(?).

AC "Integration tests added (OpenAssetIO-Test-CMake or otherwise)" - do we still think this is necessary in addition to included Catch2 tests?

## Test Instructions

Unit tests provided. Tricky to test externally without hacking together a hybrid C++/Python OpenAssetIO host.
