### PR TITLE
[Docs] Docs detailing python cast exceptions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,6 +34,10 @@ v1.0.0-alpha.xx
 - Added utility methods `castToPyObject` and `castFromPyObject` to
   `openassetio-python-bridge` to facilitate converting between C++ and
   Python objects for hosts seeking to support mixed language workflows.
+  Note : Some methods on `Manager` and `ManagerInterface` are currently
+  implemented in python, pending imminent port to C++. Due to this,
+  these methods will not yet be available for use on a python object
+  returned from `castToPyObject`.
   [#798](https://github.com/OpenAssetIO/OpenAssetIO/issues/798)
 
 ### Improvements

--- a/src/openassetio-python/bridge/include/openassetio/python/converter.hpp
+++ b/src/openassetio-python/bridge/include/openassetio/python/converter.hpp
@@ -33,6 +33,11 @@ namespace python::converter {
  * @warning A Python environment, with `openassetio` imported, must be
  *          available in order to use this function.
  *
+ * @warning Some methods on @ref manager and @ref ManagerInterface are
+ * currently implemented in python, pending imminent port to C++. Due to
+ * this, these methods will not yet be available for use on a python
+ * object returned from this function.
+ *
  * @throws std::invalid_argument if the input is null.
  * @throws std::runtime_error if the cast fails.
  *


### PR DESCRIPTION
We forgot to add these, wanna do it before the release.

Some methods are implemented in python, temporarily, and this means that casted PyObjects wont have access to those methods. Add docs to describe this niggle, even though this problem will disappear soon as these methods get ported to c++.

## Description

Closes # (issue)

- [x] I have updated the release notes.

