### PR TITLE
Migrate `getWithRelationship[s]` to callbacks

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -39,12 +39,6 @@ jobs:
           pylint-paths: >
             src/openassetio-python/package/openassetio
             src/openassetio-python/tests/package
-          # Presently it's not possible to disable the `duplicate-code`
-          # check for specific files, so it thinks that the symlink is
-          # duplicated implementation. See:
-          #     https://github.com/PyCQA/pylint/issues/214
-          pylint-ignore-paths: >
-            src/openassetio-python/tests/package/pluginSystem/resources/symlinkPath
 
   black:
     runs-on: ubuntu-latest

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,8 +8,11 @@ feature/getRelatedReferencesRefactor
 
 - Refactored `getRelatedReferences` into `getWithRelationship` and
   `getWithRelationships` to better define the two possible batch-axis,
-  and simplify implementation on both sides of the API.
+  and simplify implementation on both sides of the API. This also
+  changes the methods over to callback signatures for consistency with
+  the rest of the API.
   [#847](https://github.com/OpenAssetIO/OpenAssetIO/issues/847)
+  [#919](https://github.com/OpenAssetIO/OpenAssetIO/issues/919)
 
 ### Improvements
 

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -592,12 +592,12 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * @param successCallback Callback that will be called for each
    * successful resolution of an entity reference. It will be
    * given the corresponding index of the entity reference in
-   * `entityRefs` along with its `TraitsData`. The callback will be
-   * called on the same thread that initiated the call to `resolve`.
+   * `entityReferences` along with its `TraitsData`. The callback will
+   * be called on the same thread that initiated the call to `resolve`.
    *
    * @param errorCallback Callback that will be called for each
    * failed resolution of an entity reference. It will be given the
-   * corresponding index of the entity reference in `entityRefs`
+   * corresponding index of the entity reference in `entityReferences`
    * along with a populated @fqref{BatchElementError}
    * "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
    * "ErrorCodes"). The callback will be called on the same thread
@@ -901,7 +901,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    *
    * @param errorCallback Callback that will be called for each
    * failed preflight of an entity reference. It will be given the
-   * corresponding index of the entity reference in `entityRefs`
+   * corresponding index of the entity reference in `entityReferences`
    * along with a populated @fqref{BatchElementError}
    * "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
    * "ErrorCodes"). The callback will be called on the same thread
@@ -1147,7 +1147,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    *
    * @param errorCallback Callback that will be called for each
    * failed registration of an entity reference. It will be given the
-   * corresponding index of the entity reference in `entityRefs`
+   * corresponding index of the entity reference in `entityReferences`
    * along with a populated @fqref{BatchElementError}
    * "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
    * "ErrorCodes"). The callback will be called on the same thread

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -249,7 +249,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    *
    * @param context The calling context.
    *
-   * @return a `TraitsData` for each element in `traitSets`.
+   * @return a `TraitsData` for each element in @p traitSets.
    */
   [[nodiscard]] trait::TraitsDatas managementPolicy(const trait::TraitSets& traitSets,
                                                     const ContextConstPtr& context) const;
@@ -592,12 +592,12 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * @param successCallback Callback that will be called for each
    * successful resolution of an entity reference. It will be
    * given the corresponding index of the entity reference in
-   * `entityReferences` along with its `TraitsData`. The callback will
+   * @p entityReferences along with its `TraitsData`. The callback will
    * be called on the same thread that initiated the call to `resolve`.
    *
    * @param errorCallback Callback that will be called for each
    * failed resolution of an entity reference. It will be given the
-   * corresponding index of the entity reference in `entityReferences`
+   * corresponding index of the entity reference in @p entityReferences
    * along with a populated @fqref{BatchElementError}
    * "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
    * "ErrorCodes"). The callback will be called on the same thread
@@ -894,14 +894,14 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * @param successCallback Callback that will be called for each
    * successful preflight of an entity reference. It will be given
    * the corresponding index of the entity reference in
-   * `targetEntityRefs` along with an updated reference to use for
+   * @p entityReferences along with an updated reference to use for
    * future interactions as part of the publishing operation. The
    * callback will be called on the same thread that initiated the
    * call to `preflight`.
    *
    * @param errorCallback Callback that will be called for each
    * failed preflight of an entity reference. It will be given the
-   * corresponding index of the entity reference in `entityReferences`
+   * corresponding index of the entity reference in @p entityReferences
    * along with a populated @fqref{BatchElementError}
    * "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
    * "ErrorCodes"). The callback will be called on the same thread
@@ -1140,14 +1140,14 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * @param successCallback Callback that will be called for each
    * successful registration of an entity reference. It will be given
    * the corresponding index of the entity reference in
-   * `targetEntityRefs` along with an updated reference to use for
+   * @p entityReferences along with an updated reference to use for
    * future interactions with the resulting new entity. The callback
    * will be called on the same thread that initiated the call to
    * `register`.
    *
    * @param errorCallback Callback that will be called for each
    * failed registration of an entity reference. It will be given the
-   * corresponding index of the entity reference in `entityReferences`
+   * corresponding index of the entity reference in @p entityReferences
    * along with a populated @fqref{BatchElementError}
    * "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
    * "ErrorCodes"). The callback will be called on the same thread
@@ -1155,10 +1155,10 @@ class OPENASSETIO_CORE_EXPORT Manager {
    *
    * @return None
    *
-   * @exception std::out_of_range If `entityReferences` and
-   * `entityTraitsDatas` are not lists of the same length.
+   * @exception std::out_of_range If @p entityReferences and
+   * @p entityTraitsDatas are not lists of the same length.
    *
-   * @exception std::invalid_argument If all `entityTraitsDatas` do
+   * @exception std::invalid_argument If all @p entityTraitsDatas do
    * not share the same trait set.
    *
    * Other exceptions may be raised for fatal runtime errors, for

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -673,14 +673,14 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * @param hostSession The API session.
    *
    * @param successCallback Callback that must be called for each
-   * successful resolution of an entity reference. It should be
-   * given the corresponding index of the entity reference in
-   * `entityRefs` along with its `TraitsData`. The callback must be
-   * called on the same thread that initiated the call to `resolve`.
+   * successful resolution of an entity reference. It should be given
+   * the corresponding index of the entity reference in
+   * `entityReferences` along with its `TraitsData`. The callback must
+   * be called on the same thread that initiated the call to `resolve`.
    *
    * @param errorCallback Callback that must be called for each
    * failed resolution of an entity reference. It should be given the
-   * corresponding index of the entity reference in `entityRefs`
+   * corresponding index of the entity reference in `entityReferences`
    * along with a populated @fqref{BatchElementError}
    * "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
    * "ErrorCodes"). The callback must be called on the same thread
@@ -816,7 +816,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * @param successCallback Callback to be called for each successful
    * preflight of an entity reference. It should be called with the
-   * corresponding index of the entity reference in `entityRefs`
+   * corresponding index of the entity reference in `entityReferences`
    * along with the (potentially revised) working reference to be
    * used by the host for the rest of the publishing operation for
    * this specific entity (ie, resolve then register). This is an
@@ -827,11 +827,12 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * @param errorCallback Callback to be called for each failed
    * preflight of an entity reference. It should be called with the
-   * corresponding index of the entity reference in `entityRefs` along
-   * with a populated @fqref{BatchElementError} "BatchElementError" (see
-   * @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The callback
-   * must be called on the same thread that initiated the call to
-   * `preflight`. A @fqref{BatchElementError.ErrorCode.kEntityAccessError}
+   * corresponding index of the entity reference in `entityReferences`
+   * along with a populated @fqref{BatchElementError}
+   * "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
+   * "ErrorCodes"). The callback must be called on the same thread that
+   * initiated the call to `preflight`. A
+   * @fqref{BatchElementError.ErrorCode.kEntityAccessError}
    * "kEntityAccessError" should be used for any target references that
    * are conceptually read-only.
    *

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -375,7 +375,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * @param hostSession The API session.
    *
-   * @return a `TraitsData` for each element in `traitSets`.
+   * @return a `TraitsData` for each element in @p traitSets.
    */
   [[nodiscard]] virtual trait::TraitsDatas managementPolicy(
       const trait::TraitSets& traitSets, const ContextConstPtr& context,
@@ -658,7 +658,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * it is up to the host to handle the exception. For errors specific
    * to a particular entity, where other entities may still resolve
    * successfully, an appropriate @fqref{BatchElementError}
-   * "BatchElementError" should be given to the `errorCallback`. Using
+   * "BatchElementError" should be given to the @p errorCallback. Using
    * HTTP status codes as an analogy, typically a server error (5xx)
    * would correspond to an exception whereas a client error (4xx) would
    * correspond to a `BatchElementError`.
@@ -675,12 +675,12 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * @param successCallback Callback that must be called for each
    * successful resolution of an entity reference. It should be given
    * the corresponding index of the entity reference in
-   * `entityReferences` along with its `TraitsData`. The callback must
+   * @p entityReferences along with its `TraitsData`. The callback must
    * be called on the same thread that initiated the call to `resolve`.
    *
    * @param errorCallback Callback that must be called for each
    * failed resolution of an entity reference. It should be given the
-   * corresponding index of the entity reference in `entityReferences`
+   * corresponding index of the entity reference in @p entityReferences
    * along with a populated @fqref{BatchElementError}
    * "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
    * "ErrorCodes"). The callback must be called on the same thread
@@ -816,7 +816,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * @param successCallback Callback to be called for each successful
    * preflight of an entity reference. It should be called with the
-   * corresponding index of the entity reference in `entityReferences`
+   * corresponding index of the entity reference in @p entityReferences
    * along with the (potentially revised) working reference to be
    * used by the host for the rest of the publishing operation for
    * this specific entity (ie, resolve then register). This is an
@@ -827,7 +827,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * @param errorCallback Callback to be called for each failed
    * preflight of an entity reference. It should be called with the
-   * corresponding index of the entity reference in `entityReferences`
+   * corresponding index of the entity reference in @p entityReferences
    * along with a populated @fqref{BatchElementError}
    * "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
    * "ErrorCodes"). The callback must be called on the same thread that
@@ -920,7 +920,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * @param successCallback Callback to be called for each successful
    * registration. It should be called with the corresponding index
-   * of the entity reference in `entityRefs` along with the
+   * of the entity reference in @p entityReferences along with the
    * (potentially revised) final reference to be used by the host for
    * subsequent interactions with this specific entity. This is an
    * opportunity to update the reference to one specific to the
@@ -930,8 +930,8 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * @param errorCallback Callback to be called for each failed
    * registration. It should be called with the corresponding index
-   * of the entity reference in `entityRefs` along with a populated
-   * @fqref{BatchElementError} "BatchElementError" (see
+   * of the entity reference in @p entityReferences along with a
+   * populated @fqref{BatchElementError} "BatchElementError" (see
    * @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The callback
    * must be called on the same thread that initiated the call to
    * `register`.

--- a/src/openassetio-python/package/openassetio/hostApi/Manager.py
+++ b/src/openassetio-python/package/openassetio/hostApi/Manager.py
@@ -403,10 +403,16 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
     @debugApiCall
     @auditApiCall("Manager methods")
     def getWithRelationship(
-        self, relationshipTraitsData, entityReferences, context, resultTraitSet=None
+        self,
+        relationshipTraitsData,
+        entityReferences,
+        context,
+        successCallback,
+        errorCallback,
+        resultTraitSet=None,
     ):
         """
-        Returns entity references that are related to the input
+        Query entity references that are related to the input
         references by the relationship defined by a set of traits and
         their properties.
 
@@ -430,6 +436,24 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
 
         @param context Context The calling context.
 
+        @param successCallback Callback that will be called for each
+        successful relationship query. It will be given the
+        corresponding index of the entity reference in
+        `entityReferences` along with a list of entity references for
+        entities that have the relationship specified by
+        `relationshipTraitsData`. If there are no relations, the
+        callback will receive an empty list. The callback will be called
+        on the same thread that initiated the call to
+        `getWithRelationship`.
+
+        @param errorCallback Callback that will be called for each
+        failed relationship query. It will be given the corresponding
+        index of the entity reference in `entityReferences` along with a
+        populated @fqref{BatchElementError} "BatchElementError" (see
+        @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The callback
+        will be called on the same thread that initiated the call to
+        `getWithRelationship`.
+
         @param resultTraitSet `Set[str]` or None, a hint as to what
         traits the returned entities should have.
 
@@ -447,13 +471,21 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
             entityReferences,
             context,
             self.__hostSession,
+            successCallback,
+            errorCallback,
             resultTraitSet=resultTraitSet,
         )
 
     @debugApiCall
     @auditApiCall("Manager methods")
     def getWithRelationships(
-        self, relationshipTraitsDatas, entityReference, context, resultTraitSet=None
+        self,
+        relationshipTraitsDatas,
+        entityReference,
+        context,
+        successCallback,
+        errorCallback,
+        resultTraitSet=None,
     ):
         """
         Returns entity references that are related to the input
@@ -480,6 +512,23 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
 
         @param context Context The calling context.
 
+        @param successCallback Callback that will be called for each
+        successful relationship query. It will be given the
+        corresponding index of the relationship in
+        `relationshipTraitsDatas` along with a list of entity references
+        for entities that have that relationship to the supplied
+        `entityReference`. If there are no relations, the callback will
+        receive an empty list. The callback will be called on the same
+        thread that initiated the call to `getWithRelationships`.
+
+        @param errorCallback Callback that will be called for each
+        failed relationship query. It will be given the corresponding
+        index of the relationship in `relationshipTraitsDatas` along
+        with a populated @fqref{BatchElementError} "BatchElementError"
+        (see @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The
+        callback will be called on the same thread that initiated the
+        call to `getWithRelationships`.
+
         @param resultTraitSet `Set[str]` or None, a hint as to what
         traits the returned entities should have.
 
@@ -497,6 +546,8 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
             entityReference,
             context,
             self.__hostSession,
+            successCallback,
+            errorCallback,
             resultTraitSet=resultTraitSet,
         )
 

--- a/src/openassetio-python/package/openassetio/hostApi/Manager.py
+++ b/src/openassetio-python/package/openassetio/hostApi/Manager.py
@@ -345,7 +345,7 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         reference, or `EntityResolutionError`. An
         `EntityResolutionError` will be returned if the entity
         reference is ambiguously versioned or if the supplied
-        `overrideVersionName` does not exist for that entity. For
+        @p overrideVersionName does not exist for that entity. For
         example, if the version is missing from a reference to a
         versioned entity, and that behavior is undefined in the
         manager's model, then an `EntityResolutionError` will be
@@ -439,16 +439,16 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         @param successCallback Callback that will be called for each
         successful relationship query. It will be given the
         corresponding index of the entity reference in
-        `entityReferences` along with a list of entity references for
+        @p entityReferences along with a list of entity references for
         entities that have the relationship specified by
-        `relationshipTraitsData`. If there are no relations, the
+        @p relationshipTraitsData. If there are no relations, the
         callback will receive an empty list. The callback will be called
         on the same thread that initiated the call to
         `getWithRelationship`.
 
         @param errorCallback Callback that will be called for each
         failed relationship query. It will be given the corresponding
-        index of the entity reference in `entityReferences` along with a
+        index of the entity reference in @p entityReferences along with a
         populated @fqref{BatchElementError} "BatchElementError" (see
         @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The callback
         will be called on the same thread that initiated the call to
@@ -515,15 +515,15 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         @param successCallback Callback that will be called for each
         successful relationship query. It will be given the
         corresponding index of the relationship in
-        `relationshipTraitsDatas` along with a list of entity references
+        @p relationshipTraitsDatas along with a list of entity references
         for entities that have that relationship to the supplied
-        `entityReference`. If there are no relations, the callback will
+        @p entityReference. If there are no relations, the callback will
         receive an empty list. The callback will be called on the same
         thread that initiated the call to `getWithRelationships`.
 
         @param errorCallback Callback that will be called for each
         failed relationship query. It will be given the corresponding
-        index of the relationship in `relationshipTraitsDatas` along
+        index of the relationship in @p relationshipTraitsDatas along
         with a populated @fqref{BatchElementError} "BatchElementError"
         (see @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The
         callback will be called on the same thread that initiated the

--- a/src/openassetio-python/package/openassetio/managerApi/ManagerInterface.py
+++ b/src/openassetio-python/package/openassetio/managerApi/ManagerInterface.py
@@ -480,12 +480,19 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
     # @{
 
     def getWithRelationship(
-        self, relationshipTraitsData, entityReferences, context, hostSession, resultTraitSet=None
+        self,
+        relationshipTraitsData,
+        entityReferences,
+        context,
+        hostSession,
+        successCallback,
+        errorCallback,
+        resultTraitSet=None,
     ):
         """
-        Return entity references that are related to the input
+        Queries entity references that are related to the input
         references by the relationship defined by a set of traits and
-        their properties.
+        their properties in `relationshipTraitsData`.
 
         This is an essential function in this API - as it is widely used
         to query other entities or organisational structure.
@@ -513,6 +520,25 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         logging and provides access to the openassetio.managerApi.Host
         object representing the process that initiated the API session.
 
+        @param successCallback Callback that must be called for each
+        successful relationship query for an input entity reference. It
+        should be given the corresponding index of the entity reference
+        in `entityReferences` along with a list of entity references for
+        entities that have the relationship specified by
+        `relationshipTraitsData`. If there are no relations, an empty
+        list should be passed to the callback. The callback must be
+        called on the same thread that initiated the call to
+        `getWithRelationship`.
+
+        @param errorCallback Callback that must be called for each
+        failed relationship query for an entity reference. It should be
+        given the corresponding index of the entity reference in
+        `entityReferences` along with a populated
+        @fqref{BatchElementError} "BatchElementError" (see
+        @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The callback
+        must be called on the same thread that initiated the call to
+        `getWithRelationship`.
+
         @param resultTraitSet `Set[str]` or None, a hint as to what
         traits the returned entities should have.
 
@@ -527,15 +553,24 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         host whether or not you are capable of handling queries for
         those relationships in this method.
         """
-        return [[] for _ in entityReferences]
+        for i in range(len(entityReferences)):
+            successCallback(i, [])
 
     def getWithRelationships(
-        self, relationshipTraitsDatas, entityReference, context, hostSession, resultTraitSet=None
+        self,
+        relationshipTraitsDatas,
+        entityReference,
+        context,
+        hostSession,
+        successCallback,
+        errorCallback,
+        resultTraitSet=None,
     ):
         """
-        Returns entity references that are related to the input
+        Queries entity references that are related to the input
         reference by the relationships defined by a set of traits and
-        their properties.
+        their properties. Each element of `relationshipTraitsDatas`
+        defines a specific relationship to query.
 
         This is an essential function in this API - as it is widely used
         to query other entities or organisational structure.
@@ -563,6 +598,25 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
 
         @param context Context The calling context.
 
+        @param successCallback Callback that must be called for each
+        successful relationship query for an input relationship. It
+        should be given the corresponding index of the relationship
+        definition in in `relationshipTraitsDatas` along with a list of
+        entity references for entities that are related to
+        `entityReference` by that relationship. If there are no
+        relations, an empty list should be passed to the callback. The
+        callback must be called on the same thread that initiated the
+        call to `getWithRelationships`.
+
+        @param errorCallback Callback that must be called for each
+        failed query for a relationship. It should be given the
+        corresponding index of the relationship in
+        `relationshipTraitsDatas` along with a populated
+        @fqref{BatchElementError} "BatchElementError" (see
+        @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The callback
+        must be called on the same thread that initiated the call to
+        `getWithRelationships`.
+
         @param resultTraitSet `Set[str]` or None, a hint as to what
         traits the returned entities should have.
 
@@ -577,6 +631,7 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         host whether or not you are capable of handling queries for
         those relationships in this method.
         """
-        return [[] for _ in relationshipTraitsDatas]
+        for i in range(len(relationshipTraitsDatas)):
+            successCallback(i, [])
 
     ## @}

--- a/src/openassetio-python/package/openassetio/managerApi/ManagerInterface.py
+++ b/src/openassetio-python/package/openassetio/managerApi/ManagerInterface.py
@@ -426,7 +426,7 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         reference, or `EntityResolutionError`. An
         `EntityResolutionError` should be returned if the entity
         reference is ambiguously versioned or if the supplied
-        `overrideVersionName` does not exist for that entity. For
+        @p overrideVersionName does not exist for that entity. For
         example, if the version is missing from a reference to a
         versioned entity, and that behavior is undefined in the
         manager's model, then an `EntityResolutionError` should be
@@ -492,7 +492,7 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         """
         Queries entity references that are related to the input
         references by the relationship defined by a set of traits and
-        their properties in `relationshipTraitsData`.
+        their properties in @p relationshipTraitsData.
 
         This is an essential function in this API - as it is widely used
         to query other entities or organisational structure.
@@ -523,9 +523,9 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         @param successCallback Callback that must be called for each
         successful relationship query for an input entity reference. It
         should be given the corresponding index of the entity reference
-        in `entityReferences` along with a list of entity references for
+        in @p entityReferences along with a list of entity references for
         entities that have the relationship specified by
-        `relationshipTraitsData`. If there are no relations, an empty
+        @p relationshipTraitsData. If there are no relations, an empty
         list should be passed to the callback. The callback must be
         called on the same thread that initiated the call to
         `getWithRelationship`.
@@ -533,7 +533,7 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         @param errorCallback Callback that must be called for each
         failed relationship query for an entity reference. It should be
         given the corresponding index of the entity reference in
-        `entityReferences` along with a populated
+        @p entityReferences along with a populated
         @fqref{BatchElementError} "BatchElementError" (see
         @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The callback
         must be called on the same thread that initiated the call to
@@ -569,7 +569,7 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         """
         Queries entity references that are related to the input
         reference by the relationships defined by a set of traits and
-        their properties. Each element of `relationshipTraitsDatas`
+        their properties. Each element of @p relationshipTraitsDatas
         defines a specific relationship to query.
 
         This is an essential function in this API - as it is widely used
@@ -601,9 +601,9 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         @param successCallback Callback that must be called for each
         successful relationship query for an input relationship. It
         should be given the corresponding index of the relationship
-        definition in in `relationshipTraitsDatas` along with a list of
+        definition in @p relationshipTraitsDatas along with a list of
         entity references for entities that are related to
-        `entityReference` by that relationship. If there are no
+        @p entityReference by that relationship. If there are no
         relations, an empty list should be passed to the callback. The
         callback must be called on the same thread that initiated the
         call to `getWithRelationships`.
@@ -611,7 +611,7 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         @param errorCallback Callback that must be called for each
         failed query for a relationship. It should be given the
         corresponding index of the relationship in
-        `relationshipTraitsDatas` along with a populated
+        @p relationshipTraitsDatas along with a populated
         @fqref{BatchElementError} "BatchElementError" (see
         @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The callback
         must be called on the same thread that initiated the call to

--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -84,6 +84,18 @@ disable = [
     "super-with-arguments",
     "consider-using-f-string"
 ]
+# Presently it's not possible to disable the `duplicate-code` check for
+# specific files, so it thinks that symlinks are duplicated
+# implementation. We also have issues where multi-line calls are
+# classed as duplicates.
+#
+# See:
+#     https://github.com/PyCQA/pylint/issues/214
+#
+# As we're not going to have a lot of python
+# implementation anyway, use this trick to disable the similarity
+# checker globally.
+min-similarity-lines=10000
 
 # NB: This requires the use of pyproject-flake8
 [tool.flake8]

--- a/src/openassetio-python/tests/conftest.py
+++ b/src/openassetio-python/tests/conftest.py
@@ -240,7 +240,14 @@ class ValidatingMockManagerInterface(ManagerInterface):
         )
 
     def getWithRelationship(
-        self, relationshipTraitsData, entityReferences, context, hostSession, resultTraitSet=None
+        self,
+        relationshipTraitsData,
+        entityReferences,
+        context,
+        hostSession,
+        successCallback,
+        errorCallback,
+        resultTraitSet=None,
     ):
         assert isinstance(relationshipTraitsData, TraitsData)
         self.__assertIsIterableOf(entityReferences, EntityReference)
@@ -248,21 +255,44 @@ class ValidatingMockManagerInterface(ManagerInterface):
         if resultTraitSet is not None:
             assert isinstance(resultTraitSet, set)
             self.__assertIsIterableOf(resultTraitSet, str)
+        assert callable(successCallback)
+        assert callable(errorCallback)
         return self.mock.getWithRelationship(
-            relationshipTraitsData, entityReferences, context, hostSession, resultTraitSet
+            relationshipTraitsData,
+            entityReferences,
+            context,
+            hostSession,
+            successCallback,
+            errorCallback,
+            resultTraitSet,
         )
 
     def getWithRelationships(
-        self, relationshipTraitsDatas, entityReference, context, hostSession, resultTraitSet=None
+        self,
+        relationshipTraitsDatas,
+        entityReference,
+        context,
+        hostSession,
+        successCallback,
+        errorCallback,
+        resultTraitSet=None,
     ):
         self.__assertIsIterableOf(relationshipTraitsDatas, TraitsData)
         assert isinstance(entityReference, EntityReference)
         self.__assertCallingContext(context, hostSession)
+        assert callable(successCallback)
+        assert callable(errorCallback)
         if resultTraitSet is not None:
             assert isinstance(resultTraitSet, set)
             self.__assertIsIterableOf(resultTraitSet, str)
         return self.mock.getWithRelationships(
-            relationshipTraitsDatas, entityReference, context, hostSession, resultTraitSet
+            relationshipTraitsDatas,
+            entityReference,
+            context,
+            hostSession,
+            successCallback,
+            errorCallback,
+            resultTraitSet,
         )
 
     def register(

--- a/src/openassetio-python/tests/package/managerApi/test_managerinterface.py
+++ b/src/openassetio-python/tests/package/managerApi/test_managerinterface.py
@@ -21,7 +21,7 @@ Tests for the default implementations of ManagerInterface methods.
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import pytest
 
@@ -195,12 +195,22 @@ class Test_ManagerInterface_getWithRelationship:
         assert method_introspector.is_implemented_once(ManagerInterface, "getWithRelationship")
 
     def test_returns_empty_list_for_each_input(self, manager_interface):
-        for refs, expected in (
-            ([], []),
-            ([Mock()], [[]]),
-            ([Mock(), Mock()], [[], []]),
+        success_callback = Mock()
+        error_callback = Mock()
+
+        for refs in (
+            [],
+            [Mock()],
+            [Mock(), Mock()],
         ):
-            assert manager_interface.getWithRelationship(Mock(), refs, Mock(), Mock()) == expected
+            manager_interface.getWithRelationship(
+                Mock(), refs, Mock(), Mock(), success_callback, error_callback
+            )
+
+            error_callback.assert_not_called()
+            success_callback.assert_has_calls([call(i, []) for i in range(len(refs))])
+
+            success_callback.reset_mock()
 
 
 class Test_ManagerInterface_getWithRelationships:
@@ -209,11 +219,22 @@ class Test_ManagerInterface_getWithRelationships:
         assert method_introspector.is_implemented_once(ManagerInterface, "getWithRelationships")
 
     def test_returns_empty_list_for_each_input(self, manager_interface):
-        for relationships, expected in (([], []), ([Mock()], [[]]), ([Mock(), Mock()], [[], []])):
-            assert (
-                manager_interface.getWithRelationships(relationships, Mock(), Mock(), Mock())
-                == expected
+        success_callback = Mock()
+        error_callback = Mock()
+
+        for rels in (
+            [],
+            [Mock()],
+            [Mock(), Mock()],
+        ):
+            manager_interface.getWithRelationships(
+                rels, Mock(), Mock(), Mock(), success_callback, error_callback
             )
+
+            error_callback.assert_not_called()
+            success_callback.assert_has_calls([call(i, []) for i in range(len(rels))])
+
+            success_callback.reset_mock()
 
 
 class Test_ManagerInterface__createEntityReference:


### PR DESCRIPTION
Still Python only, but should now be the final signature.

Fixes a few typos, and has to disable the `pylint` similarity checker due to  false positives.

Closes #919 
