### PR TITLE
[Core] Add optional `configPath` argument to `defaultManagerForInterface`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+v1.0.0-alpha.xx
+---------------
+
+### New Features
+
+- Added an overload of `ManagerFactory.defaultManagerForInterface` that
+  takes a config file path string argument, rather than using an
+  environment variable.
+  [#937](https://github.com/OpenAssetIO/OpenAssetIO/issues/937)
+
 v1.0.0-alpha.11
 ---------------
 

--- a/src/openassetio-core/include/openassetio/hostApi/ManagerFactory.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/ManagerFactory.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <memory>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -183,24 +184,16 @@ class OPENASSETIO_CORE_EXPORT ManagerFactory final {
    * the TOML configuration file referenced by the
    * @ref default_config_var.
    *
-   * This allows deployments to centralize OpenAssetIO manager settings,
-   * and for hosts to instantiate this manager without the need for their
-   * own settings and persistence mechanism.
-   *
    * @note This mechanism should be the default approach for a host to
-   * initialize the API. Extended functionality to override this configuration
-   * can optionally be provided, but the ability to use the shared, default
-   * configuration is always required.
+   * initialize the API. Extended functionality to override this
+   * configuration can optionally be provided, but the ability to use
+   * the shared, default configuration is always required.
    *
-   * The referenced TOML file should have the following structure.
-   *
-   * @code{.toml}
-   * [manager]
-   * identifier = "some.identifier"
-   *
-   * [manager.settings]  # Optional
-   * some_setting = "value"
-   * @endcode
+   * @see @ref defaultManagerForInterface(std::string_view, <!--
+   * -->const HostInterfacePtr&,<!--
+   * -->const ManagerImplementationFactoryInterfacePtr&,<!--
+   * -->const log::LoggerInterfacePtr&) "Alternative direct signature"
+   * for more details.
    *
    * @envvar **OPENASSETIO_DEFAULT_CONFIG** *str* The path to a
    * TOML file containing configuration information for the default
@@ -216,6 +209,51 @@ class OPENASSETIO_CORE_EXPORT ManagerFactory final {
    */
   [[nodiscard]] static ManagerPtr defaultManagerForInterface(
       const HostInterfacePtr& hostInterface,
+      const ManagerImplementationFactoryInterfacePtr& managerImplementationFactory,
+      const log::LoggerInterfacePtr& logger);
+
+  /**
+   * Creates the default @fqref{hostApi.Manager} "Manager" as defined by
+   * the given TOML configuration file.
+   *
+   * This allows deployments to centralize OpenAssetIO manager settings,
+   * and for hosts to instantiate this manager without the need for
+   * their own settings and persistence mechanism.
+   *
+   * The referenced TOML file should have the following structure.
+   *
+   * @code{.toml}
+   * [manager]
+   * identifier = "some.identifier"
+   *
+   * [manager.settings]  # Optional
+   * some_setting = "value"
+   * @endcode
+   *
+   * @param configPath Path to the TOML config file, compatible with
+   * <a href="https://en.cppreference.com/w/cpp/io/basic_ifstream/open">
+   * `std::ifstream::open`</a>. Relative paths resolve to a
+   * platform/environment-dependent location.
+   *
+   * @param hostInterface The @ref host "host's" implementation of the
+   * `HostInterface` that uniquely identifies the host and provides
+   * common hooks for the @ref manager to query asset-related properties
+   * from the host.
+   *
+   * @param managerImplementationFactory The factory that will be used
+   * to instantiate managers.
+   *
+   * @param logger The logger instance that will be used for all
+   * messaging from the instantiated @fqref{hostApi.Manager} "Manager"
+   * instances.
+   *
+   * @return A default-configured manager.
+   *
+   * @throws std::runtime_error if there are errors occur whilst
+   * loading the TOML file
+   */
+  [[nodiscard]] static ManagerPtr defaultManagerForInterface(
+      std::string_view configPath, const HostInterfacePtr& hostInterface,
       const ManagerImplementationFactoryInterfacePtr& managerImplementationFactory,
       const log::LoggerInterfacePtr& logger);
 

--- a/src/openassetio-core/src/hostApi/ManagerFactory.cpp
+++ b/src/openassetio-core/src/hostApi/ManagerFactory.cpp
@@ -90,11 +90,25 @@ ManagerPtr ManagerFactory::defaultManagerForInterface(
     logger->log(log::LoggerInterface::Severity::kDebug, msg);
     return nullptr;
   }
-
   {
-    Str msg = "Loading default manager config from '";
+    Str msg = "Retrieved default manager config file path from '";
+    msg += kDefaultManagerConfigEnvVarName;
+    msg += "'";
+    logger->log(log::LoggerInterface::Severity::kDebug, msg);
+  }
+
+  return defaultManagerForInterface(configPath, hostInterface, managerImplementationFactory,
+                                    logger);
+}
+
+ManagerPtr ManagerFactory::defaultManagerForInterface(
+    const std::string_view configPath, const HostInterfacePtr& hostInterface,
+    const ManagerImplementationFactoryInterfacePtr& managerImplementationFactory,
+    const log::LoggerInterfacePtr& logger) {
+  {
+    Str msg = "Loading default manager config at '";
     msg += configPath;
-    msg += "' [" + kDefaultManagerConfigEnvVarName + "]";
+    msg += "'";
     logger->log(log::LoggerInterface::Severity::kDebug, msg);
   }
 

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerFactoryBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerFactoryBinding.cpp
@@ -12,8 +12,12 @@
 #include "../_openassetio.hpp"
 
 void registerManagerFactory(const py::module& mod) {
+  using openassetio::hostApi::HostInterfacePtr;
   using openassetio::hostApi::ManagerFactory;
   using openassetio::hostApi::ManagerFactoryPtr;
+  using openassetio::hostApi::ManagerImplementationFactoryInterfacePtr;
+  using openassetio::hostApi::ManagerPtr;
+  using openassetio::log::LoggerInterfacePtr;
 
   // TODO(DF): `py::final()` once ManagerFactory is fully C++.
   py::class_<ManagerFactory, ManagerFactoryPtr> managerFactory(mod, "ManagerFactory");
@@ -41,7 +45,17 @@ void registerManagerFactory(const py::module& mod) {
                   py::arg("managerImplementationFactory").none(false),
                   py::arg("logger").none(false))
       .def_static("defaultManagerForInterface",
-                  RetainCommonPyArgs::forFn<&ManagerFactory::defaultManagerForInterface>(),
+                  RetainCommonPyArgs::forFn<static_cast<ManagerPtr (*)(
+                      std::string_view, const HostInterfacePtr&,
+                      const ManagerImplementationFactoryInterfacePtr&, const LoggerInterfacePtr&)>(
+                      &ManagerFactory::defaultManagerForInterface)>(),
+                  py::arg("configPath"), py::arg("hostInterface").none(false),
+                  py::arg("managerImplementationFactory").none(false),
+                  py::arg("logger").none(false))
+      .def_static("defaultManagerForInterface",
+                  RetainCommonPyArgs::forFn<static_cast<ManagerPtr (*)(
+                      const HostInterfacePtr&, const ManagerImplementationFactoryInterfacePtr&,
+                      const LoggerInterfacePtr&)>(&ManagerFactory::defaultManagerForInterface)>(),
                   py::arg("hostInterface").none(false),
                   py::arg("managerImplementationFactory").none(false),
                   py::arg("logger").none(false));

--- a/src/openassetio-python/package/openassetio/hostApi/ManagerFactory.py
+++ b/src/openassetio-python/package/openassetio/hostApi/ManagerFactory.py
@@ -61,14 +61,12 @@ class ManagerFactory(_openassetio.hostApi.ManagerFactory):
         return Manager(cppManager._interface(), cppManager._hostSession())
 
     @staticmethod
-    def defaultManagerForInterface(hostInterface, managerImplementationFactory, logger):
+    def defaultManagerForInterface(*args):
         """
         @see @fqref{hostApi.ManagerFactory.defaultManagerForInterface}
         "ManagerFactory.defaultManagerForInterface".
         """
-        cppManager = _openassetio.hostApi.ManagerFactory.defaultManagerForInterface(
-            hostInterface, managerImplementationFactory, logger
-        )
+        cppManager = _openassetio.hostApi.ManagerFactory.defaultManagerForInterface(*args)
         if cppManager:
             # pylint: disable=protected-access
             return Manager(cppManager._interface(), cppManager._hostSession())


### PR DESCRIPTION
## Description

Closes #937.

Add a new overload of `defaultManagerForInterface` that uses a `configPath` argument, rather than an environment variable, to determine the location of the TOML config file.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.
