### PR TITLE
[Core] Add $config_dir config TOML interpolation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,12 @@ v1.0.0-alpha.xx
   environment variable.
   [#937](https://github.com/OpenAssetIO/OpenAssetIO/issues/937)
 
+- Added support for `${config_dir}` interpolation within manager string
+  settings retrieved from the TOML config file used by
+  `defaultManagerForInterface`. This token expands to the absolute
+  directory of the TOML config file.
+  [#804](https://github.com/OpenAssetIO/OpenAssetIO/issues/804)
+
 v1.0.0-alpha.11
 ---------------
 

--- a/src/openassetio-core/include/openassetio/hostApi/ManagerFactory.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/ManagerFactory.hpp
@@ -195,6 +195,10 @@ class OPENASSETIO_CORE_EXPORT ManagerFactory final {
    * -->const log::LoggerInterfacePtr&) "Alternative direct signature"
    * for more details.
    *
+   * Any occurrences of `${config_dir}` within TOML string values will
+   * be substituted with the absolute path to the directory containing
+   * the TOML file, before being passed on to the manager settings.
+   *
    * @envvar **OPENASSETIO_DEFAULT_CONFIG** *str* The path to a
    * TOML file containing configuration information for the default
    * manager.

--- a/src/openassetio-python/tests/package/hostApi/resources/default_manager.toml
+++ b/src/openassetio-python/tests/package/hostApi/resources/default_manager.toml
@@ -6,3 +6,4 @@ a_string = "Hello 🐈"
 a_float = 3.141579
 a_bool = false
 a_int = 42
+a_config_path_twice = "${config_dir}/my/🐈/${config_dir}"


### PR DESCRIPTION
## Description

Closes #804.

It is common in test scenarios to create portable, self-contained manager states using BAL.

At the moment, this requires relative paths in the TOML file, and so becomes working directory sensitive. This makes it fragile.

So add support for the substitution in TOML string values of `$config_dir` or `${config_dir}` tokens with the absolute directory to the TOML config file.

This is currently done in the most basic way possible, by direct string find-and-replace, rather than a more complete solution supporting e.g. environment variable interpolation. Such improvement is for future work if/when the need ever arises.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.
