### PR TITLE
Refactor `getRelatedReferences`

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -39,12 +39,6 @@ jobs:
           pylint-paths: >
             src/openassetio-python/package/openassetio
             src/openassetio-python/tests/package
-          # Presently it's not possible to disable the `duplicate-code`
-          # check for specific files, so it thinks that the symlink is
-          # duplicated implementation. See:
-          #     https://github.com/PyCQA/pylint/issues/214
-          pylint-ignore-paths: >
-            src/openassetio-python/tests/package/pluginSystem/resources/symlinkPath
 
   black:
     runs-on: ubuntu-latest

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -67,10 +67,12 @@ jobs:
           repository: OpenAssetIO/OpenAssetIO-Manager-BAL
           path: external/BAL
 
-      - name: Test BAL
-        run: |
-          python -m pip install ./external/BAL
-          python -m pytest -v external/BAL/tests
+      # Disabled pending https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/34
+      #
+      # - name: Test BAL
+      #   run: |
+      #     python -m pip install ./external/BAL
+      #     python -m pytest -v external/BAL/tests
 
       - name: Test Simple Resolver
         run: |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,26 @@
 Release Notes
 =============
 
+v1.0.0-alpha.xx
+---------------
+
+### Breaking changes
+
+- Refactored `getRelatedReferences` into `getWithRelationship` and
+  `getWithRelationships` to better define the two possible batch-axis,
+  and simplify implementation on both sides of the API. This also
+  changes the methods over to callback signatures for consistency with
+  the rest of the API.
+  [#847](https://github.com/OpenAssetIO/OpenAssetIO/issues/847)
+  [#919](https://github.com/OpenAssetIO/OpenAssetIO/issues/919)
+
+### Improvements
+
+- Added default implementations of `getWithRelationship` and
+  `getWithRelationships` that return empty lists, making these methods
+  opt-in for manager implementations.
+  [#163](https://github.com/OpenAssetIO/OpenAssetIO/issues/163)
+
 v1.0.0-alpha.12
 ---------------
 

--- a/doc/doxygen/src/EntitiesTraitsSpecifications.dox
+++ b/doc/doxygen/src/EntitiesTraitsSpecifications.dox
@@ -277,8 +277,8 @@
  * @subsection Using Trait Sets as a Filter Predicate
  *
  * When a @ref trait_set is used as a predicate to search for entities.
- * Such as in @ref openassetio.hostApi.Manager.Manager.getRelatedReferences
- * "getRelatedReferences", or when browsing for assets, traits are
+ * Such as in @ref openassetio.hostApi.Manager.Manager.getWithRelationship
+ * "getWithRelationship", or when browsing for assets, traits are
  * considered additive, and they must all be satisfied.
  *
  * As an example, consider a world-building tool wishing to browse for

--- a/doc/doxygen/src/ForManagers.dox
+++ b/doc/doxygen/src/ForManagers.dox
@@ -195,13 +195,15 @@
  *
  * In order to support entity relationships:
  *
- * - Implement
- *   @ref openassetio.managerApi.ManagerInterface.ManagerInterface.getRelatedReferences
- *   "getRelatedReferences" to return any appropriate @ref entity_reference
- *   "entity references" for the supplied @ref Specification. Hosts may
- *   use these relationships to simplify common pipeline integration
- *   tasks. For example, loading multiple AOVs for a render, or
- *   determining data dependencies when transferring assets.
+ * - Implement the API methods grouped under
+ *   @ref openassetio.managerApi.ManagerInterface.ManagerInterface
+ *   "Related Entities" to return any appropriate @ref entity_reference
+ *   "entity references" for the supplied relationship(s).
+ *   Hosts may use these relationships to simplify common pipeline
+ *   integration tasks. For example, loading multiple AOVs for a render,
+ *   or determining data dependencies when transferring assets.
+ * - Update your implementation of @fqref{managerApi.ManagerInterface.managementPolicy}
+ *   "managementPolicy" to cover the relationship trait sets you support.
  *
  * @subsection manager_todo_ui Embedding Custom UI Within the Host
  *

--- a/doc/doxygen/src/Glossary.dox
+++ b/doc/doxygen/src/Glossary.dox
@@ -154,8 +154,8 @@
  *
  * In such a system, the ManagerInterface may provide access to
  * alternate paths from any one of these path-specific references via
- * the @ref openassetio.managerApi.ManagerInterface.ManagerInterface.getRelatedReferences
- * "getRelatedReferences" method, with a suitable @ref Specification
+ * the @ref openassetio.managerApi.ManagerInterface.ManagerInterface.getWithRelationship
+ * "getWithRelationship" method, with a suitable relationship @ref trait_set.
  *
  * 3. 'Potential' entity representation
  * ------------------------------------

--- a/doc/doxygen/src/Thumbnails.dox
+++ b/doc/doxygen/src/Thumbnails.dox
@@ -47,8 +47,8 @@
  *
  * @section thumbnails_lookup Looking Up Existing Thumbnails
  *
- * A host can use the standard @ref openassetio.hostApi.Manager.Manager.getRelatedReferences
- * "getRelatedReferences" method of the @ref manager to request the
+ * A host can use the standard @ref openassetio.hostApi.Manager.Manager.getWithRelationship
+ * "getWithRelationship" method of the @ref manager to request the
  * @ref entity_reference "entity references" of any existing thumbnails
  * that depict a particular @ref entity.
  *

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -249,7 +249,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    *
    * @param context The calling context.
    *
-   * @return a `TraitsData` for each element in `traitSets`.
+   * @return a `TraitsData` for each element in @p traitSets.
    */
   [[nodiscard]] trait::TraitsDatas managementPolicy(const trait::TraitSets& traitSets,
                                                     const ContextConstPtr& context) const;
@@ -545,10 +545,11 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * documentation for each respective trait to determine which
    * properties are considered required. It is the responsibility of the
    * caller to handle optional property values being missing in a
-   * fashion appropriate to its intended use. The @ref managementPolicy
-   * query can be used ahead of time with a read @ref Context to
-   * determine which specific traits any given manager supports
-   * resolving property data for.
+   * fashion appropriate to its intended use. The
+   * @fqref{hostApi.Manager.managementPolicy} "managementPolicy" query
+   * can be used ahead of time with a read @ref Context to determine
+   * which specific traits any given manager supports resolving property
+   * data for.
    *
    * @note @fqref{EntityReference} "EntityReference" objects _must_ be
    * constructed using either
@@ -591,12 +592,12 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * @param successCallback Callback that will be called for each
    * successful resolution of an entity reference. It will be
    * given the corresponding index of the entity reference in
-   * `entityRefs` along with its `TraitsData`. The callback will be
-   * called on the same thread that initiated the call to `resolve`.
+   * @p entityReferences along with its `TraitsData`. The callback will
+   * be called on the same thread that initiated the call to `resolve`.
    *
    * @param errorCallback Callback that will be called for each
    * failed resolution of an entity reference. It will be given the
-   * corresponding index of the entity reference in `entityRefs`
+   * corresponding index of the entity reference in @p entityReferences
    * along with a populated @fqref{BatchElementError}
    * "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
    * "ErrorCodes"). The callback will be called on the same thread
@@ -893,14 +894,14 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * @param successCallback Callback that will be called for each
    * successful preflight of an entity reference. It will be given
    * the corresponding index of the entity reference in
-   * `targetEntityRefs` along with an updated reference to use for
+   * @p entityReferences along with an updated reference to use for
    * future interactions as part of the publishing operation. The
    * callback will be called on the same thread that initiated the
    * call to `preflight`.
    *
    * @param errorCallback Callback that will be called for each
    * failed preflight of an entity reference. It will be given the
-   * corresponding index of the entity reference in `entityRefs`
+   * corresponding index of the entity reference in @p entityReferences
    * along with a populated @fqref{BatchElementError}
    * "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
    * "ErrorCodes"). The callback will be called on the same thread
@@ -1139,14 +1140,14 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * @param successCallback Callback that will be called for each
    * successful registration of an entity reference. It will be given
    * the corresponding index of the entity reference in
-   * `targetEntityRefs` along with an updated reference to use for
+   * @p entityReferences along with an updated reference to use for
    * future interactions with the resulting new entity. The callback
    * will be called on the same thread that initiated the call to
    * `register`.
    *
    * @param errorCallback Callback that will be called for each
    * failed registration of an entity reference. It will be given the
-   * corresponding index of the entity reference in `entityRefs`
+   * corresponding index of the entity reference in @p entityReferences
    * along with a populated @fqref{BatchElementError}
    * "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
    * "ErrorCodes"). The callback will be called on the same thread
@@ -1154,10 +1155,10 @@ class OPENASSETIO_CORE_EXPORT Manager {
    *
    * @return None
    *
-   * @exception std::out_of_range If `entityReferences` and
-   * `entityTraitsDatas` are not lists of the same length.
+   * @exception std::out_of_range If @p entityReferences and
+   * @p entityTraitsDatas are not lists of the same length.
    *
-   * @exception std::invalid_argument If all `entityTraitsDatas` do
+   * @exception std::invalid_argument If all @p entityTraitsDatas do
    * not share the same trait set.
    *
    * Other exceptions may be raised for fatal runtime errors, for

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -375,7 +375,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * @param hostSession The API session.
    *
-   * @return a `TraitsData` for each element in `traitSets`.
+   * @return a `TraitsData` for each element in @p traitSets.
    */
   [[nodiscard]] virtual trait::TraitsDatas managementPolicy(
       const trait::TraitSets& traitSets, const ContextConstPtr& context,
@@ -658,7 +658,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * it is up to the host to handle the exception. For errors specific
    * to a particular entity, where other entities may still resolve
    * successfully, an appropriate @fqref{BatchElementError}
-   * "BatchElementError" should be given to the `errorCallback`. Using
+   * "BatchElementError" should be given to the @p errorCallback. Using
    * HTTP status codes as an analogy, typically a server error (5xx)
    * would correspond to an exception whereas a client error (4xx) would
    * correspond to a `BatchElementError`.
@@ -673,14 +673,14 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * @param hostSession The API session.
    *
    * @param successCallback Callback that must be called for each
-   * successful resolution of an entity reference. It should be
-   * given the corresponding index of the entity reference in
-   * `entityRefs` along with its `TraitsData`. The callback must be
-   * called on the same thread that initiated the call to `resolve`.
+   * successful resolution of an entity reference. It should be given
+   * the corresponding index of the entity reference in
+   * @p entityReferences along with its `TraitsData`. The callback must
+   * be called on the same thread that initiated the call to `resolve`.
    *
    * @param errorCallback Callback that must be called for each
    * failed resolution of an entity reference. It should be given the
-   * corresponding index of the entity reference in `entityRefs`
+   * corresponding index of the entity reference in @p entityReferences
    * along with a populated @fqref{BatchElementError}
    * "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
    * "ErrorCodes"). The callback must be called on the same thread
@@ -816,7 +816,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * @param successCallback Callback to be called for each successful
    * preflight of an entity reference. It should be called with the
-   * corresponding index of the entity reference in `entityRefs`
+   * corresponding index of the entity reference in @p entityReferences
    * along with the (potentially revised) working reference to be
    * used by the host for the rest of the publishing operation for
    * this specific entity (ie, resolve then register). This is an
@@ -827,11 +827,12 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * @param errorCallback Callback to be called for each failed
    * preflight of an entity reference. It should be called with the
-   * corresponding index of the entity reference in `entityRefs` along
-   * with a populated @fqref{BatchElementError} "BatchElementError" (see
-   * @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The callback
-   * must be called on the same thread that initiated the call to
-   * `preflight`. A @fqref{BatchElementError.ErrorCode.kEntityAccessError}
+   * corresponding index of the entity reference in @p entityReferences
+   * along with a populated @fqref{BatchElementError}
+   * "BatchElementError" (see @fqref{BatchElementError.ErrorCode}
+   * "ErrorCodes"). The callback must be called on the same thread that
+   * initiated the call to `preflight`. A
+   * @fqref{BatchElementError.ErrorCode.kEntityAccessError}
    * "kEntityAccessError" should be used for any target references that
    * are conceptually read-only.
    *
@@ -919,7 +920,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * @param successCallback Callback to be called for each successful
    * registration. It should be called with the corresponding index
-   * of the entity reference in `entityRefs` along with the
+   * of the entity reference in @p entityReferences along with the
    * (potentially revised) final reference to be used by the host for
    * subsequent interactions with this specific entity. This is an
    * opportunity to update the reference to one specific to the
@@ -929,8 +930,8 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * @param errorCallback Callback to be called for each failed
    * registration. It should be called with the corresponding index
-   * of the entity reference in `entityRefs` along with a populated
-   * @fqref{BatchElementError} "BatchElementError" (see
+   * of the entity reference in @p entityReferences along with a
+   * populated @fqref{BatchElementError} "BatchElementError" (see
    * @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The callback
    * must be called on the same thread that initiated the call to
    * `register`.

--- a/src/openassetio-python/package/openassetio/hostApi/Manager.py
+++ b/src/openassetio-python/package/openassetio/hostApi/Manager.py
@@ -345,7 +345,7 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
         reference, or `EntityResolutionError`. An
         `EntityResolutionError` will be returned if the entity
         reference is ambiguously versioned or if the supplied
-        `overrideVersionName` does not exist for that entity. For
+        @p overrideVersionName does not exist for that entity. For
         example, if the version is missing from a reference to a
         versioned entity, and that behavior is undefined in the
         manager's model, then an `EntityResolutionError` will be
@@ -389,122 +389,166 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
     # 'shot' exists in a certain part of the asset system. One approach would be
     # to use a 'getChildren' call, on this part of the system. This has the
     # drawback that is assumes that shots are always something that can be
-    # described as 'immediate children' of the location in question. This lay not
+    # described as 'immediate children' of the location in question. This may not
     # always be the case (say, for example there is some kind of 'task' structure
     # in place too). Instead we use a request that asks for any 'shots' that
     # relate to the chosen location. It is then up to the implementation of the
     # manager to determine how that maps to its own data model. Hopefully this
     # allows a host to work with a broader range of asset management systems,
     # without providing any requirements of their structure or data model within
-    # the  system itself.
+    # the system itself.
     #
     # @{
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def getRelatedReferences(
-        self, references, relationshipTraitsDataOrDatas, context, resultTraitSet=None
+    def getWithRelationship(
+        self,
+        relationshipTraitsData,
+        entityReferences,
+        context,
+        successCallback,
+        errorCallback,
+        resultTraitSet=None,
     ):
         """
-        Returns related entity references, based on a relationship
-        defined by a set of traits and their properties.
+        Query entity references that are related to the input
+        references by the relationship defined by a set of traits and
+        their properties.
 
         This is an essential function in this API - as it is widely used
-        to query organisational hierarchy, etc...
+        to query other entities or organisational structure.
 
-        There are three possible conventions for calling this function,
-        to allow for batch optimisations in the implementation and
-        prevent excessive query times with high-latency services.
-
-          a)  A single entity reference, a list of relationships.
-          b)  A list of entity references and a single relationship.
-          c)  Equal length lists of references and relationships.
-
-        In all cases, the return value is a list of lists, for example:
-
-            a)  getRelatedReferences([ r1 ], [ td1, td2, td3 ])
-
-            > [ [ r1td1... ], [ r1td2... ], [ r1td3... ] ]
-
-            b)  getRelatedReferences([ r1, r2, r3 ], [ td1 ])
-
-            > [ [ r1td1... ], [ r2td1... ], [ r3td1... ] ]
-
-            c)  getRelatedReferences([ r1, r2, r3 ], [ td1, td2, td3 ])
-
-            > [ [ r1td1... ], [ r2td2... ], [ r3td3... ] ]
-
-        @note The order of entities in the inner lists of matching
-        references should not be considered meaningful, but the outer
-        list should match the input order.
-
-        In summary, if only a single entityRef is provided, it should be
-        assumed that all relationships should be considered for that one
-        entity. If only a single relationship is provided, then it
-        should be considered for all supplied entity references. If
-        lists of both are supplied, then they must be the same length,
-        and it should be assumed that it is a 1:1 mapping of a
-        relationship definition to an entity. If this is not the case,
-        ValueErrors will be thrown.
+        @note Consult the documentation for the relevant relationship
+        traits to determine if the order of entities in the inner lists
+        of matching references is considered meaningful.
 
         If any relationship definition is unknown, then an empty list
-        will be returned for that relationship, and no errors should be
+        will be returned for that entity, and no errors will be
         raised.
 
-        @param references List[str] A list of @ref entity_reference, see
-        the notes on array length above.
+        @param relationshipTraitsData @fqref{TraitsData} "TraitsData"
+        The traits of the relationship to query.
 
-        @param relationshipTraitsDataOrDatas `List[`
-        @fqref{TraitsData} "TraitsData" `]`
+        @param entityReferences `List[` @fqref{EntityReference} "EntityReference" `]`
+        A list of @ref entity_reference to query the specified
+        relationship for.
+
+        @param context Context The calling context.
+
+        @param successCallback Callback that will be called for each
+        successful relationship query. It will be given the
+        corresponding index of the entity reference in
+        @p entityReferences along with a list of entity references for
+        entities that have the relationship specified by
+        @p relationshipTraitsData. If there are no relations, the
+        callback will receive an empty list. The callback will be called
+        on the same thread that initiated the call to
+        `getWithRelationship`.
+
+        @param errorCallback Callback that will be called for each
+        failed relationship query. It will be given the corresponding
+        index of the entity reference in @p entityReferences along with a
+        populated @fqref{BatchElementError} "BatchElementError" (see
+        @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The callback
+        will be called on the same thread that initiated the call to
+        `getWithRelationship`.
 
         @param resultTraitSet `Set[str]` or None, a hint as to what
         traits the returned entities should have.
 
-        @param context Context The calling context.
+        @return `List[List[`@fqref{EntityReference} "EntityReference"`]]`
+        A list of references to related entities, for each input
+        reference.
 
-        @return list of str lists The return is *always* a list of lists
-        regardless of which form of invocation is used. The outer list
-        is for each supplied entity or relationship. The inner lists
-        are all the matching entities for that source entity.
-
-        @exception ValueError If more than one reference and
-        relationship is provided, but they lists are not equal in
-        length, ie: not a 1:1 mapping of entities to relationships.
-
-        @unstable
+        @note The @ref trait_set of the queried relationship can be
+        passed to @fqref{hostApi.Manager.managementPolicy}
+        "managementPolicy" in order to determine if the manager handles
+        relationships of that type.
         """
-        if not isinstance(references, (list, tuple)):
-            references = [
-                references,
-            ]
-
-        if not isinstance(relationshipTraitsDataOrDatas, (list, tuple)):
-            relationshipTraitsDataOrDatas = [
-                relationshipTraitsDataOrDatas,
-            ]
-
-        numEntities = len(references)
-        numRelationships = len(relationshipTraitsDataOrDatas)
-
-        if (numEntities > 1 and numRelationships > 1) and numRelationships != numEntities:
-            raise ValueError(
-                (
-                    "You must supply either a single entity and a "
-                    + "list of relationships, a single relationship "
-                    + "and a list of entities, or an equal number of "
-                    + "both... %s entities .vs. %s relationships"
-                )
-                % (numEntities, numRelationships)
-            )
-
-        result = self.__impl.getRelatedReferences(
-            references,
-            relationshipTraitsDataOrDatas,
+        return self.__impl.getWithRelationship(
+            relationshipTraitsData,
+            entityReferences,
             context,
             self.__hostSession,
+            successCallback,
+            errorCallback,
             resultTraitSet=resultTraitSet,
         )
 
-        return result
+    @debugApiCall
+    @auditApiCall("Manager methods")
+    def getWithRelationships(
+        self,
+        relationshipTraitsDatas,
+        entityReference,
+        context,
+        successCallback,
+        errorCallback,
+        resultTraitSet=None,
+    ):
+        """
+        Returns entity references that are related to the input
+        reference by the relationships defined by a set of traits and
+        their properties.
+
+        This is an essential function in this API - as it is widely used
+        to query other entities or organisational structure.
+
+        @note Consult the documentation for the relevant relationship
+        traits to determine if the order of entities in the inner lists
+        of matching references is considered meaningful.
+
+        If any relationship definition is unknown, then an empty list
+        will be returned for that relationship, and no errors will be
+        raised.
+
+        @param relationshipTraitsDatas `List[` @fqref{TraitsData} "TraitsData" `]`
+        The traits of the relationships to query.
+
+        @param entityReference @fqref{EntityReference} "EntityReference"
+        The @ref entity_reference to query the specified relationships
+        for.
+
+        @param context Context The calling context.
+
+        @param successCallback Callback that will be called for each
+        successful relationship query. It will be given the
+        corresponding index of the relationship in
+        @p relationshipTraitsDatas along with a list of entity references
+        for entities that have that relationship to the supplied
+        @p entityReference. If there are no relations, the callback will
+        receive an empty list. The callback will be called on the same
+        thread that initiated the call to `getWithRelationships`.
+
+        @param errorCallback Callback that will be called for each
+        failed relationship query. It will be given the corresponding
+        index of the relationship in @p relationshipTraitsDatas along
+        with a populated @fqref{BatchElementError} "BatchElementError"
+        (see @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The
+        callback will be called on the same thread that initiated the
+        call to `getWithRelationships`.
+
+        @param resultTraitSet `Set[str]` or None, a hint as to what
+        traits the returned entities should have.
+
+        @return `List[List[`@fqref{EntityReference} "EntityReference"`]]`
+        A list of references to related entities, for each input
+        relationship.
+
+        @note The @ref trait_set of any queried relationship can be
+        passed to @fqref{hostApi.Manager.managementPolicy}
+        "managementPolicy" in order to determine if the manager handles
+        relationships of that type.
+        """
+        return self.__impl.getWithRelationships(
+            relationshipTraitsDatas,
+            entityReference,
+            context,
+            self.__hostSession,
+            successCallback,
+            errorCallback,
+            resultTraitSet=resultTraitSet,
+        )
 
     ## @}

--- a/src/openassetio-python/package/openassetio/managerApi/ManagerInterface.py
+++ b/src/openassetio-python/package/openassetio/managerApi/ManagerInterface.py
@@ -426,7 +426,7 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         reference, or `EntityResolutionError`. An
         `EntityResolutionError` should be returned if the entity
         reference is ambiguously versioned or if the supplied
-        `overrideVersionName` does not exist for that entity. For
+        @p overrideVersionName does not exist for that entity. For
         example, if the version is missing from a reference to a
         versioned entity, and that behavior is undefined in the
         manager's model, then an `EntityResolutionError` should be
@@ -468,7 +468,7 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
     # 'shot' exists in a certain part of the asset system. One approach would be
     # to use a 'getChildren' call, on this part of the system. This has the
     # drawback that is assumes that shots are always something that can be
-    # described as 'immediate children' of the location in question. This lay not
+    # described as 'immediate children' of the location in question. This may not
     # always be the case (say, for example there is some kind of 'task' structure
     # in place too). Instead we use a request that asks for any 'shots' that
     # relate to the chosen location. It is then up to the implementation of the
@@ -479,61 +479,39 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
     #
     # @{
 
-    @abc.abstractmethod
-    def getRelatedReferences(
-        self, entityRefs, relationshipTraitsDatas, context, hostSession, resultTraitSet=None
+    def getWithRelationship(
+        self,
+        relationshipTraitsData,
+        entityReferences,
+        context,
+        hostSession,
+        successCallback,
+        errorCallback,
+        resultTraitSet=None,
     ):
         """
-        Returns related entity references, based on a relationship
-        defined by a set of traits and their properties.
+        Queries entity references that are related to the input
+        references by the relationship defined by a set of traits and
+        their properties in @p relationshipTraitsData.
 
         This is an essential function in this API - as it is widely used
-        to query organisational hierarchy, etc...
+        to query other entities or organisational structure.
 
-        There are three possible conventions for calling this function,
-        to allow for batch optimisations in the implementation and
-        prevent excessive query times with high-latency services.
-
-         - a)  A single entity reference, a list of relationships.
-         - b)  A list of entity references and a single relationship.
-         - c)  Equal length lists of references and relationship.
-
-        In all cases, the return value is a list of lists, for example:
-
-            a)  getRelatedReferences([ r1 ], [ td1, td2, td3 ])
-
-            > [ [ r1td1... ], [ r1td2... ], [ r1td3... ] ]
-
-            b)  getRelatedReferences([ r1, r2, r3 ], [ td1 ])
-
-            > [ [ r1td1... ], [ r2td1... ], [ r3td1... ] ]
-
-            c)  getRelatedReferences([ r1, r2, r3 ], [ td1, td2, td3 ])
-
-            > [ [ r1td1... ], [ r2td2... ], [ r3td3... ] ]
-
-        @note The order of entities in the inner lists of matching
-        references will not be considered meaningful, but the outer list
-        should match the input order.
-
-        In summary, if only a single entityRef is provided, it should be
-        assumed that all relationship definitions should be considered
-        for that one entity. If only a single relationship definition is
-        provided, then it should be considered for all supplied entity
-        references. If lists of both are supplied, then they must be the
-        same length, and it should be assumed that it is a 1:1 mapping
-        of a relationship definition to an entity. If this is not the
-        case, ValueErrors should be thrown.
+        @note Consult the documentation for the relevant relationship
+        traits to determine if the order of entities in the inner lists
+        of matching references is required to be meaningful.
 
         If any relationship definition is unknown, then an empty list
-        should be returned for that relationship, and no errors should
-        be raised.
+        must be returned for that entity, and no errors raised. The
+        default implementation returns an empty list for all
+        relationships.
 
-        @param entityRefs List[` @fqref{EntityReference}
-        "EntityReference" `]
+        @param relationshipTraitsData @fqref{TraitsData} "TraitsData"
+        The traits of the relationship to query.
 
-        @param relationshipTraitsDatas `List[`
-        @fqref{TraitsData} "TraitsData" `]`
+        @param entityReferences `List[` @fqref{EntityReference} "EntityReference" `]`
+        A list of @ref entity_reference "entity references" to query the specified
+        relationship for.
 
         @param context Context The calling context.
 
@@ -542,22 +520,118 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         logging and provides access to the openassetio.managerApi.Host
         object representing the process that initiated the API session.
 
+        @param successCallback Callback that must be called for each
+        successful relationship query for an input entity reference. It
+        should be given the corresponding index of the entity reference
+        in @p entityReferences along with a list of entity references for
+        entities that have the relationship specified by
+        @p relationshipTraitsData. If there are no relations, an empty
+        list should be passed to the callback. The callback must be
+        called on the same thread that initiated the call to
+        `getWithRelationship`.
+
+        @param errorCallback Callback that must be called for each
+        failed relationship query for an entity reference. It should be
+        given the corresponding index of the entity reference in
+        @p entityReferences along with a populated
+        @fqref{BatchElementError} "BatchElementError" (see
+        @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The callback
+        must be called on the same thread that initiated the call to
+        `getWithRelationship`.
+
         @param resultTraitSet `Set[str]` or None, a hint as to what
-        traits the caller is expecting the returned entities to have.
+        traits the returned entities should have.
 
-        @return List[List[str]] This MUST be the correct length,
-        returning an empty outer list is NOT valid. (ie: max(len(refs),
-        len(relationships)))
+        @return `List[List[`@fqref{EntityReference} "EntityReference"`]]`
+        A list of references to related entities, for each input
+        reference.
 
-        @exception ValueError If more than one reference and
-        relationship are provided, but they lists are not equal in
-        length, ie: not a 1:1 mapping of entities to relationships. The
-        abstraction of this interface into the Manager class does
-        cursory validation that this is the case before calling this
-        function.
-
-        @unstable
+        @note Ensure that your implementation of
+        @fqref{managerApi.ManagerInterface.managementPolicy}
+        "managementPolicy" responds appropriately when queried with
+        relationship trait sets and a read policy to communicate to the
+        host whether or not you are capable of handling queries for
+        those relationships in this method.
         """
-        raise NotImplementedError
+        for i in range(len(entityReferences)):
+            successCallback(i, [])
+
+    def getWithRelationships(
+        self,
+        relationshipTraitsDatas,
+        entityReference,
+        context,
+        hostSession,
+        successCallback,
+        errorCallback,
+        resultTraitSet=None,
+    ):
+        """
+        Queries entity references that are related to the input
+        reference by the relationships defined by a set of traits and
+        their properties. Each element of @p relationshipTraitsDatas
+        defines a specific relationship to query.
+
+        This is an essential function in this API - as it is widely used
+        to query other entities or organisational structure.
+
+        @note Consult the documentation for the relevant relationship
+        traits to determine if the order of entities in the inner lists
+        of matching references is required to be meaningful.
+
+        If any relationship definition is unknown, then an empty list
+        must be returned for that relationship, and no errors raised. The
+        default implementation returns an empty list for all
+        relationships.
+
+        @param relationshipTraitsDatas `List[` @fqref{TraitsData} "TraitsData" `]`
+        The traits of the relationships to query.
+
+        @param entityReference @fqref{EntityReference} "EntityReference"
+        The @ref entity_reference to query the specified relationships
+        for.
+
+        @param hostSession openassetio.managerApi.HostSession The host
+        session that maps to the caller, this should be used for all
+        logging and provides access to the openassetio.managerApi.Host
+        object representing the process that initiated the API session.
+
+        @param context Context The calling context.
+
+        @param successCallback Callback that must be called for each
+        successful relationship query for an input relationship. It
+        should be given the corresponding index of the relationship
+        definition in @p relationshipTraitsDatas along with a list of
+        entity references for entities that are related to
+        @p entityReference by that relationship. If there are no
+        relations, an empty list should be passed to the callback. The
+        callback must be called on the same thread that initiated the
+        call to `getWithRelationships`.
+
+        @param errorCallback Callback that must be called for each
+        failed query for a relationship. It should be given the
+        corresponding index of the relationship in
+        @p relationshipTraitsDatas along with a populated
+        @fqref{BatchElementError} "BatchElementError" (see
+        @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The callback
+        must be called on the same thread that initiated the call to
+        `getWithRelationships`.
+
+        @param resultTraitSet `Set[str]` or None, a hint as to what
+        traits the returned entities should have.
+
+        @return `List[List[`@fqref{EntityReference} "EntityReference"`]]`
+        A list of references to related entities, for each input
+        relationship.
+
+        @note Ensure that your implementation of
+        @fqref{managerApi.ManagerInterface.managementPolicy}
+        "managementPolicy" responds appropriately when queried with
+        relationship trait sets and a read policy to communicate to the
+        host whether or not you are capable of handling queries for
+        those relationships in this method.
+        """
+        for i in range(len(relationshipTraitsDatas)):
+            successCallback(i, [])
 
     ## @}

--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -84,6 +84,18 @@ disable = [
     "super-with-arguments",
     "consider-using-f-string"
 ]
+# Presently it's not possible to disable the `duplicate-code` check for
+# specific files, so it thinks that symlinks are duplicated
+# implementation. We also have issues where multi-line calls are
+# classed as duplicates.
+#
+# See:
+#     https://github.com/PyCQA/pylint/issues/214
+#
+# As we're not going to have a lot of python
+# implementation anyway, use this trick to disable the similarity
+# checker globally.
+min-similarity-lines=10000
 
 # NB: This requires the use of pyproject-flake8
 [tool.flake8]

--- a/src/openassetio-python/tests/conftest.py
+++ b/src/openassetio-python/tests/conftest.py
@@ -239,17 +239,60 @@ class ValidatingMockManagerInterface(ManagerInterface):
             entityRefs, traitSet, context, hostSession, successCallback, errorCallback
         )
 
-    def getRelatedReferences(
-        self, entityRefs, relationshipTraitsDatas, context, hostSession, resultTraitSet=None
+    def getWithRelationship(
+        self,
+        relationshipTraitsData,
+        entityReferences,
+        context,
+        hostSession,
+        successCallback,
+        errorCallback,
+        resultTraitSet=None,
     ):
-        self.__assertIsIterableOf(entityRefs, EntityReference)
-        self.__assertIsIterableOf(relationshipTraitsDatas, TraitsData)
+        assert isinstance(relationshipTraitsData, TraitsData)
+        self.__assertIsIterableOf(entityReferences, EntityReference)
         self.__assertCallingContext(context, hostSession)
         if resultTraitSet is not None:
             assert isinstance(resultTraitSet, set)
             self.__assertIsIterableOf(resultTraitSet, str)
-        return self.mock.getRelatedReferences(
-            entityRefs, relationshipTraitsDatas, context, hostSession, resultTraitSet
+        assert callable(successCallback)
+        assert callable(errorCallback)
+        return self.mock.getWithRelationship(
+            relationshipTraitsData,
+            entityReferences,
+            context,
+            hostSession,
+            successCallback,
+            errorCallback,
+            resultTraitSet,
+        )
+
+    def getWithRelationships(
+        self,
+        relationshipTraitsDatas,
+        entityReference,
+        context,
+        hostSession,
+        successCallback,
+        errorCallback,
+        resultTraitSet=None,
+    ):
+        self.__assertIsIterableOf(relationshipTraitsDatas, TraitsData)
+        assert isinstance(entityReference, EntityReference)
+        self.__assertCallingContext(context, hostSession)
+        assert callable(successCallback)
+        assert callable(errorCallback)
+        if resultTraitSet is not None:
+            assert isinstance(resultTraitSet, set)
+            self.__assertIsIterableOf(resultTraitSet, str)
+        return self.mock.getWithRelationships(
+            relationshipTraitsDatas,
+            entityReference,
+            context,
+            hostSession,
+            successCallback,
+            errorCallback,
+            resultTraitSet,
         )
 
     def register(

--- a/src/openassetio-python/tests/package/managerApi/test_managerinterface.py
+++ b/src/openassetio-python/tests/package/managerApi/test_managerinterface.py
@@ -21,7 +21,7 @@ Tests for the default implementations of ManagerInterface methods.
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import pytest
 
@@ -187,6 +187,54 @@ class Test_ManagerInterface_finalizedEntityVersion:
         finalized_refs = manager_interface.finalizedEntityVersion(refs, Mock(), Mock())
 
         assert finalized_refs == refs
+
+
+class Test_ManagerInterface_getWithRelationship:
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(ManagerInterface.getWithRelationship)
+        assert method_introspector.is_implemented_once(ManagerInterface, "getWithRelationship")
+
+    def test_returns_empty_list_for_each_input(self, manager_interface):
+        success_callback = Mock()
+        error_callback = Mock()
+
+        for refs in (
+            [],
+            [Mock()],
+            [Mock(), Mock()],
+        ):
+            manager_interface.getWithRelationship(
+                Mock(), refs, Mock(), Mock(), success_callback, error_callback
+            )
+
+            error_callback.assert_not_called()
+            success_callback.assert_has_calls([call(i, []) for i in range(len(refs))])
+
+            success_callback.reset_mock()
+
+
+class Test_ManagerInterface_getWithRelationships:
+    def test_method_defined_in_python(self, method_introspector):
+        assert method_introspector.is_defined_in_python(ManagerInterface.getWithRelationships)
+        assert method_introspector.is_implemented_once(ManagerInterface, "getWithRelationships")
+
+    def test_returns_empty_list_for_each_input(self, manager_interface):
+        success_callback = Mock()
+        error_callback = Mock()
+
+        for rels in (
+            [],
+            [Mock()],
+            [Mock(), Mock()],
+        ):
+            manager_interface.getWithRelationships(
+                rels, Mock(), Mock(), Mock(), success_callback, error_callback
+            )
+
+            error_callback.assert_not_called()
+            success_callback.assert_has_calls([call(i, []) for i in range(len(rels))])
+
+            success_callback.reset_mock()
 
 
 class Test_ManagerInterface__createEntityReference:


### PR DESCRIPTION
## Description

Merges a squashed version of the [`relatedReferencesRefactor` feature branch](https://github.com/OpenAssetIO/OpenAssetIO/tree/feature/relatedReferencesRefactor) into `main`.

Closes #919 

The last temporary commit re-enables BAL integration tests to demonstrate coverage, pending BALs own updates being merged into its `main`.

Diff with head of the feature branch [here](https://github.com/OpenAssetIO/OpenAssetIO/compare/1528e7c..8b5480b), which is 98% updates to `main` since the last feature branch PR.