### PR TITLE
[Docs] Add expand-to-content width

### DIFF
--- a/doc/doxygen/src/styles.scss
+++ b/doc/doxygen/src/styles.scss
@@ -330,7 +330,15 @@ body {
 }
 
 #all-content {
-	max-width: 1100px;
+
+	// When the width of the screen is < 1100, allow the frame to shrink,
+	// as much as it can
+	@media screen and (max-width: 1100px) {
+		min-width: auto
+	}
+
+	min-width: 1100px;
+	width: min-content;
 	margin: auto;
 	position: relative;
 	margin-top: 30px;


### PR DESCRIPTION
Changes the width of the main content div to by default, always be 1100px. This is effectively the same as our prior max-width in  every case, as we always have prose that can push the width to that limit and cause a wrap.

The `width: min-content` flag, in combination with using min rather than max, overrides this in cases where the contents are fixed width and cannot wrap (like method sig tables,) and allows the frame to be pushed out to support its minimum width.

However, the problem with this approach would be that smaller frame sizes that _could_ support non-fixed widths, (ie, all of our pages that are just prose and can wrap very tightly), would no longer wrap below 1100px. To that end, use a media query to remove the minimum width when the frame gets that narrow.

I think this is a good compromise, that keeps our nice column view whilst also allowing small screens/split windows to get wrapped text and use the full screen real estate when they need it, and and allowing our unwrappable elements to push the frame size wider.

## Description

Closes #940 

## Test Instructions

I'd appreciate folks take a look over a few pages, particularly the dynamic behaviour when resizing the window, as I'm not super confident in CSS. Leaving this as draft as I am perfectly happy not to make this change as there are tradeoffs, and no doubt a CSS expert/me putting lots more time into it may come up with something better.

Edit : Removed linked docs as they were apparently misleading.