### PR TITLE
Paged GetWithRelationship

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,15 @@ v1.0.0-alpha.xx
 
 ### Improvements
 
+- Added paged implementations of `getWithRelationship` and
+  `getWithRelationships`, called `getWithRelationshipPaged` and
+  `getWithRelationshipsPaged`
+  These methods are the equivalent of the non-paged versions, but
+  provide an `EntityReferencePager` object, rather than a direct list
+  of results, allowing for correct handling of extremely large/unbounded
+  data sets.
+  [#971](https://github.com/OpenAssetIO/OpenAssetIO/issues/971)
+
 - Added default implementations of `getWithRelationship` and
   `getWithRelationships` that return empty lists, making these methods
   opt-in for manager implementations.

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -70,6 +70,7 @@ target_sources(
     src/hostApi/Manager.cpp
     src/hostApi/ManagerFactory.cpp
     src/hostApi/ManagerImplementationFactoryInterface.cpp
+    src/hostApi/EntityReferencePager.cpp
     src/log/ConsoleLogger.cpp
     src/log/LoggerInterface.cpp
     src/log/SeverityFilter.cpp

--- a/src/openassetio-core/include/openassetio/hostApi/EntityReferencePager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/EntityReferencePager.hpp
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2023 The Foundry Visionmongers Ltd
+
+#pragma once
+
+#include <openassetio/EntityReference.hpp>
+#include <openassetio/typedefs.hpp>
+
+OPENASSETIO_FWD_DECLARE(managerApi, HostSession)
+OPENASSETIO_FWD_DECLARE(managerApi, EntityReferencePagerInterface)
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace hostApi {
+
+OPENASSETIO_DECLARE_PTR(EntityReferencePager)
+
+/**
+ * The EntityReferencePager allows for the retrieval and traversal of
+ * large datasets in a paginated manner.
+ *
+ * @note Instances of this class should not be constructed directly by
+ * the host.
+ *
+ * @see @ref Manager.getWithRelationshipPaged
+ * @see @ref Manager.getWithRelationshipsPaged
+ *
+ * None of the functions of this class should be considered thread-safe.
+ * Hosts should add their own synchronization around concurrent usage.
+ *
+ * Due to the variance of backends, construction, `hasNext`, `get` and
+ * `next` may all reasonably need to perform non-trivial, networked
+ * operations, and thus performance characteristics should not be
+ * assumed.
+ *
+ * Destruction of this object is a signal to the manager that the
+ * connection query is finished. For this reason you should avoid
+ * keeping hold of this object for longer than necessary.
+ */
+class OPENASSETIO_CORE_EXPORT EntityReferencePager final {
+ public:
+  OPENASSETIO_ALIAS_PTR(EntityReferencePager)
+  using Page = EntityReferences;
+
+  /**
+   * Constructs a new EntityReferencePager wrapping a @ref manager
+   * plugin's implementation.
+   *
+   * @note Instances of this class should not be constructed
+   * directly by the host.
+   *
+   * @param pagerInterface Implementation of the underlying pager.
+   * @param hostSession The API session.
+   * @return Newly created instance wrapped in a `std::shared_ptr`.
+   */
+  [[nodiscard]] static EntityReferencePager::Ptr make(
+      managerApi::EntityReferencePagerInterfacePtr pagerInterface,
+      managerApi::HostSessionPtr hostSession);
+
+  /**
+   * Deleted copy constructor.
+   *
+   * EntityReferencePager cannot be copied, as each object represents a
+   * single paginated query.
+   */
+  EntityReferencePager(const EntityReferencePager&) = delete;
+
+  /**
+   * Deleted copy assignment operator.
+   *
+   * EntityReferencePager cannot be copied, as each object represents a
+   * single paginated query.
+   */
+  EntityReferencePager& operator=(const EntityReferencePager&) = delete;
+
+  /// Defaulted move constructor.
+  EntityReferencePager(EntityReferencePager&&) noexcept = default;
+
+  /// Defaulted move assignment operator.
+  EntityReferencePager& operator=(EntityReferencePager&&) noexcept = default;
+
+  /**
+   *  Destruction of this object is tantamount to closing the query.
+   */
+  ~EntityReferencePager() = default;
+
+  /**
+   * Return whether or not there is more data accessible by advancing
+   * the page.
+   *
+   * @return `true` if another page is available, `false` otherwise.
+   */
+  bool hasNext();
+
+  /**
+   * Return the current page of data.
+   *
+   * If the current page has advanced beyond the last page, an empty
+   * list will be returned.
+   *
+   * @return The current page's list of entity references.
+   */
+  Page get();
+
+  /**
+   * Advance the page.
+   *
+   * Advancing beyond the last page is not an error, but will result in
+   * all subsequent calls to @ref get to return an empty page, whilst
+   * @ref hasNext will continue to return `false`.
+   */
+  void next();
+
+ private:
+  EntityReferencePager(managerApi::EntityReferencePagerInterfacePtr pagerInterface,
+                       managerApi::HostSessionPtr hostSession);
+
+  managerApi::EntityReferencePagerInterfacePtr pagerInterface_;
+  managerApi::HostSessionPtr hostSession_;
+};
+static_assert(!std::is_default_constructible_v<EntityReferencePager>);
+static_assert(!std::is_copy_constructible_v<EntityReferencePager>);
+static_assert(!std::is_copy_assignable_v<EntityReferencePager>);
+
+}  // namespace hostApi
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -12,6 +12,7 @@
 #include <openassetio/BatchElementError.hpp>
 #include <openassetio/EntityReference.hpp>
 #include <openassetio/InfoDictionary.hpp>
+#include <openassetio/hostApi/EntityReferencePager.hpp>
 #include <openassetio/trait/collection.hpp>
 #include <openassetio/typedefs.hpp>
 
@@ -835,13 +836,12 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * @param context The calling context.
    *
    * @param successCallback Callback that will be called for each
-   * successful relationship query. It will be given the
-   * corresponding index of the entity reference in
-   * @p entityReferences along with a list of entity references for
-   * entities that have the relationship specified by
-   * @p relationshipTraitsData. If there are no relations, the
-   * callback will receive an empty list. The callback will be called
-   * on the same thread that initiated the call to
+   * successful relationship query. It will be given the corresponding
+   * index of the entity reference in @p entityReferences along with a
+   * list of entity references for entities that have the relationship
+   * specified by @p relationshipTraitsData. If there are no relations,
+   * the callback will receive an empty list. The callback will be
+   * called on the same thread that initiated the call to
    * `getWithRelationship`.
    *
    * @param errorCallback Callback that will be called for each failed
@@ -918,6 +918,108 @@ class OPENASSETIO_CORE_EXPORT Manager {
                             const BatchElementErrorCallback& errorCallback,
                             const trait::TraitSet& resultTraitSet = {});
 
+  /**
+   * Callback signature used for a successful paged entity relationship
+   * query.
+   */
+  using PagedRelationshipSuccessCallback =
+      std::function<void(std::size_t, EntityReferencePagerPtr)>;
+
+  /**
+   * Paged version of getWithRelationship. See non-paged
+   * @ref getWithRelationship for further documentation.
+   *
+   * @param relationshipTraitsData The traits of the relationship to
+   * query.
+   *
+   * @param entityReferences A list of @ref entity_reference to query
+   * the specified relationship for.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param context The calling context.
+   *
+   * @param successCallback Callback that will be called for each
+   * successful relationship query. It will be given the corresponding
+   * index of the entity reference in @p entityReferences as well as a
+   * pager capable of returning pages of entities that have the
+   * relationship to the entity at the corresponding index, specified by
+   * @p relationshipTraitsData. If there are no relations, the pager
+   * will have no pages. The callback will be called on the same thread
+   * that initiated the call to `getWithRelationshipPaged`. To access
+   * the data, retrieve the @ref EntityReferencePager from the callback,
+   * and use its interface to traverse pages.
+   *
+   * @param errorCallback Callback that will be called for each failed
+   * relationship query. It will be given the corresponding index of the
+   * entity reference in @p entityReferences along with a populated
+   * BatchElementError (see @ref BatchElementError.ErrorCode
+   * "ErrorCodes"). The callback will be called on the same thread that
+   * initiated the call to `getWithRelationshipPaged`.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @throws std::out_of_range if @p pageSize is zero.
+   */
+  void getWithRelationshipPaged(const EntityReferences& entityReferences,
+                                const TraitsDataPtr& relationshipTraitsData, size_t pageSize,
+                                const ContextConstPtr& context,
+                                const PagedRelationshipSuccessCallback& successCallback,
+                                const BatchElementErrorCallback& errorCallback,
+                                const trait::TraitSet& resultTraitSet = {});
+
+  /**
+   * Paged version of getWithRelationships. See non-paged
+   * @ref getWithRelationships for further documentation.
+   *
+   * @param relationshipTraitsDatas The traits of the relationships to
+   * query.
+   *
+   * @param entityReference The @ref entity_reference to query the
+   * specified relationships for.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param context The calling context.
+   *
+   * @param successCallback Callback that will be called for each
+   * successful relationship query. It will be given the corresponding
+   * index of the relationship in @p relationshipTraitsDatas as well as
+   * a pager capable of returning pages of entities related to @p
+   * entityReference by the relationship at that corresponding index. If
+   * there are no relations, the pager will have no pages. The callback
+   * will be called on the same thread that initiated the call to
+   * `getWithRelationshipsPaged`. To access the data, retrieve the
+   * @ref EntityReferencePager from the callback, and use its interface
+   * to traverse pages.
+   *
+   * @param errorCallback Callback that will be called for each failed
+   * relationship query. It will be given the corresponding index of the
+   * relationship in @p relationshipTraitsDatas along with a populated
+   * BatchElementError (see @fqref{BatchElementError.ErrorCode}
+   * "ErrorCodes"). The callback will be called on the same thread that
+   * initiated the call to `getWithRelationshipsPaged`.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @note The @ref trait_set of any queried relationship can be passed
+   * to @ref managementPolicy in order to determine if the manager
+   * handles relationships of that type.
+   *
+   * @throws std::out_of_range if @p pageSize is zero.
+   */
+  void getWithRelationshipsPaged(const EntityReference& entityReference,
+                                 const trait::TraitsDatas& relationshipTraitsDatas,
+                                 size_t pageSize, const ContextConstPtr& context,
+                                 const PagedRelationshipSuccessCallback& successCallback,
+                                 const BatchElementErrorCallback& errorCallback,
+                                 const trait::TraitSet& resultTraitSet = {});
   /// @}
 
   /**

--- a/src/openassetio-core/include/openassetio/managerApi/EntityReferencePagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/EntityReferencePagerInterface.hpp
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2023 The Foundry Visionmongers Ltd
+
+#pragma once
+
+#include <vector>
+
+#include <openassetio/export.h>
+#include <openassetio/EntityReference.hpp>
+#include <openassetio/typedefs.hpp>
+
+OPENASSETIO_FWD_DECLARE(managerApi, HostSession)
+OPENASSETIO_FWD_DECLARE(Context)
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace managerApi {
+
+OPENASSETIO_DECLARE_PTR(EntityReferencePagerInterface)
+
+/**
+ * Deals with the retrieval of paginated data from the backend at the
+ * behest of the host.
+ *
+ * The manager is expected to extend this type, and store data necessary
+ * to perform the paging operations on the extended object, utilizing
+ * caching when possible to reduce redundant queries.
+ *
+ * Thread-safety of operations is not expected. Hosts will synchronize
+ * calls themselves, if required.
+ *
+ * This is a non-copyable object that will be held in a `shared_ptr`,
+ * meaning multiple references may be held, but only to a single
+ * instance of the ongoing query, whose destructor will be called when
+ * all references are released. As such, the destructor of this class is
+ * a good place to place any complex cleanup operations (e.g. closing
+ * open connections).
+ *
+ * To support as wide array of possible backends as possible,
+ * OpenAssetIO places no restraints on the behaviour of this type
+ * concerning performance, however, it is considered friendly to
+ * document the performance characteristics of your Pager
+ * implementation.
+ */
+class OPENASSETIO_CORE_EXPORT EntityReferencePagerInterface {
+ public:
+  OPENASSETIO_ALIAS_PTR(EntityReferencePagerInterface)
+  using Page = std::vector<EntityReference>;
+
+  /// Defaulted default constructor.
+  EntityReferencePagerInterface() = default;
+
+  /**
+   * Deleted copy constructor.
+   *
+   * Copying of pagers is disallowed, for convenience of implementation.
+   *
+   * However, be aware that multiple references to the pager may be
+   * held.
+   */
+  explicit EntityReferencePagerInterface(const EntityReferencePagerInterface&) = delete;
+
+  /**
+   * Deleted copy assignment operator.
+   *
+   * Copying of pagers is disallowed, for convenience of implementation.
+   *
+   * However, be aware that multiple references to the pager may be
+   * held.
+   */
+  EntityReferencePagerInterface& operator=(const EntityReferencePagerInterface&) = delete;
+
+  /// Defaulted move constructor.
+  EntityReferencePagerInterface(EntityReferencePagerInterface&&) noexcept = default;
+
+  /// Defaulted move assignment operator.
+  EntityReferencePagerInterface& operator=(EntityReferencePagerInterface&&) noexcept = default;
+
+  /**
+   * Manager should override destructor to be notified when query has
+   * finished.
+   */
+  virtual ~EntityReferencePagerInterface() = default;
+
+  /**
+   * Returns whether or not there is more data accessible by advancing
+   * the page.
+   *
+   * The mechanism to acquire this information is variable, and left up
+   * to the specifics of the backend implementation.
+   *
+   * @return `true` if another page is available, `false` otherwise.
+   */
+  virtual bool hasNext(const HostSessionPtr&) = 0;
+
+  /**
+   * Return the current page of data.
+   *
+   * If the current page has advanced beyond the last page, an empty
+   * list should be returned.
+   *
+   * @return The current page's list of entity references.
+   */
+  virtual Page get(const HostSessionPtr&) = 0;
+
+  /**
+   * Advance the page.
+   *
+   * If currently on the last page of results, calling `next` should
+   * logically advance to the page after the last page, in analogy with
+   * `std::end`. Subsequent calls should then be a no-op. In this state,
+   * @ref hasNext should continue to return `false` and @ref get should
+   * return an empty page.
+   */
+  virtual void next(const HostSessionPtr&) = 0;
+};
+static_assert(!std::is_copy_constructible_v<EntityReferencePagerInterface>);
+static_assert(!std::is_copy_assignable_v<EntityReferencePagerInterface>);
+
+}  // namespace managerApi
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -15,6 +15,7 @@
 #include <openassetio/trait/collection.hpp>
 #include <openassetio/typedefs.hpp>
 
+OPENASSETIO_FWD_DECLARE(managerApi, EntityReferencePagerInterface)
 OPENASSETIO_FWD_DECLARE(managerApi, ManagerStateBase)
 OPENASSETIO_FWD_DECLARE(managerApi, HostSession)
 OPENASSETIO_FWD_DECLARE(Context)
@@ -863,6 +864,127 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
                                     const HostSessionPtr& hostSession,
                                     const RelationshipSuccessCallback& successCallback,
                                     const BatchElementErrorCallback& errorCallback);
+
+  /**
+   * Callback signature used for a successful paged entity relationship
+   * query.
+   */
+  using PagedRelationshipSuccessCallback =
+      std::function<void(std::size_t, managerApi::EntityReferencePagerInterfacePtr)>;
+
+  /**
+   * Paged version of getWithRelationship. See non-paged
+   * @ref getWithRelationship for further documentation.
+   *
+   * @param relationshipTraitsData The traits of the relationship to
+   * query.
+   *
+   * @param entityReferences A list of @ref entity_reference to query
+   * the specified relationship for.
+   *
+   * @param pageSize The size of each page of data. The page size must
+   * be fixed for the lifetime of pager object given to the @p
+   * successCallback. Guaranteed to be greater than zero.
+   *
+   * @param context The calling context.
+   *
+   * @param hostSession The host session that maps to the caller, this
+   * should be used for all logging and provides access to the Host
+   * object representing the process that initiated the API session.
+   *
+   * @param successCallback Callback that should be called for each
+   * successful relationship query. It should be given the corresponding
+   * index of the entity reference in @p entityReferences as well as a
+   * pager capable of returning pages of entities that have the
+   * relationship to the entity at the corresponding index, specified by
+   * @p relationshipTraitsData.
+   *
+   * The pager should be created by implementing @ref
+   * EntityReferencePagerInterface, and should return results in pages
+   * of size specified by @p pageSize
+   *
+   * If there are no relations, the pager should have no pages. The
+   * callback should be called on the same thread that initiated the
+   * call to `getWithRelationship`. To access the data, retrieve the
+   * @fqref{hostApi.EntityReferencePager} from the callback, and use its
+   * interface to traverse pages.
+   *
+   * @param errorCallback Callback that should be called for each failed
+   * relationship query. It should be given the corresponding index of
+   * the entity reference in @p entityReferences along with a populated
+   * BatchElementError (see @ref BatchElementError.ErrorCode
+   * "ErrorCodes"). The callback should be called on the same thread
+   * that initiated the call to `getWithRelationship`.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   */
+  virtual void getWithRelationshipPaged(const EntityReferences& entityReferences,
+                                        const TraitsDataPtr& relationshipTraitsData,
+                                        const trait::TraitSet& resultTraitSet, size_t pageSize,
+                                        const ContextConstPtr& context,
+                                        const HostSessionPtr& hostSession,
+                                        const PagedRelationshipSuccessCallback& successCallback,
+                                        const BatchElementErrorCallback& errorCallback);
+
+  /**
+   * Paged version of getWithRelationships. See non-paged
+   * @ref getWithRelationships for further documentation.
+   *
+   * @param relationshipTraitsDatas The traits of the relationships to
+   * query.
+   *
+   * @param entityReference The @ref entity_reference to query the
+   * specified relationships for.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Guaranteed to be greater than zero.
+   *
+   * @param context The calling context.
+   *
+   * @param hostSession The host session that maps to the caller, this
+   * should be used for all logging and provides access to the Host
+   * object representing the process that initiated the API session.
+   *
+   * @param successCallback Callback that should be called for each
+   * successful relationship query. It should be given the corresponding
+   * index of the relationship in @p relationshipTraitsDatas as well as
+   * a pager capable of returning pages of entities related to @p
+   * entityReference by the relationship at that corresponding index.
+   *
+   * The pager should be created by implementing @ref
+   * EntityReferencePagerInterface, and should return results in pages
+   * of size specified by @p pageSize
+   *
+   * If there are no relations, the pager should have no pages. The
+   * callback should be called on the same thread that initiated the
+   * call to `getWithRelationship`. To access the data, retrieve the
+   * @fqref{hostApi.EntityReferencePager} from the callback, and use its
+   * interface to traverse pages.
+   *
+   * @param errorCallback Callback that should be called for each failed
+   * relationship query. It should be given the corresponding index of
+   * the relationship in @p relationshipTraitsDatas along with a
+   * populated BatchElementError (see
+   * @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The callback
+   * should be called on the same thread that initiated the call to
+   * `getWithRelationships`.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @note The @ref trait_set of any queried relationship can be passed
+   * to @ref managementPolicy in order to determine if the manager
+   * handles relationships of that type.
+   */
+  virtual void getWithRelationshipsPaged(const EntityReference& entityReference,
+                                         const trait::TraitsDatas& relationshipTraitsDatas,
+                                         const trait::TraitSet& resultTraitSet, size_t pageSize,
+                                         const ContextConstPtr& context,
+                                         const HostSessionPtr& hostSession,
+                                         const PagedRelationshipSuccessCallback& successCallback,
+                                         const BatchElementErrorCallback& errorCallback);
 
   /// @}
   /**

--- a/src/openassetio-core/src/hostApi/EntityReferencePager.cpp
+++ b/src/openassetio-core/src/hostApi/EntityReferencePager.cpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2023 The Foundry Visionmongers Ltd
+
+#include <openassetio/EntityReference.hpp>
+#include <openassetio/hostApi/EntityReferencePager.hpp>
+#include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace hostApi {
+
+typename EntityReferencePager::Ptr EntityReferencePager::make(
+    managerApi::EntityReferencePagerInterfacePtr pagerInterface,
+    managerApi::HostSessionPtr hostSession) {
+  return EntityReferencePager::Ptr{
+      new EntityReferencePager{std::move(pagerInterface), std::move(hostSession)}};
+}
+
+EntityReferencePager::EntityReferencePager(
+    managerApi::EntityReferencePagerInterfacePtr pagerInterface,
+    managerApi::HostSessionPtr hostSession)
+    : pagerInterface_(std::move(pagerInterface)), hostSession_(std::move(hostSession)) {}
+
+bool EntityReferencePager::hasNext() { return pagerInterface_->hasNext(hostSession_); }
+
+typename EntityReferencePager::Page EntityReferencePager::get() {
+  return pagerInterface_->get(hostSession_);
+}
+
+void EntityReferencePager::next() { pagerInterface_->next(hostSession_); }
+
+}  // namespace hostApi
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/managerApi/ManagerInterface.cpp
+++ b/src/openassetio-core/src/managerApi/ManagerInterface.cpp
@@ -2,6 +2,9 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #include <stdexcept>
 
+#include <openassetio/TraitsData.hpp>
+#include <openassetio/hostApi/EntityReferencePager.hpp>
+#include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
 
 namespace openassetio {
@@ -74,6 +77,52 @@ void ManagerInterface::getWithRelationships(
     successCallback(idx, {});
   }
 }
+
+namespace {
+/*
+ * A dummy pager interface that acts as if it has no data. For use in
+ * getWithRelationship[s] default implementation.
+ */
+class EmptyEntityReferencePagerInterface : public managerApi::EntityReferencePagerInterface {
+  bool hasNext([[maybe_unused]] const HostSessionPtr& hsp) override { return false; }
+
+  Page get([[maybe_unused]] const HostSessionPtr& hsp) override { return {}; }
+
+  void next([[maybe_unused]] const HostSessionPtr& hsp) override {}
+};
+
+}  // namespace
+
+void ManagerInterface::getWithRelationshipPaged(
+    const EntityReferences& entityReferences,
+    [[maybe_unused]] const TraitsDataPtr& relationshipTraitsData,
+    [[maybe_unused]] const trait::TraitSet& resultTraitSet, [[maybe_unused]] size_t pageSize,
+    [[maybe_unused]] const ContextConstPtr& context,
+    [[maybe_unused]] const HostSessionPtr& hostSession,
+    const PagedRelationshipSuccessCallback& successCallback,
+    [[maybe_unused]] const BatchElementErrorCallback& errorCallback) {
+  const auto size = entityReferences.size();
+
+  for (std::size_t idx = 0; idx < size; ++idx) {
+    successCallback(idx, std::make_shared<EmptyEntityReferencePagerInterface>());
+  }
+}
+
+void ManagerInterface::getWithRelationshipsPaged(
+    [[maybe_unused]] const EntityReference& entityReference,
+    const trait::TraitsDatas& relationshipTraitsDatas,
+    [[maybe_unused]] const trait::TraitSet& resultTraitSet, [[maybe_unused]] size_t pageSize,
+    [[maybe_unused]] const ContextConstPtr& context,
+    [[maybe_unused]] const HostSessionPtr& hostSession,
+    const PagedRelationshipSuccessCallback& successCallback,
+    [[maybe_unused]] const BatchElementErrorCallback& errorCallback) {
+  const auto size = relationshipTraitsDatas.size();
+
+  for (std::size_t idx = 0; idx < size; ++idx) {
+    successCallback(idx, std::make_shared<EmptyEntityReferencePagerInterface>());
+  }
+}
+
 }  // namespace managerApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-python/cmodule/CMakeLists.txt
+++ b/src/openassetio-python/cmodule/CMakeLists.txt
@@ -45,6 +45,7 @@ target_sources(
     src/ContextBinding.cpp
     src/EntityReferenceBinding.cpp
     src/TraitsDataBinding.cpp
+    src/hostApi/EntityReferencePagerBinding.cpp
     src/hostApi/ManagerBinding.cpp
     src/hostApi/HostInterfaceBinding.cpp
     src/hostApi/ManagerFactoryBinding.cpp
@@ -54,6 +55,7 @@ target_sources(
     src/log/SeverityFilterBinding.cpp
     src/managerApi/HostBinding.cpp
     src/managerApi/HostSessionBinding.cpp
+    src/managerApi/EntityReferencePagerInterfaceBinding.cpp
     src/managerApi/ManagerInterfaceBinding.cpp
     src/managerApi/ManagerStateBaseBinding.cpp
 )

--- a/src/openassetio-python/cmodule/src/PyRetainingSharedPtr.hpp
+++ b/src/openassetio-python/cmodule/src/PyRetainingSharedPtr.hpp
@@ -10,6 +10,7 @@
  * The solution was inspired by
  * https://github.com/pybind/pybind11/issues/1546
  */
+#include <functional>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -168,6 +169,14 @@ struct RetainPyArgs {
   template <auto Fn>
   static auto forFn() {
     return decorator<Fn>(Fn);
+  }
+
+  template <class Ret, class... Args>
+  static auto forFn(std::function<Ret(Args...)> func) {
+    return py::cpp_function(
+        [func = std::move(func)](ConvertToPyRetainingSharedPtrT<Args>... args) {
+          return func(std::forward<ConvertToPyRetainingSharedPtrT<Args>>(args)...);
+        });
   }
 
  private:

--- a/src/openassetio-python/cmodule/src/_openassetio.cpp
+++ b/src/openassetio-python/cmodule/src/_openassetio.cpp
@@ -27,6 +27,8 @@ PYBIND11_MODULE(_openassetio, mod) {
   registerHostInterface(hostApi);
   registerHost(managerApi);
   registerHostSession(managerApi);
+  registerEntityReferencePagerInterface(managerApi);
+  registerEntityReferencePager(hostApi);
   registerManagerInterface(managerApi);
   registerManagerImplementationFactoryInterface(hostApi);
   registerManager(hostApi);

--- a/src/openassetio-python/cmodule/src/_openassetio.hpp
+++ b/src/openassetio-python/cmodule/src/_openassetio.hpp
@@ -15,9 +15,31 @@
 
 OPENASSETIO_FWD_DECLARE(ManagerStateBase)
 OPENASSETIO_FWD_DECLARE(managerApi, ManagerInterface)
+OPENASSETIO_FWD_DECLARE(managerApi, EntityReferencePagerInterface)
 OPENASSETIO_FWD_DECLARE(log, LoggerInterface)
 OPENASSETIO_FWD_DECLARE(hostApi, HostInterface)
 OPENASSETIO_FWD_DECLARE(hostApi, ManagerImplementationFactoryInterface)
+
+/**
+ * Similar to PYBIND11_OVERRIDE, but allows different arguments to be
+ * given to the Python implementation and the C++ fallback (base
+ * class) implementation.
+ *
+ * For example, this is useful to decorate std::function callbacks
+ * with `PyRetainingSharedPtr`s, so that Python objects are kept alive
+ * as they pass through C++ callbacks.
+ *
+ * The CppArgs parameter must be a parentheses-enclosed,
+ * comma-separated, list of arguments. These are given to the C++ base
+ * class implementation, if no Python override is found.
+ *
+ * All remaining arguments following the CppArgs (not
+ * parentheses-enclosed) are passed to the Python override
+ * implementation, if one exists.
+ */
+#define OPENASSETIO_PYBIND11_OVERRIDE_ARGS(Ret, Class, Fn, CppArgs, ... /* PyArgs */) \
+  PYBIND11_OVERRIDE_IMPL(PYBIND11_TYPE(Ret), PYBIND11_TYPE(Class), #Fn, __VA_ARGS__); \
+  return Class::Fn CppArgs
 
 /**
  * Declare a `RetainPyArgs` alias with common template arguments.
@@ -36,7 +58,8 @@ OPENASSETIO_FWD_DECLARE(hostApi, ManagerImplementationFactoryInterface)
 using RetainCommonPyArgs = openassetio::RetainPyArgs<
     openassetio::log::LoggerInterfacePtr, openassetio::ManagerStateBasePtr,
     openassetio::managerApi::ManagerInterfacePtr, openassetio::hostApi::HostInterfacePtr,
-    openassetio::hostApi::ManagerImplementationFactoryInterfacePtr>;
+    openassetio::hostApi::ManagerImplementationFactoryInterfacePtr,
+    openassetio::managerApi::EntityReferencePagerInterfacePtr>;
 
 /// Concise pybind alias.
 namespace py = pybind11;
@@ -85,3 +108,9 @@ void registerEntityReference(const py::module& mod);
 
 /// Register the BatchElementError type with Python.
 void registerBatchElementError(py::module& mod);
+
+/// Register the EntityReferencePager class with Python.
+void registerEntityReferencePager(const py::module& mod);
+
+/// Register the EntityReferencePagerInterface class with Python.
+void registerEntityReferencePagerInterface(const py::module& mod);

--- a/src/openassetio-python/cmodule/src/hostApi/EntityReferencePagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/EntityReferencePagerBinding.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <algorithm>
+
+#include <pybind11/functional.h>
+#include <pybind11/stl.h>
+
+#include <openassetio/BatchElementError.hpp>
+#include <openassetio/Context.hpp>
+#include <openassetio/TraitsData.hpp>
+#include <openassetio/hostApi/EntityReferencePager.hpp>
+#include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
+#include <openassetio/managerApi/HostSession.hpp>
+#include <openassetio/trait/collection.hpp>
+
+#include "../_openassetio.hpp"
+
+void registerEntityReferencePager(const py::module& mod) {
+  using openassetio::hostApi::EntityReferencePager;
+  using openassetio::hostApi::EntityReferencePagerPtr;
+
+  py::class_<EntityReferencePager, EntityReferencePagerPtr>{mod, "EntityReferencePager"}
+      .def(py::init(RetainCommonPyArgs::forFn<&EntityReferencePager::make>()),
+           py::arg("entityReferencePagerInterface").none(false),
+           py::arg("hostSession").none(false))
+      .def("hasNext", &EntityReferencePager::hasNext)
+      .def("get", &EntityReferencePager::get)
+      .def("next", &EntityReferencePager::next);
+}

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -154,6 +154,31 @@ void registerManager(const py::module& mod) {
           py::arg("entityReference"), py::arg("relationshipTraitsDatas"),
           py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"),
           py::arg("resultTraitSet") = trait::TraitSet{})
+      .def("getWithRelationshipPaged",
+           py::overload_cast<const EntityReferences&, const TraitsDataPtr&, std::size_t,
+                             const ContextConstPtr&,
+                             const Manager::PagedRelationshipSuccessCallback&,
+                             const Manager::BatchElementErrorCallback&, const trait::TraitSet&>(
+               &Manager::getWithRelationshipPaged),
+           py::arg("entityReferences"), py::arg("relationshipTraitsData").none(false),
+           py::arg("pageSize"), py::arg("context").none(false), py::arg("successCallback"),
+           py::arg("errorCallback"), py::arg("resultTraitSet") = trait::TraitSet{})
+      .def(
+          "getWithRelationshipsPaged",
+          [](Manager& self, const EntityReference& entityReference,
+             const trait::TraitsDatas& relationshipTraitsDatas, size_t pageSize,
+             const ContextConstPtr& context,
+             const Manager::PagedRelationshipSuccessCallback& successCallback,
+             const Manager::BatchElementErrorCallback& errorCallback,
+             const trait::TraitSet& resultTraitSet) {
+            validateTraitsDatas(relationshipTraitsDatas);
+            self.getWithRelationshipsPaged(entityReference, relationshipTraitsDatas, pageSize,
+                                           context, successCallback, errorCallback,
+                                           resultTraitSet);
+          },
+          py::arg("entityReference"), py::arg("relationshipTraitsDatas"), py::arg("pageSize"),
+          py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"),
+          py::arg("resultTraitSet") = trait::TraitSet{})
       .def("preflight",
            static_cast<void (Manager::*)(
                const EntityReferences&, const trait::TraitSet&, const ContextConstPtr&,

--- a/src/openassetio-python/cmodule/src/managerApi/EntityReferencePagerInterfaceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/managerApi/EntityReferencePagerInterfaceBinding.cpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <pybind11/functional.h>
+#include <pybind11/stl.h>
+
+#include <openassetio/Context.hpp>
+#include <openassetio/InfoDictionary.hpp>
+#include <openassetio/TraitsData.hpp>
+#include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
+#include <openassetio/managerApi/HostSession.hpp>
+#include <openassetio/trait/collection.hpp>
+#include <openassetio/typedefs.hpp>
+
+#include "../_openassetio.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace managerApi {
+
+/**
+ * Trampoline class required for pybind to bind pure virtual methods
+ * and allow C++ -> Python calls via a C++ instance.
+ */
+struct PyEntityReferencePagerInterface : EntityReferencePagerInterface {
+  using EntityReferencePagerInterface::EntityReferencePagerInterface;
+
+  bool hasNext(const HostSessionPtr& hostSession) override {
+    PYBIND11_OVERRIDE_PURE(bool, EntityReferencePagerInterface, hasNext, hostSession);
+  }
+
+  EntityReferencePagerInterface::Page get(const HostSessionPtr& hostSession) override {
+    PYBIND11_OVERRIDE_PURE(EntityReferencePagerInterface::Page, EntityReferencePagerInterface, get,
+                           hostSession);
+  }
+
+  void next(const HostSessionPtr& hostSession) override {
+    PYBIND11_OVERRIDE_PURE(void, EntityReferencePagerInterface, next, hostSession);
+  }
+};
+
+}  // namespace managerApi
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio
+
+void registerEntityReferencePagerInterface(const py::module& mod) {
+  using openassetio::managerApi::EntityReferencePagerInterface;
+  using openassetio::managerApi::EntityReferencePagerInterfacePtr;
+  using openassetio::managerApi::PyEntityReferencePagerInterface;
+
+  py::class_<EntityReferencePagerInterface, PyEntityReferencePagerInterface,
+             EntityReferencePagerInterfacePtr>(mod, "EntityReferencePagerInterface")
+      .def(py::init())
+      .def("hasNext", &EntityReferencePagerInterface::hasNext, py::arg("hostSession").none(false))
+      .def("get", &EntityReferencePagerInterface::get, py::arg("hostSession").none(false))
+      .def("next", &EntityReferencePagerInterface::next, py::arg("hostSession").none(false));
+}

--- a/src/openassetio-python/cmodule/src/managerApi/ManagerInterfaceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/managerApi/ManagerInterfaceBinding.cpp
@@ -6,6 +6,8 @@
 #include <openassetio/Context.hpp>
 #include <openassetio/InfoDictionary.hpp>
 #include <openassetio/TraitsData.hpp>
+#include <openassetio/hostApi/EntityReferencePager.hpp>
+#include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/managerApi/ManagerStateBase.hpp>
@@ -112,6 +114,34 @@ struct PyManagerInterface : ManagerInterface {
                       successCallback, errorCallback);
   }
 
+  void getWithRelationshipPaged(
+      const EntityReferences& entityReferences, const TraitsDataPtr& relationshipTraitsData,
+      const trait::TraitSet& resultTraitSet, size_t pageSize, const ContextConstPtr& context,
+      const HostSessionPtr& hostSession,
+      const ManagerInterface::PagedRelationshipSuccessCallback& successCallback,
+      const ManagerInterface::BatchElementErrorCallback& errorCallback) override {
+    OPENASSETIO_PYBIND11_OVERRIDE_ARGS(
+        void, ManagerInterface, getWithRelationshipPaged,
+        (entityReferences, relationshipTraitsData, resultTraitSet, pageSize, context, hostSession,
+         successCallback, errorCallback),
+        entityReferences, relationshipTraitsData, resultTraitSet, pageSize, context, hostSession,
+        RetainCommonPyArgs::forFn(successCallback), errorCallback);
+  }
+
+  void getWithRelationshipsPaged(
+      const EntityReference& entityReference, const trait::TraitsDatas& relationshipTraitsDatas,
+      const trait::TraitSet& resultTraitSet, size_t pageSize, const ContextConstPtr& context,
+      const HostSessionPtr& hostSession,
+      const ManagerInterface::PagedRelationshipSuccessCallback& successCallback,
+      const ManagerInterface::BatchElementErrorCallback& errorCallback) override {
+    OPENASSETIO_PYBIND11_OVERRIDE_ARGS(
+        void, ManagerInterface, getWithRelationshipsPaged,
+        (entityReference, relationshipTraitsDatas, resultTraitSet, pageSize, context, hostSession,
+         successCallback, errorCallback),
+        entityReference, relationshipTraitsDatas, resultTraitSet, pageSize, context, hostSession,
+        RetainCommonPyArgs::forFn(successCallback), errorCallback);
+  }
+
   void preflight(const EntityReferences& entityReferences, const trait::TraitSet& traitSet,
                  const ContextConstPtr& context, const HostSessionPtr& hostSession,
                  const PreflightSuccessCallback& successCallback,
@@ -137,6 +167,11 @@ struct PyManagerInterface : ManagerInterface {
 }  // namespace openassetio
 
 void registerManagerInterface(const py::module& mod) {
+  using openassetio::ContextConstPtr;
+  using openassetio::EntityReference;
+  using openassetio::EntityReferences;
+  using openassetio::TraitsDataPtr;
+  using openassetio::managerApi::HostSessionPtr;
   using openassetio::managerApi::ManagerInterface;
   using openassetio::managerApi::ManagerInterfacePtr;
   using openassetio::managerApi::ManagerStateBasePtr;
@@ -163,6 +198,16 @@ void registerManagerInterface(const py::module& mod) {
       .def("isEntityReferenceString", &ManagerInterface::isEntityReferenceString,
            py::arg("someString"), py::arg("hostSession").none(false))
       .def("resolve", &ManagerInterface::resolve, py::arg("entityReferences"), py::arg("traitSet"),
+           py::arg("context").none(false), py::arg("hostSession").none(false),
+           py::arg("successCallback"), py::arg("errorCallback"))
+      .def("getWithRelationshipPaged", &ManagerInterface::getWithRelationshipPaged,
+           py::arg("entityReferences"), py::arg("relationshipTraitsData").none(false),
+           py::arg("resultTraitSet"), py::arg("pageSize").none(false),
+           py::arg("context").none(false), py::arg("hostSession").none(false),
+           py::arg("successCallback"), py::arg("errorCallback"))
+      .def("getWithRelationshipsPaged", &ManagerInterface::getWithRelationshipsPaged,
+           py::arg("entityReference"), py::arg("relationshipTraitsDatas"),
+           py::arg("resultTraitSet"), py::arg("pageSize").none(false),
            py::arg("context").none(false), py::arg("hostSession").none(false),
            py::arg("successCallback"), py::arg("errorCallback"))
       .def("getWithRelationship", &ManagerInterface::getWithRelationship,

--- a/src/openassetio-python/package/openassetio/hostApi/__init__.py
+++ b/src/openassetio-python/package/openassetio/hostApi/__init__.py
@@ -30,3 +30,4 @@ from .ManagerFactory import ManagerFactory
 
 HostInterface = _openassetio.hostApi.HostInterface
 ManagerImplementationFactoryInterface = _openassetio.hostApi.ManagerImplementationFactoryInterface
+EntityReferencePager = _openassetio.hostApi.EntityReferencePager

--- a/src/openassetio-python/package/openassetio/managerApi/__init__.py
+++ b/src/openassetio-python/package/openassetio/managerApi/__init__.py
@@ -27,3 +27,4 @@ from .ManagerInterface import ManagerInterface
 Host = _openassetio.managerApi.Host
 HostSession = _openassetio.managerApi.HostSession
 ManagerStateBase = _openassetio.managerApi.ManagerStateBase
+EntityReferencePagerInterface = _openassetio.managerApi.EntityReferencePagerInterface

--- a/src/openassetio-python/tests/package/hostApi/test_entityreferencepager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_entityreferencepager.py
@@ -1,0 +1,143 @@
+#
+#   Copyright 2013-2023 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Tests that cover the openassetio.hostApi.EntityReferencePager wrapper class.
+"""
+
+# pylint: disable=no-self-use
+# pylint: disable=invalid-name,redefined-outer-name
+# pylint: disable=missing-class-docstring,missing-function-docstring
+from unittest import mock
+
+import pytest
+import weakref
+
+from openassetio import EntityReference
+from openassetio.hostApi import Manager, EntityReferencePager
+from openassetio.managerApi import EntityReferencePagerInterface
+
+
+class Test_EntityReferencePager_init:
+    def test_when_constructed_with_EntityReferencePagerInterface_as_None_then_raises_TypeError(
+        self, a_host_session
+    ):
+        # Check the message is both helpful and that the bindings
+        # were loaded in the correct order such that types are
+        # described correctly.
+        matchExpr = (
+            r".+The following argument types are supported:[^(]+"
+            r"EntityReferencePager\([^,]+managerApi.EntityReferencePagerInterface,[^,]+managerApi.HostSession.+"
+        )
+
+        with pytest.raises(TypeError, match=matchExpr):
+            EntityReferencePager(None, a_host_session)
+
+
+class Test_EntityReferencePager_next:
+    def test_wraps_the_corresponding_method_of_the_held_interface(
+        self, an_entity_reference_pager, mock_entity_reference_pager_interface, a_host_session
+    ):
+        method = mock_entity_reference_pager_interface.mock.next
+        an_entity_reference_pager.next()
+        method.assert_called_once_with(a_host_session)
+
+
+class Test_EntityReferencePager_hasNext:
+    @pytest.mark.parametrize("expected", (True, False))
+    def test_wraps_the_corresponding_method_of_the_held_interface(
+        self,
+        an_entity_reference_pager,
+        mock_entity_reference_pager_interface,
+        a_host_session,
+        expected,
+    ):
+        method = mock_entity_reference_pager_interface.mock.hasNext
+        method.return_value = expected
+
+        assert an_entity_reference_pager.hasNext() == expected
+        method.assert_called_once_with(a_host_session)
+
+
+class Test_EntityReferencePager_get:
+    @pytest.mark.parametrize(
+        "expected",
+        (
+            [],
+            [EntityReference("first 🌱")],
+            [EntityReference("second 🌿"), EntityReference("third 🌲")],
+        ),
+    )
+    def test_wraps_the_corresponding_method_of_the_held_interface(
+        self,
+        an_entity_reference_pager,
+        mock_entity_reference_pager_interface,
+        a_host_session,
+        expected,
+    ):
+        method = mock_entity_reference_pager_interface.mock.get
+        method.return_value = expected
+
+        assert an_entity_reference_pager.get() == expected
+        method.assert_called_once_with(a_host_session)
+
+
+class FakeEntityReferencePagerInterface(EntityReferencePagerInterface):
+    """
+    Throwaway pager interface def, so we can create a temporary
+    interface intended to fall out of scope.
+
+    See `test_when_EntityReferencePager_holding_interface_loses_scope_then_scope_is_destructed`.
+    """
+
+    def __init__(self):
+        EntityReferencePagerInterface.__init__(self)
+
+    def hasNext(self, hostSession):
+        return False
+
+    def get(self, hostSession):
+        return []
+
+    def next(self, hostSession):
+        pass
+
+
+class Test_EntityReferencePager_destruction:
+    def test_when_EntityReferencePager_holding_interface_loses_scope_then_scope_is_destructed(
+        self, a_host_session
+    ):
+        weak_interface_ref = None
+
+        def makePagerInScope():
+            pagerInterface = FakeEntityReferencePagerInterface()
+
+            nonlocal weak_interface_ref
+            weak_interface_ref = weakref.ref(pagerInterface)
+
+            pager = EntityReferencePager(pagerInterface, a_host_session)
+            del pagerInterface
+            assert weak_interface_ref() is not None
+            # The pager is still in scope until this method exits
+
+        makePagerInScope()
+        # Once method exits, pager falls out of scope, and interface is
+        # destroyed.
+        assert weak_interface_ref() is None
+
+
+@pytest.fixture
+def an_entity_reference_pager(mock_entity_reference_pager_interface, a_host_session):
+    return EntityReferencePager(mock_entity_reference_pager_interface, a_host_session)


### PR DESCRIPTION
## Description
Adds paged GetWithRelationship methods.

Closes #971 

- [x] I have updated the release notes.
- [ ] I have updated all relevant user documentation. (I'm not sure, does this need guide doc?)

## Reviewer Notes
Split into 4 main commits, but will be squashed into 2 (maybe just 1)

This PR introduces a new pattern for PyRetainingSharedPtr in the ManagerInterfaceBinding. This needs to be factored out a bit, or at least docc'd.

We did some C++ testing for the pager object as part of a test-loop workflow. In theory these can be deleted now to fit with our python test philosophy, but I see no need to.

