### PR TITLE
Return `None` when `castToPyObject` a `nullptr`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,10 @@ v1.0.0-alpha.xx
   details.
   [#980](https://github.com/OpenAssetIO/OpenAssetIO/issues/980)
 
+- Updated `castToPyObject` to convert a `nullptr` input to a Python
+  `None`, rather than throwing an exception.
+  [#988](https://github.com/OpenAssetIO/OpenAssetIO/issues/988)
+
 ### Improvements
 
 - Added paged implementations of `getWithRelationship` and
@@ -41,7 +45,6 @@ v1.0.0-alpha.xx
 - Added coverage of the `getWithRelationship[s]` methods of the
   `ManagerInterface` to the `openassetio.manager.test` harness.
   [#914](https://github.com/OpenAssetIO/OpenAssetIO/issues/914)
-
 
 - Added `requireEntityReferenceFixture` and
   `requireEntityReferencesFixture` utility methods for cases written for

--- a/src/openassetio-python/bridge/src/python/converter.cpp
+++ b/src/openassetio-python/bridge/src/python/converter.cpp
@@ -35,12 +35,6 @@ PyObject* castToPyObject(const T& objectPtr) {
   // scope
   const py::error_scope previousErrorState;
 
-  if (objectPtr == nullptr) {
-    throw std::invalid_argument(
-        "Attempting to cast a nullptr objectPtr in "
-        "openassetio::python::converter::castToPyObject");
-  }
-
   py::object pybindObj = py::cast(objectPtr);
 
   // Check to see if the py::cast has spawned a python error


### PR DESCRIPTION
## Description

Closes #988. 

In real-world use cases, it is useful to get a `None` value from an uninitialised `shared_ptr` when passed to `castToPyObject`, rather than that being an error case. E.g. testing whether a manager (`ManagerPtr`) has been created or not.

Note that the converse was already the case, i.e. `castFromPyObject`, when given `None`, would return a `nullptr`, but we didn't have tests for that case (until now).

The behaviour when passing a `nullptr` `PyObject` to `castFromPyObject` has not been changed - we will still throw an exception in that case. This seems reasonable, since the alternative is a segfault.

- [x] I have updated the release notes.
- [ ] ~~I have updated all relevant user documentation.~~
