### PR TITLE
[Core] Add close method to PagerInterface

### DIFF
--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -77,6 +77,7 @@ target_sources(
     src/managerApi/Host.cpp
     src/managerApi/HostSession.cpp
     src/managerApi/ManagerInterface.cpp
+    src/managerApi/EntityReferencePagerInterface.cpp
 )
 
 # Public header dependency.

--- a/src/openassetio-core/include/openassetio/hostApi/EntityReferencePager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/EntityReferencePager.hpp
@@ -82,7 +82,7 @@ class OPENASSETIO_CORE_EXPORT EntityReferencePager final {
   /**
    *  Destruction of this object is tantamount to closing the query.
    */
-  ~EntityReferencePager() = default;
+  ~EntityReferencePager();
 
   /**
    * Return whether or not there is more data accessible by advancing

--- a/src/openassetio-core/include/openassetio/managerApi/EntityReferencePagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/EntityReferencePagerInterface.hpp
@@ -113,6 +113,20 @@ class OPENASSETIO_CORE_EXPORT EntityReferencePagerInterface {
    * return an empty page.
    */
   virtual void next(const HostSessionPtr&) = 0;
+
+  /**
+   * Close the paging query.
+   *
+   * Signals that the host is finished with the paging query,
+   * allowing for any potential cleanup that may need to be performed.
+   * This method is guaranteed to be called only once, and no other
+   * interface methods will be called by the host thereafter.
+   *
+   * This method is called from a destructor. Thrown exceptions will be
+   * caught and logged as errors if possible. Despite that, throwing
+   * from this function is nonetheless discouraged.
+   */
+  virtual void close(const HostSessionPtr& hostSession);
 };
 static_assert(!std::is_copy_constructible_v<EntityReferencePagerInterface>);
 static_assert(!std::is_copy_assignable_v<EntityReferencePagerInterface>);

--- a/src/openassetio-core/src/hostApi/EntityReferencePager.cpp
+++ b/src/openassetio-core/src/hostApi/EntityReferencePager.cpp
@@ -3,7 +3,9 @@
 
 #include <openassetio/EntityReference.hpp>
 #include <openassetio/hostApi/EntityReferencePager.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
+#include <openassetio/managerApi/HostSession.hpp>
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -20,6 +22,17 @@ EntityReferencePager::EntityReferencePager(
     managerApi::EntityReferencePagerInterfacePtr pagerInterface,
     managerApi::HostSessionPtr hostSession)
     : pagerInterface_(std::move(pagerInterface)), hostSession_(std::move(hostSession)) {}
+
+EntityReferencePager::~EntityReferencePager() {
+  try {
+    pagerInterface_->close(hostSession_);
+  } catch (const std::exception& ex) {
+    hostSession_->logger()->error(ex.what());
+  } catch (...) {
+    hostSession_->logger()->error(
+        "Unknown non-exception object caught during destruction of EntityReferencePager");
+  }
+}
 
 bool EntityReferencePager::hasNext() { return pagerInterface_->hasNext(hostSession_); }
 

--- a/src/openassetio-core/src/managerApi/EntityReferencePagerInterface.cpp
+++ b/src/openassetio-core/src/managerApi/EntityReferencePagerInterface.cpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2023 The Foundry Visionmongers Ltd
+#include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace managerApi {
+
+void EntityReferencePagerInterface::close([[maybe_unused]] const HostSessionPtr& hostSession) {}
+}  // namespace managerApi
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-python/cmodule/src/managerApi/EntityReferencePagerInterfaceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/managerApi/EntityReferencePagerInterfaceBinding.cpp
@@ -36,6 +36,10 @@ struct PyEntityReferencePagerInterface : EntityReferencePagerInterface {
   void next(const HostSessionPtr& hostSession) override {
     PYBIND11_OVERRIDE_PURE(void, EntityReferencePagerInterface, next, hostSession);
   }
+
+  void close(const HostSessionPtr& hostSession) override {
+    PYBIND11_OVERRIDE(void, EntityReferencePagerInterface, close, hostSession);
+  }
 };
 
 }  // namespace managerApi
@@ -52,5 +56,6 @@ void registerEntityReferencePagerInterface(const py::module& mod) {
       .def(py::init())
       .def("hasNext", &EntityReferencePagerInterface::hasNext, py::arg("hostSession").none(false))
       .def("get", &EntityReferencePagerInterface::get, py::arg("hostSession").none(false))
-      .def("next", &EntityReferencePagerInterface::next, py::arg("hostSession").none(false));
+      .def("next", &EntityReferencePagerInterface::next, py::arg("hostSession").none(false))
+      .def("close", &EntityReferencePagerInterface::close, py::arg("hostSession").none(false));
 }

--- a/src/openassetio-python/tests/conftest.py
+++ b/src/openassetio-python/tests/conftest.py
@@ -446,6 +446,9 @@ class MockEntityReferencePagerInterface(EntityReferencePagerInterface):
     def next(self, hostSession):
         self.mock.next(hostSession)
 
+    def close(self, hostSession):
+        self.mock.close(hostSession)
+
 
 #
 # Python to C++ migration helpers


### PR DESCRIPTION

## Description
Add `close` method to pager interface, called upon destruction of pager

There were various subtle issues with tying the notification of the end of the page query to the destruction of the pager interface. Aside from relying on lifetime like that not being very pythonic (having to override del,) it creates an implicit usage assumption that the PagerInterface is not declared in a greater scope than the pager. Not to mention that the prior design encourages throwing in destructors moreso than this new one.

Adding a close method binds the cleanup entry hook directly to the lifetime of the Pager, rather than the PagerInterface.
Closes #990

- [x] I have updated the release notes.
~~I have updated all relevant user documentation.~~

## Reviewer Notes

This comes with a single additional test that just checks the method is called after a `del`. Tbh I couldn't think of any further surface that might need testing. Let me know if anything pops to mind.
