### PR TITLE
[Docs] Breaking change release note for `constants` import

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,7 +30,10 @@ v1.0.0-alpha.xx
   module. These have been replaced by domain-specific traits and
   specifications defined in their own repositories, such as
   [OpenAssetIO-MediaCreation](https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation).
-  Migrated remaining constants to C++ with Python bindings
+
+- Migrated remaining constants to C++ with Python bindings. This means
+  that `from openassetio.constants import <name>` no longer works - the
+  `constants` module must be imported wholesale.
   [#998](https://github.com/OpenAssetIO/OpenAssetIO/issues/998)
 
 ### Deprecated


### PR DESCRIPTION
In #998 the `openassetio.constants` pure-Python module was migrated to a CPython submodule (`_openassetio.constants`), which has the unfortunate side-effect of no longer allowing the `import` of individual elements inside the module (i.e. `from constants import <something>`).

So update the release notes to call that out as an additional breaking change.

This was detected (and fixed) in BAL in OpenAssetIO/OpenAssetIO-Manager-BAL#55
