### PR TITLE
[Python] Increase verbosity of API compliance suite

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+---------------
+
+### Improvements
+
+- Increased verbosity when running the `openassetio.test.manager` API
+  compliance suite test harness. The report includes tests that were
+  skipped, helping to detect accidentally omitted fixtures.
+  [1032](https://github.com/OpenAssetIO/OpenAssetIO/pull/1032)
+
 v1.0.0-alpha.13
 ---------------
 

--- a/src/openassetio-python/package/openassetio/test/manager/_implementation.py
+++ b/src/openassetio-python/package/openassetio/test/manager/_implementation.py
@@ -102,7 +102,7 @@ class _ValidatorHarness:
         if extraArgs:
             argv.extend(extraArgs)
         runnerInstance = self.__runner(
-            testLoader=self.__loader, argv=argv, module=module, exit=False
+            testLoader=self.__loader, argv=argv, module=module, exit=False, verbosity=2
         )
         return runnerInstance.result.wasSuccessful()
 


### PR DESCRIPTION
## Description

It's very easy for manager plugin authors to accidentally miss defining a fixture, causing a test to be skipped erroneously. With the default report, it is difficult to discern which tests were skipped.

So increase the verbosity, so that all tests are printed along with their status, including the reason given for skipping a test.

- [x] I have updated the release notes.
- [ ] ~~I have updated all relevant user documentation.~~

## Reviewer Notes

This was highlighted when, on a hunch, I increased verbosity to find that BAL's fixtures file seems to be missing some definitions that should be there (see https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/pull/61). Hopefully permanently increasing verbosity will help prevent this in future.

## Test Instructions

Run the API compliance suite against, say, BAL, and note that all test names are printed alongside their status.
