### PR TITLE
[Docs] Fix Doxygen include path and macro expansion

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,9 @@ v1.0.0-alpha.x
   skipped, helping to detect accidentally omitted fixtures.
   [1032](https://github.com/OpenAssetIO/OpenAssetIO/pull/1032)
 
+- Added some aliases to the Doxygen API documentation. In
+  particular, `Ptr` and `ConstPtr` aliases are now cross-referencable.
+
 v1.0.0-alpha.13
 ---------------
 

--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -2080,7 +2080,9 @@ SEARCH_INCLUDES        = YES
 # preprocessor.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
-INCLUDE_PATH           =
+INCLUDE_PATH           = ../../src/openassetio-core/include \
+                         ../../src/openassetio-core-c/include \
+                         ../../src/openassetio-python/bridge/include
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the
@@ -2109,7 +2111,14 @@ PREDEFINED             = OPENASSETIO_CORE_ABI_VERSION=$(OPENASSETIO_CORE_ABI_VER
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      = OPENASSETIO_NS
+EXPAND_AS_DEFINED      = OPENASSETIO_NS \
+                         OPENASSETIO_DECLARE_PTR \
+                         OPENASSETIO_ALIAS_PTR \
+                         OPENASSETIO_FWD_DECLARE \
+                         OPENASSETIO_FWD_DECLARE_IN_NS \
+                         OPENASSETIO_FWD_DECLARE_TOP_LEVEL_NS \
+                         OPENASSETIO_FWD_DECLARE_ \
+                         OPENASSETIO_PP_EXPAND
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have


### PR DESCRIPTION
Doxygen rendered the `Ptr` types (e.g. `ManagerPtr`, `Manager::Ptr`) as plain text because its preprocessor couldn't find `typedefs.hpp`, where the various macros are defined. Further, those macros were not on the allow-list.

So fix the `INCLUDE_PATH`, and augment the `EXPAND_AS_DEFINED` parameters. This makes the Doxygen output have much richer cross-references.

## Description

Closes # (issue)

- [x] I have updated the release notes.
- [ ] ~~I have updated all relevant user documentation.~~

## Reviewer Notes

I came across this yet again when updating docs for [#1028](https://github.com/OpenAssetIO/OpenAssetIO/issues/1028). The fix is simple enough so I thought worth a cheeky PR.

## Test Instructions

Build the docs locally in `doc/doxygen` by simply typing `make`. Check against the current published docs at https://openassetio.github.io/OpenAssetIO/index.html
