### PR TITLE
[Core] Refine Context.access modes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,20 @@ v1.0.0-alpha.x
 
 ### Breaking changes
 
+- Removed `Context.Access.kWriteMultiple` and
+ `Context.Access.kReadMultiple`access patterns, due to not having
+ coherent use cases.
+ [1016](https://github.com/OpenAssetIO/OpenAssetIO/issues/1016)
+
+### New Features
+
+- Added `Context.Access.kCreateRelated` access pattern, to  indicate
+  when a workflow specifically creates a new entity as a relation to an
+  existing one.
+  [1016](https://github.com/OpenAssetIO/OpenAssetIO/issues/1016)
+
+### Breaking changes
+
 - Removed `cpython` dependency from `conanfile.py`. When building
   OpenAssetIO, it is now expected that a development install of the
   appropriate Python version is discoverable on the system.

--- a/doc/doxygen/src/Glossary.dox
+++ b/doc/doxygen/src/Glossary.dox
@@ -28,8 +28,7 @@
  * single image @ref entity to, so any viable container should be
  * selectable. If it is 'kRead' then the host is wishing to browse for
  * an entity to read, so only existing entities that match the
- * specification should be presented. If 'kWriteMultiple' is specified,
- * then the applicable selections generally changes again.
+ * specification should be presented.
  *
  * The Context also holds an opaque (to the host) data pointer, created
  * by the @ref ManagerInterface, that contains any persistent state its
@@ -448,7 +447,6 @@
  *
  * When publishing existing data, the preflight step is omitted.
  *
- *
  * @section register register
  *
  * The registration mechanism allows for a @ref host to create or update
@@ -456,16 +454,23 @@
  * mutated within the system.
  *
  * It is up to the @ref manager to decide what the registration of new
- * data to an existing entity should mean. The API has no opinion as to
- * whether it is permitted to update in-place, or to require the
- * creation of a new version. The manager should apply its own rules,
- * and return an @ref entity_reference that points to the result of the
- * registration - whether this be a new version, or the same entity that
- * was subject to the registration.
+ * data to an existing entity should mean. The API generally has no
+ * opinion as to whether it is permitted to update in-place, or to
+ * require the creation of a new version. The manager should apply its
+ * own rules, and return an @ref entity_reference that points to the
+ * result of the registration - whether this be a new version, or the
+ * same entity that was subject to the registration.
  *
  * For compound entities, the registration call signifies the completion
  * of the registration of any child entities.
  *
+ * @subsection create_related Create related
+ * Despite the API having no opinion as to the specific reaction of the
+ * manager to registration, there are some occasions, specifically
+ * around the creation of new related entities, where additional
+ * instruction is required from the host. For this purpose, the use of
+ * @fqref{Context.Access.kCreateRelated} "Context.Access.kCreateRelated"
+ * in the context is used as a flag to indicate this intent.
  *
  * @section resolve resolve
  *

--- a/doc/doxygen/src/Thumbnails.dox
+++ b/doc/doxygen/src/Thumbnails.dox
@@ -30,7 +30,9 @@
  *
  * If supported by the host, it will then:
  * - Call @ref preflight with the target entity and the traits from the
- *   @needsref ThumbnailSpecification.
+ *   @needsref ThumbnailSpecification, using the
+     @fqref{Context.Access.kCreateRelated} "Access.kCreateRelated"
+     access mode.
  * - Call @needsref resolve on the returned reference to determine the
  *   desired width/height/format for the thumbnail.
  * - Generate a thumbnail and @ref register it to the same reference.

--- a/src/openassetio-core/include/openassetio/Context.hpp
+++ b/src/openassetio-core/include/openassetio/Context.hpp
@@ -41,10 +41,38 @@ class OPENASSETIO_CORE_EXPORT Context final {
   /**
    * @name Access Pattern
    */
-  enum class Access { kRead, kReadMultiple, kWrite, kWriteMultiple, kUnknown };
+  enum class Access {
+    /**
+     * Host intends to read data. For example, trait property values
+     * obtained via `resolve` may be used to control the loading of data
+     * from a resource, and its subsequent interpretation.
+     */
+    kRead,
+    /**
+     * Host intends to write data.  For example, trait property values
+     * obtained via `resolve` may be used to control the writing of data
+     * to a resource, and specifics of its format or content. During
+     * publishing this must be used whenever the entity reference
+     * explicitly targets the specific entity whose data is being
+     * written. For example creating or updating a simple, unstructured
+     * asset such as an image or other file-based data.
+     */
+    kWrite,
+    /**
+     * Hosts intends to write data for a new entity in relation to
+     * another. During publishing this must be used whenever the entity
+     * reference points to an existing entity, and the intention is to
+     * create a  new, related entity instead of updating the target. For
+     * example, when programmatically creating new  entities under an
+     * existing parent collection, or the publishing of the components
+     * of a structured asset based on a single root entity reference.
+     */
+    kCreateRelated,
+    /// Unknown Access Pattern
+    kUnknown
+  };
 
-  static constexpr std::array kAccessNames{"read", "readMultiple", "write", "writeMultiple",
-                                           "unknown"};
+  static constexpr std::array kAccessNames{"read", "write", "createRelated", "unknown"};
   /// @}
 
   /**
@@ -67,10 +95,12 @@ class OPENASSETIO_CORE_EXPORT Context final {
   /**
    * Describes what the @ref host is intending to do with the data.
    *
-   * For example, when passed to resolve, it specifies if the @ref
-   * host is about to read or write. When configuring a BrowserWidget,
-   * then it will hint as to whether the Host is wanting to choose a
-   * new file name to save, or open an existing one.
+   * For example, when passed to resolve, it specifies if the @ref host
+   * is about to read or write. When configuring a BrowserWidget, then
+   * it will hint as to whether the Host is wanting to choose a new file
+   * name to save, or open an existing one.
+   *
+   * See also @ref create_related "Create related glossary entry".
    */
   Access access;
 
@@ -133,30 +163,17 @@ class OPENASSETIO_CORE_EXPORT Context final {
                                        TraitsDataPtr locale = nullptr,
                                        managerApi::ManagerStateBasePtr managerState = nullptr);
   /**
-   * @return `true` if the context is any of the 'Read' based access
-   * patterns. If the access is unknown (Access::kUnknown), then `false`
-   * is returned.
+   * @return `true` if the context is a 'Read' based access pattern. If
+   * the access is unknown (Access::kUnknown), then `false` is returned.
    */
-  [[nodiscard]] inline bool isForRead() const {
-    return access == Access::kRead || access == Access::kReadMultiple;
-  }
+  [[nodiscard]] inline bool isForRead() const { return access == Access::kRead; }
 
   /**
-   * @return `true` if the context is any of the 'Write' based access
-   * patterns. If the access is unknown (Access::kUnknown), then `false`
-   * is returned.
+   * @return `true` if the context is a 'Write' based access pattern. If
+   * the access is unknown (Access::kUnknown), then `false` is returned.
    */
   [[nodiscard]] inline bool isForWrite() const {
-    return access == Access::kWrite || access == Access::kWriteMultiple;
-  }
-
-  /**
-   * @return `true` if the context is any of the 'Multiple' based access
-   * patterns. If the access is unknown (Access::kUnknown), then `false`
-   * is returned.
-   */
-  [[nodiscard]] inline bool isForMultiple() const {
-    return access == Access::kReadMultiple || access == Access::kWriteMultiple;
+    return access == Access::kWrite || access == Access::kCreateRelated;
   }
 
  private:

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -215,10 +215,12 @@ class OPENASSETIO_CORE_EXPORT Manager {
    *
    *  - The trait set of the entity type in question. This is usually
    *    obtained from the relevant @ref Specification.
-   *  - For read contexts, any additional traits with properties that
-   *    you wish to resolve for that type of entity.
-   *  - For write contexts, any additional traits with properties that
-   *    you wish to publish for that type of entity.
+   *  - For @fqref{Context.Access} "read" contexts, any additional
+   *    traits with properties that you wish to resolve for that type of
+   *    entity.
+   *  - For @fqref{Context.Access} "write" contexts, any additional
+   *    traits with properties that you wish to publish for that type of
+   *    entity.
    *
    * Along with the traits that describe the manager's desired
    * interaction pattern (ones with the `managementPolicy` usage
@@ -1379,13 +1381,12 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * that represents the result of this."
    *
    * It is up to the manager to understand the correct result for the
-   * particular trait set in relation to this reference. For example,
-   * if you received this reference in response to browsing for a
-   * target to `kWriteMultiple` and the traits of a
-   * `ShotSpecification`s, then the Manager should have returned you
-   * a reference that you can then register multiple
-   * `ShotSpecification` entities to without error. Each resulting
-   * entity reference should then reference the newly created Shot.
+   * particular trait set in relation to this reference. For example, if
+   * you received this reference in response to browsing for a target to
+   * `kWrite` and the traits of a `ShotSpecification`, then the Manager
+   * should have returned you a reference that you can then register a
+   * `ShotSpecification` entity to without error. The resulting entity
+   * reference should then reference the newly created Shot.
    *
    * @note All supplied TraitsDatas should have the same trait
    * sets. If you wish to register different "types" of entity, they

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -1140,8 +1140,12 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * "ErrorCodes"). The callback must be called on the same thread that
    * initiated the call to `preflight`. A
    * @fqref{BatchElementError.ErrorCode.kEntityAccessError}
-   * "kEntityAccessError" should be used for any target references that
-   * are conceptually read-only.
+   * "kEntityAccessError" should be used if the access pattern cannot be
+   * adhered to, for example when attempting to write any target
+   * references that are conceptually read-only in response to
+   * @fqref{Context.Access.kWrite} "Access.kWrite", or in response to
+   * @fqref{Context.Access.kCreateRelated} "Access.kCreateRelated" if
+   * creating related entities is not supported.
    *
    * @note it is important for the implementation to pay attention to
    * @fqref{Context.retention} "Context.retention", as not all hosts
@@ -1166,9 +1170,9 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * This instructs the implementation to ensure a valid entity exists
    * for each given reference and to persist the data provided in the
    * @fqref{TraitsData}. This will be called either in isolation or
-   * after calling preflight, depending on whether work needed to be
-   * done to generate the data. Preflight is omitted if the data is already
-   * available at the time of publishing.
+   * after calling preflight, depending on whether there is work needed
+   * to be done to generate the data. Preflight is omitted if the data
+   * is already available at the time of publishing.
    *
    * This call must block until registration is complete for all
    * supplied references, and callbacks have been called on the same

--- a/src/openassetio-python/cmodule/src/ContextBinding.cpp
+++ b/src/openassetio-python/cmodule/src/ContextBinding.cpp
@@ -22,9 +22,8 @@ void registerContext(const py::module& mod) {
 
   py::enum_<Context::Access>{context, "Access"}
       .value("kRead", Context::Access::kRead)
-      .value("kReadMultiple", Context::Access::kReadMultiple)
       .value("kWrite", Context::Access::kWrite)
-      .value("kWriteMultiple", Context::Access::kWriteMultiple)
+      .value("kCreateRelated", Context::Access::kCreateRelated)
       .value("kUnknown", Context::Access::kUnknown);
 
   context.def_readonly_static("kAccessNames", &Context::kAccessNames);
@@ -51,6 +50,5 @@ void registerContext(const py::module& mod) {
             self.managerState = std::move(managerState);
           })
       .def("isForRead", &Context::isForRead)
-      .def("isForWrite", &Context::isForWrite)
-      .def("isForMultiple", &Context::isForMultiple);
+      .def("isForWrite", &Context::isForWrite);
 }

--- a/src/openassetio-python/package/openassetio/managerApi/ManagerInterface.py
+++ b/src/openassetio-python/package/openassetio/managerApi/ManagerInterface.py
@@ -263,7 +263,7 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
         being run in some known environment.
 
         For example, a host may request the default ref for the @ref
-        trait_set of a 'ShotSpecification' with access kWriteMultiple'.
+        trait_set of a 'ShotSpecification' with access 'kWrite'.
         If the Manager has some concept of the 'current sequence' it may
         wish to return this so that a 'Create Shots' action starts
         somewhere meaningful.

--- a/src/openassetio-python/package/openassetio/test/manager/apiComplianceSuite.py
+++ b/src/openassetio-python/package/openassetio/test/manager/apiComplianceSuite.py
@@ -183,14 +183,9 @@ class Test_managementPolicy(FixtureAugmentedTestCase):
         context.access = context.Access.kWrite
         self.__assertPolicyResults(1, context)
 
-    def test_calling_with_read_multiple_context(self):
+    def test_calling_with_createRelated_context(self):
         context = self.createTestContext()
-        context.access = context.Access.kReadMultiple
-        self.__assertPolicyResults(1, context)
-
-    def test_calling_with_write_multiple_context(self):
-        context = self.createTestContext()
-        context.access = context.Access.kWriteMultiple
+        context.access = context.Access.kCreateRelated
         self.__assertPolicyResults(1, context)
 
     def test_calling_with_empty_trait_set_does_not_error(self):

--- a/src/openassetio-python/tests/package/test/manager/test_harness.py
+++ b/src/openassetio-python/tests/package/test/manager/test_harness.py
@@ -159,11 +159,14 @@ class Test_FixtureAugmentedTestCase_createTestContext:
         assert context.locale is a_test_case._locale  # pylint: disable=protected-access
 
     def test_when_supplied_with_access_then_the_context_access_is_set(self, a_test_case):
-        context = a_test_case.createTestContext(Context.Access.kWriteMultiple)
-        assert context.access == Context.Access.kWriteMultiple
+        context = a_test_case.createTestContext(Context.Access.kWrite)
+        assert context.access == Context.Access.kWrite
 
-        context = a_test_case.createTestContext(Context.Access.kReadMultiple)
-        assert context.access == Context.Access.kReadMultiple
+        context = a_test_case.createTestContext(Context.Access.kRead)
+        assert context.access == Context.Access.kRead
+
+        context = a_test_case.createTestContext(Context.Access.kCreateRelated)
+        assert context.access == Context.Access.kCreateRelated
 
 
 class Test_FixtureAugmentedTestCase_assertIsStringKeyPrimitiveValueDict:

--- a/src/openassetio-python/tests/package/test_context.py
+++ b/src/openassetio-python/tests/package/test_context.py
@@ -28,9 +28,8 @@ class Test_Context:
     def test_access_constants_are_unique(self):
         consts = (
             Context.Access.kRead,
-            Context.Access.kReadMultiple,
             Context.Access.kWrite,
-            Context.Access.kWriteMultiple,
+            Context.Access.kCreateRelated,
             Context.Access.kUnknown,
         )
         assert len(set(consts)) == len(consts)
@@ -41,9 +40,8 @@ class Test_Context:
 
     def test_access_names_indices_match_constants(self):
         assert Context.kAccessNames[int(Context.Access.kRead)] == "read"
-        assert Context.kAccessNames[int(Context.Access.kReadMultiple)] == "readMultiple"
         assert Context.kAccessNames[int(Context.Access.kWrite)] == "write"
-        assert Context.kAccessNames[int(Context.Access.kWriteMultiple)] == "writeMultiple"
+        assert Context.kAccessNames[int(Context.Access.kCreateRelated)] == "createRelated"
         assert Context.kAccessNames[int(Context.Access.kUnknown)] == "unknown"
 
     def test_retention_constants_are_not_exported(self):
@@ -78,7 +76,7 @@ class Test_Context_init:
         class TestState(managerApi.ManagerStateBase):
             pass
 
-        expected_access = Context.Access.kReadMultiple
+        expected_access = Context.Access.kRead
         expected_retention = Context.Retention.kSession
         expected_locale = TraitsData()
         expected_state = TestState()
@@ -105,9 +103,8 @@ class Test_Context_access:
     def test_when_set_to_known_value_then_stores_that_value(self, a_context):
         for expected_access in (
             Context.Access.kRead,
-            Context.Access.kReadMultiple,
             Context.Access.kWrite,
-            Context.Access.kWriteMultiple,
+            Context.Access.kCreateRelated,
         ):
             a_context.access = expected_access
             assert a_context.access == expected_access
@@ -185,14 +182,11 @@ class Test_Context_isForRead:
     def test_when_called_with_read_context_then_returns_true(self):
         assert Context(access=Context.Access.kRead).isForRead() is True
 
-    def test_when_called_with_readMultiple_context_then_returns_true(self):
-        assert Context(access=Context.Access.kReadMultiple).isForRead() is True
-
     def test_when_called_with_write_context_then_returns_false(self):
         assert Context(access=Context.Access.kWrite).isForRead() is False
 
-    def test_when_called_with_writeMultiple_context_then_returns_false(self):
-        assert Context(access=Context.Access.kWriteMultiple).isForRead() is False
+    def test_when_called_with_createRelated_context_then_returns_false(self):
+        assert Context(access=Context.Access.kCreateRelated).isForRead() is False
 
     def test_when_called_with_unknown_access_context_then_returns_false(self):
         assert Context(access=Context.Access.kUnknown).isForRead() is False
@@ -202,34 +196,14 @@ class Test_Context_isForWrite:
     def test_when_called_with_write_context_then_returns_true(self):
         assert Context(access=Context.Access.kWrite).isForWrite() is True
 
-    def test_when_called_with_writeMultiple_context_then_returns_true(self):
-        assert Context(access=Context.Access.kWriteMultiple).isForWrite() is True
+    def test_when_called_with_createRelated_context_then_returns_true(self):
+        assert Context(access=Context.Access.kCreateRelated).isForWrite() is True
 
     def test_when_called_with_read_context_then_returns_false(self):
         assert Context(access=Context.Access.kRead).isForWrite() is False
 
-    def test_when_called_with_readMultiple_context_then_returns_false(self):
-        assert Context(access=Context.Access.kReadMultiple).isForWrite() is False
-
     def test_when_called_with_unknown_access_context_then_returns_false(self):
         assert Context(access=Context.Access.kUnknown).isForWrite() is False
-
-
-class Test_Context_isForMultiple:
-    def test_when_called_with_read_context_then_returns_false(self):
-        assert Context(access=Context.Access.kRead).isForMultiple() is False
-
-    def test_when_called_with_readMultiple_context_then_returns_true(self):
-        assert Context(access=Context.Access.kReadMultiple).isForMultiple() is True
-
-    def test_when_called_with_write_context_then_returns_false(self):
-        assert Context(access=Context.Access.kWrite).isForMultiple() is False
-
-    def test_when_called_with_writeMultiple_context_then_returns_true(self):
-        assert Context(access=Context.Access.kWriteMultiple).isForMultiple() is True
-
-    def test_when_called_with_unknown_access_context_then_returns_false(self):
-        assert Context(access=Context.Access.kUnknown).isForMultiple() is False
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description
https://github.com/OpenAssetIO/OpenAssetIO/issues/1016

Adds the `kCreateRelated` context access mode.
This is an access mode necessary to signal intent to create related entities, rather than mutations/versions of an entity. This comes up particularly in the "folder in a folder" case, where it's very likely that the regular method of determining version/new, (checking that the traitsets match,) will not be enough.

Also remove the idea of multiple writes, due to ther being no coherent use for these within the core API methods themselves, and so this behavior could be more accurately and coherently expressed as part of the UI layer itself.

Dosen't close the linked issue, as workflow tests havn't been explored yet. OpenAssetIO api surface has been prioritised, see https://github.com/OpenAssetIO/OpenAssetIO/issues/1016#issuecomment-1670967369

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.