### PR TITLE
[CI] Remove `cpython` dependency

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -46,10 +46,6 @@ jobs:
 
       - name: Bootstrap
         uses: ./.github/bootstrap_platform
-        env:
-          # As we're building wheels inside a managed environment,
-          # (cibuildwheels) there is no need to install cpython.
-          OPENASSETIO_CONAN_SKIP_CPYTHON: "True"
 
       - name: Build wheels
         run: |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,13 @@ Release Notes
 v1.0.0-alpha.x
 ---------------
 
+### Breaking changes
+
+- Removed `cpython` dependency from `conanfile.py`. When building
+  OpenAssetIO, it is now expected that a development install of the
+  appropriate Python version is discoverable on the system.
+  [1038](https://github.com/OpenAssetIO/OpenAssetIO/pull/1038)
+
 ### Improvements
 
 - Increased verbosity when running the `openassetio.test.manager` API

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -62,11 +62,8 @@ See [Building](#building) for more information.
 >
 > On macOS, by default, CMake prefers Framework installations
 > (see: [$CMAKE_FIND_FRAMEWORK](https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_FRAMEWORK.html)).
-> This means dependencies such as Python may default to the system
-> installation despite alternatives being present. In addition, if you
-> are attempting to use the ConanCenter cpython package as an
-> alternative, we have encountered missing header issues that may
-> require additional work/configuration to resolve.
+> This means dependencies may default to the system installation despite
+> alternatives being present.
 
 ## Building
 
@@ -106,7 +103,9 @@ cmake --install build
 >
 > This installs OpenAssetIO's dependencies as described in
 > `/resources/build/conanfile.py`, and allows CMake to deduce the
-> locations via referencing the generated `conan_paths.cmake`.
+> locations via referencing the generated `conan_paths.cmake`. Note that
+> this does not include a development install of Python, which should
+> be provided by other means.
 
 The artifacts are installed to `/build/dist`. This default location can
 be overridden by setting `CMAKE_INSTALL_PREFIX` prior to build.

--- a/resources/build/bootstrap-cibuildwheel-manylinux-2014.sh
+++ b/resources/build/bootstrap-cibuildwheel-manylinux-2014.sh
@@ -26,6 +26,5 @@ conan profile update settings.compiler.libcxx=libstdc++ default
 conan config set general.revisions_enabled=True
 # Install openassetio third-party dependencies from public Conan Center
 # package repo.
-export OPENASSETIO_CONAN_SKIP_CPYTHON="True"
 conan install --install-folder ".conan" --build=missing \
     "resources/build"

--- a/resources/build/conanfile.py
+++ b/resources/build/conanfile.py
@@ -8,9 +8,7 @@ class OpenAssetIOConan(ConanFile):
     # which augments package search paths with conan package
     # directories.
     # TODO(DF): This is deprecated and should be swapped for the
-    # CMakeToolchain generator, but that is not yet compatible with the
-    # cpython recipe (it does not specify `builddirs` so is not added to
-    # the CMAKE_PREFIX_PATH).
+    # CMakeToolchain generator.
     generators = "cmake_paths"
 
     def generate(self):
@@ -35,10 +33,6 @@ class OpenAssetIOConan(ConanFile):
 
     def requirements(self):
         # CY2022
-        if not tools.get_env("OPENASSETIO_CONAN_SKIP_CPYTHON", False):
-            self.requires("cpython/3.9.7")
-            # Pin recipe as latest not compatible with Conan 1.59
-            self.requires("ncurses/6.2@#54f100a8e4a94700d4123ed31420506c")
         self.requires("pybind11/2.10.1")
         # TOML library
         self.requires("tomlplusplus/3.2.0")
@@ -46,15 +40,3 @@ class OpenAssetIOConan(ConanFile):
         self.requires("catch2/2.13.8")
         # Mocking library
         self.requires("trompeloeil/42")
-
-    def configure(self):
-        if self.settings.os == "Windows":
-            # Without the following, ConanCenter's `cpython` package
-            # doesn't get installed with all artifacts on Windows, e.g.
-            # `python -m venv` doesn't work. See:
-            # https://github.com/conan-io/conan-center-index/issues/9333
-            # However, with the following, the package's bundled Python
-            # interpreter doesn't work on Linux because it cannot find
-            # libpython (RPATH issue). So we must make this conditional
-            # on the OS.
-            self.options["cpython"].shared = True


### PR DESCRIPTION
## Description

Closes #977 

Conflicting libuuid pacakges are in the build dependency tree for cpython at this time, causing our CI to fail. So just remove cpython.

See failure here: https://github.com/elliotcmorris/OpenAssetIO/actions/runs/5820687754/job/15781579400?pr=29
To be fixed in the `cpython` recipe upstream (eventually) here: https://github.com/conan-io/conan-center-index/pull/18558

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.

## Reviewer Notes

Need to check dependent projects that build OpenAssetIO from source.
