### PR TITLE
[Core] Migrate `updateTerminology` to C++

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,6 +31,11 @@ v1.0.0-alpha.x
   Python bindings, and redesigned to use a callback based batch API.
   [#993](https://github.com/OpenAssetIO/OpenAssetIO/issues/993)
 
+- Migrated `ManagerInterface`/`Manager` `updateTerminology` to C++ with
+  Python bindings. Tweaked interface to be returned based rather than
+  out-param based.
+  [#996](https://github.com/OpenAssetIO/OpenAssetIO/issues/996)
+
 ### New Features
 
 - Added `Context.Access.kCreateRelated` access pattern, to  indicate

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2023 The Foundry Visionmongers Ltd
 #pragma once
 
 #include <functional>
@@ -115,6 +115,32 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * openassetio.constants.kInfoKey_EntityReferencesMatchPrefix.
    */
   [[nodiscard]] InfoDictionary info() const;
+
+  /**
+   * This call gives the Manager a chance to customize certain strings
+   * that you might want to use in your UI/messages.
+   *
+   * See @ref openassetio.hostApi.terminology "terminology" for
+   * well-known keys. These keys are updated in-place to the most
+   * appropriate term for the Manager. You should then use these
+   * substitutions in any user-facing messages or display text so that
+   * they feel at home.
+   *
+   * It's rare that you need to call this method directly, the @ref
+   * openassetio.hostApi.terminology API provides more utility for far
+   * less effort.
+   *
+   * @see @ref openassetio.hostApi.terminology "terminology"
+   * @see @ref openassetio.hostApi.terminology.Mapper.replaceTerms
+   * "Mapper.replaceTerms"
+   * @see @ref openassetio.hostApi.terminology.defaultTerminology
+   * "terminology.defaultTerminology"
+   *
+   * @param terms Map of terms to be substituted by the manager.
+   *
+   * @return Substituted map of terms.
+   */
+  StrMap updateTerminology(StrMap terms) const;
 
   /**
    * @}
@@ -1141,7 +1167,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * @note The term '@ref publish' is somewhat loaded. It generally
    * means something different depending on who you are talking to. See
    * the @ref publish "Glossary entry" for more on this, but to help
-   * avoid confusion, this API provides the @needsref updateTerminology
+   * avoid confusion, this API provides the @ref updateTerminology
    * call, in order to allow the Manager to standardize some of the
    * language and terminology used in your presentation of the asset
    * management system with other integrations of the system.

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2023 The Foundry Visionmongers Ltd
 
 #pragma once
 
@@ -143,7 +143,7 @@ OPENASSETIO_DECLARE_PTR(ManagerInterface)
  *    @li @ref identifier()
  *    @li @ref displayName()
  *    @li @ref info()
- *    @li @needsref updateTerminology()
+ *    @li @ref updateTerminology()
  *    @li @ref settings()
  *
  * @todo Finish/Document settings mechanism.
@@ -244,6 +244,33 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
   [[nodiscard]] virtual InfoDictionary info() const;
 
   /**
+   * This call gives the manager a chance to customize certain strings
+   * used in a host's UI/messages.
+   *
+   * See @ref openassetio.hostApi.terminology "terminology" for known
+   * keys. The values in stringDict can be freely updated to match the
+   * terminology of the asset management system you are representing.
+   *
+   * For example, you may way a host's "Publish Clip" menu item to read
+   * "Release Clip", so you would set the @ref
+   * openassetio.hostApi.terminology.kTerm_Publish value to "Release".
+   *
+   * @see @ref openassetio.hostApi.terminology.defaultTerminology
+   * "terminology.defaultTerminology"
+   *
+   * @param terms Map of terms to be substituted by the manager.
+   *
+   * @param hostSession The host session that maps to the caller. This
+   * should be used for all logging and provides access to the
+   * openassetio.managerApi.Host object representing the process that
+   * initiated the API session.
+   *
+   * @return Substituted map of terms.
+   */
+  [[nodiscard]] virtual StrMap updateTerminology(StrMap terms,
+                                                 const HostSessionPtr& hostSession) const;
+
+  /**
    * @}
    */
 
@@ -295,7 +322,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *  @li @ref identifier()
    *  @li @ref displayName()
    *  @li @ref info()
-   *  @li @needsref updateTerminology()
+   *  @li @ref updateTerminology()
    *  @li @ref settings()
    *
    * @todo We need a 'teardown' method to, before a manager is
@@ -1120,7 +1147,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * @note The term '@ref publish' is somewhat loaded. It generally
    * means something different depending on who you are talking to. See
    * the @ref publish "Glossary entry" for more on this, but to help
-   * avoid confusion, this API provides the @needsref updateTerminology
+   * avoid confusion, this API provides the @ref updateTerminology
    * call, in order to allow the implementation to standardize some of
    * the language and terminology used in a Hosts presentation of the
    * asset management system with other integrations of the system.

--- a/src/openassetio-core/include/openassetio/typedefs.hpp
+++ b/src/openassetio-core/include/openassetio/typedefs.hpp
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2023 The Foundry Visionmongers Ltd
 #pragma once
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -47,6 +48,11 @@ using Float = double;
  * This type is guaranteed to be API compatible with `std::string`.
  */
 using Str = std::string;
+
+/**
+ * Map/Dict of string to string.
+ */
+using StrMap = std::unordered_map<Str, Str>;
 
 /**
  * @}

--- a/src/openassetio-core/src/hostApi/Manager.cpp
+++ b/src/openassetio-core/src/hostApi/Manager.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2023 The Foundry Visionmongers Ltd
 #include <stdexcept>
 #include <utility>
 
@@ -84,6 +84,10 @@ Identifier Manager::identifier() const { return managerInterface_->identifier();
 Str Manager::displayName() const { return managerInterface_->displayName(); }
 
 InfoDictionary Manager::info() const { return managerInterface_->info(); }
+
+StrMap Manager::updateTerminology(StrMap terms) const {
+  return managerInterface_->updateTerminology(std::move(terms), hostSession_);
+}
 
 InfoDictionary Manager::settings() const { return managerInterface_->settings(hostSession_); }
 

--- a/src/openassetio-core/src/managerApi/ManagerInterface.cpp
+++ b/src/openassetio-core/src/managerApi/ManagerInterface.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2023 The Foundry Visionmongers Ltd
 #include <stdexcept>
 
 #include <openassetio/TraitsData.hpp>
@@ -14,6 +14,11 @@ namespace managerApi {
 ManagerInterface::ManagerInterface() = default;
 
 InfoDictionary ManagerInterface::info() const { return {}; }
+
+StrMap ManagerInterface::updateTerminology(
+    StrMap terms, [[maybe_unused]] const HostSessionPtr& hostSession) const {
+  return terms;
+}
 
 InfoDictionary ManagerInterface::settings(
     [[maybe_unused]] const HostSessionPtr& hostSession) const {

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2023 The Foundry Visionmongers Ltd
 #include <algorithm>
 
 #include <pybind11/functional.h>
@@ -84,6 +84,7 @@ void registerManager(const py::module& mod) {
            py::arg("entityReferenceString"))
       .def("entityExists", &Manager::entityExists, py::arg("entityReferences"),
            py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"))
+      .def("updateTerminology", &Manager::updateTerminology, py::arg("terms"))
       .def("resolve",
            static_cast<void (Manager::*)(
                const EntityReferences&, const trait::TraitSet&, const ContextConstPtr&,

--- a/src/openassetio-python/cmodule/src/managerApi/ManagerInterfaceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/managerApi/ManagerInterfaceBinding.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2023 The Foundry Visionmongers Ltd
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
@@ -94,6 +94,11 @@ struct PyManagerInterface : ManagerInterface {
                     const BatchElementErrorCallback& errorCallback) override {
     PYBIND11_OVERRIDE_PURE(void, ManagerInterface, entityExists, entityReferences, context,
                            hostSession, successCallback, errorCallback);
+  }
+
+  [[nodiscard]] StrMap updateTerminology(StrMap terms,
+                                         const HostSessionPtr& hostSession) const override {
+    PYBIND11_OVERRIDE(StrMap, ManagerInterface, updateTerminology, std::move(terms), hostSession);
   }
 
   void resolve(const EntityReferences& entityReferences, const trait::TraitSet& traitSet,
@@ -213,6 +218,8 @@ void registerManagerInterface(const py::module& mod) {
       .def("entityExists", &ManagerInterface::entityExists, py::arg("entityReferences"),
            py::arg("context").none(false), py::arg("hostSession").none(false),
            py::arg("successCallback"), py::arg("errorCallback"))
+      .def("updateTerminology", &ManagerInterface::updateTerminology, py::arg("terms"),
+           py::arg("hostSession").none(false))
       .def("resolve", &ManagerInterface::resolve, py::arg("entityReferences"), py::arg("traitSet"),
            py::arg("context").none(false), py::arg("hostSession").none(false),
            py::arg("successCallback"), py::arg("errorCallback"))

--- a/src/openassetio-python/package/openassetio/hostApi/Manager.py
+++ b/src/openassetio-python/package/openassetio/hostApi/Manager.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#   Copyright 2013-2023 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -91,49 +91,6 @@ class Manager(_openassetio.hostApi.Manager, Debuggable):
 
     def _interface(self):
         return self.__impl
-
-    ##
-    # @name Asset Management System Information
-    #
-    # These functions provide general information about the @ref
-    # asset_management_system itself. These can all be called before
-    # @needsref initialize has been called.
-    #
-    # @{
-
-    @debugApiCall
-    @auditApiCall("Manager methods")
-    def updateTerminology(self, stringDict):
-        """
-        This call gives the Manager a chance to customize certain
-        strings that you might want to use in your UI/messages.
-
-        See @ref openassetio.hostApi.terminology "terminology" for
-        well-known keys. These keys are updated in-place to the most
-        appropriate term for the Manager. You should then use these
-        substitutions in any user-facing messages or display text so
-        that they feel at home.
-
-        It's rare that you need to call this method directly, the @ref
-        openassetio.hostApi.terminology API provides more utility for
-        far less effort.
-
-        @see @ref openassetio.hostApi.terminology "terminology"
-        @see @ref openassetio.hostApi.terminology.Mapper.replaceTerms "Mapper.replaceTerms"
-        @see @ref openassetio.hostApi.terminology.defaultTerminology "terminology.defaultTerminology"
-
-        @param[out] stringDict `Dict[str, str]` Dictionary that is
-        modified in-place by the manager if it has any alternate
-        terminology.
-
-        @unstable
-        """
-        self.__impl.updateTerminology(stringDict, self.__hostSession)
-        # This is purely so we can see it in the debug log, the
-        # return value of this function should be discarded.
-        return stringDict
-
-    ## @}
 
     ##
     # @name Entity Retrieval

--- a/src/openassetio-python/package/openassetio/managerApi/ManagerInterface.py
+++ b/src/openassetio-python/package/openassetio/managerApi/ManagerInterface.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#   Copyright 2013-2023 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -151,7 +151,7 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
        @li @needsref identifier()
        @li @needsref displayName()
        @li @needsref info()
-       @li @ref updateTerminology()
+       @li @needsref updateTerminology()
        @li @needsref settings()
 
     @todo Finish/Document settings mechanism.
@@ -159,38 +159,6 @@ class ManagerInterface(_openassetio.managerApi.ManagerInterface):
     """
 
     __metaclass__ = abc.ABCMeta
-
-    ##
-    # @name Asset Management System Information
-    #
-    # These functions provide hosts with general information about the @ref
-    # asset_management_system itself.
-    #
-    # @{
-
-    def updateTerminology(self, stringDict, hostSession):
-        """
-        This call gives the manager a chance to customize certain
-        strings used in a host's UI/messages.
-
-        See @ref openassetio.hostApi.terminology "terminology" for known
-        keys. The values in stringDict can be freely updated to match
-        the terminology of the asset management system you are
-        representing.
-
-        For example, you may way a host's "Publish Clip" menu item to
-        read "Release Clip", so you would set the @ref openassetio.hostApi.terminology.kTerm_Publish
-        value to "Release".
-
-        @return `None`
-
-        @see @ref openassetio.hostApi.terminology.defaultTerminology
-        "terminology.defaultTerminology"
-
-        @unstable
-        """
-
-    ## @}
 
     ##
     # @name Entity Reference Resolution

--- a/src/openassetio-python/package/openassetio/test/manager/apiComplianceSuite.py
+++ b/src/openassetio-python/package/openassetio/test/manager/apiComplianceSuite.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#   Copyright 2013-2023 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -87,6 +87,17 @@ class Test_info(FixtureAugmentedTestCase):
 
     def test_matches_fixture(self):
         self.assertEqual(self._fixtures["info"], self._manager.info())
+
+
+class Test_updateTerminology(FixtureAugmentedTestCase):
+    """
+    Check plugin's implementation of managerApi.ManagerInterface.updateTerminology.
+    """
+
+    def test_output_contains_input_terms(self):
+        terms = {"aTermKey🔥 ": "aTermValue🎖️", "aSecondTermKey": "aSecondTermValue"}
+        return_terms = self._manager.updateTerminology(terms)
+        self.assertEqual(sorted(terms.keys()), sorted(return_terms.keys()))
 
 
 class Test_settings(FixtureAugmentedTestCase):

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#   Copyright 2013-2023 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -157,17 +157,29 @@ class Test_Manager_info:
 
 
 class Test_Manager_updateTerminology:
-    def test_method_defined_in_python(self, method_introspector):
-        assert method_introspector.is_defined_in_python(Manager.updateTerminology)
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(Manager.updateTerminology)
         assert method_introspector.is_implemented_once(Manager, "updateTerminology")
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
         self, manager, mock_manager_interface, a_host_session
     ):
+        a_dict = {"k": "v"}
         method = mock_manager_interface.mock.updateTerminology
-        a_dict = {"k", "v"}
-        assert manager.updateTerminology(a_dict) is a_dict
+        method.return_value = a_dict
+
+        ret = manager.updateTerminology(a_dict)
+        assert ret == a_dict
+        assert ret is not a_dict
         method.assert_called_once_with(a_dict, a_host_session)
+
+    def test_input_not_modified(self, manager, mock_manager_interface, a_host_session):
+        input_dict = {"k": "v"}
+        method = mock_manager_interface.mock.updateTerminology
+        method.return_value = {"k": "v", "l": "b"}
+
+        ret = manager.updateTerminology(input_dict)
+        assert input_dict == {"k": "v"}
 
 
 class Test_Manager_settings:

--- a/src/openassetio-python/tests/package/managerApi/test_managerinterface.py
+++ b/src/openassetio-python/tests/package/managerApi/test_managerinterface.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#   Copyright 2013-2023 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -69,6 +69,18 @@ class Test_ManagerInterface_info:
 
         assert isinstance(info, dict)
         assert info == {}
+
+
+class Test_ManagerInterface_updateTerminology:
+    def test_method_defined_in_cpp(self, method_introspector):
+        assert not method_introspector.is_defined_in_python(ManagerInterface.updateTerminology)
+        assert method_introspector.is_implemented_once(ManagerInterface, "updateTerminology")
+
+    def test_when_given_dict_then_returns_same_dict(self, a_host_session):
+        terms = {"aTermKey🔥 ": "aTermValue🎖️", "aSecondTermKey": "aSecondTermValue"}
+        return_terms = ManagerInterface().updateTerminology(terms, a_host_session)
+        assert terms == return_terms
+        assert terms is not return_terms
 
 
 class Test_ManagerInterface_flushCaches:


### PR DESCRIPTION
Closes #996

Migrate the `updateTerminology` method to C++.
No behaviour changes, although interface updated from an in-out arg to a pass-by-value return-by-value formulation, in order to sidestep any python shenanigans with object references.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.