### PR TITLE
[CI] Add ARM wheels for macOS

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -67,8 +67,10 @@ jobs:
           # single failing python version won't interrupt every other
           # deploy on that platform.
           CIBW_BUILD: ${{ matrix.python-build }}
-          CIBW_SKIP: '*musllinux* *arm64*'
+          CIBW_SKIP: '*musllinux*'
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
           PIP_VERBOSE: 1
           # Required as we make use of c++17 features
           MACOSX_DEPLOYMENT_TARGET: 10.15

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+---------------
+
+### New Features
+
+- Added ARM architecture python wheels on the macOS platform to support
+apple silicon.
+[#718](https://github.com/OpenAssetIO/OpenAssetIO/issues/718)
+
 v1.0.0-alpha.14
 ---------------
 


### PR DESCRIPTION
Link to wheels produced by this PR : https://github.com/OpenAssetIO/OpenAssetIO/suites/15780548391/artifacts/900573934

## Description
Consider this more of a proposal. It's a quick and easy fix to get silicon wheels, but there are some caveats, that might take work to investigate. Again, see below.

CIBuildWheels allows cross compilation to ARM on mac platforms, even from an x86_64 host, very clever indeed.
To enable this you need to specify the archs explicitly, which this PR does. This should allow our apple silicon users to not have to go fiddling with override arch settings when they want to use OpenAssetIO.

The "normal" way of doing this would be as we had it setup (without the exception of course), but on a arm machine, but github only supports self hosted runners for those. (At least for now, hosted silicon runners are expected later this year).

We could also consider doing this for ubuntu, as cibuildwheels lets you do a build under emulation (using QEMU), but I fear this will be extremely slow. Worth considering though.

Closes #718

- [x] I have updated the release notes.
- [ ] I have updated all relevant user documentation.


## Why is this in draft?

This was a quick friday afternoon thing so there's some diligence to be done when/if we move forward.
- There's maybe a discussion to be had about also enabling ubuntu/windows arm, or doing a very quick spike to see the performance implications (for ubuntu especially it uses QEMU to do this.)
- Cross-compiled arm wheels cant be tested normally (yet), so we'd wanna consider that. Would be good to at least test the wheel on a silicon device before shipping it, and then we run into all the problems of having access to a silicon device and that nonsense...
From the logs: 
> Warning: While arm64 wheels can be built on x86_64, they cannot be tested. The ability to test the arm64 wheels will be added in a future release of cibuildwheel, once Apple Silicon CI runners are widely available. To silence this warning, set `CIBW_TEST_SKIP: *-macosx_arm64`.
- It looks like cibuildwheels dosen't support cross-compilation for python3.7. Although i'm deducing that just from the fact that we don't get a wheel for 3.7, and that the cibuildwheel changelog mentions adding support for _3.8_ but never mentions 3.7.
