### PR TITLE
Add fmtlib dependency

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,10 @@ v1.0.0-alpha.xx
   `hasTrait`/`isImbuedTo` checks.
   [#970](https://github.com/OpenAssetIO/OpenAssetIO/issues/970)
 
+- :hammer: Added [fmt](https://fmt.dev/9.1.0) as a new header-only
+  private dependency.
+  [#1070](https://github.com/OpenAssetIO/OpenAssetIO/issues/1070)
+
 v1.0.0-alpha.14
 ---------------
 

--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -3,6 +3,13 @@
 
 find_package(tomlplusplus REQUIRED)
 
+
+#-----------------------------------------------------------------------
+# String formatting
+
+find_package(fmt REQUIRED)
+
+
 #-----------------------------------------------------------------------
 # Python
 

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -37,6 +37,7 @@ available.
 - [Python 3.7+](https://www.python.org/) (development install)
 - [pybind11](https://pybind11.readthedocs.io/en/stable/) 2.8.1+
 - [toml++](https://marzer.github.io/tomlplusplus/) 3.2.0+
+- [fmt](https://github.com/fmtlib/fmt) 9.1.0
 
 ### Test dependencies
 

--- a/doc/contributing/CODING_STANDARDS.md
+++ b/doc/contributing/CODING_STANDARDS.md
@@ -176,6 +176,19 @@ when binding a C++ `enum class` using pybind, use
 namespaced in the same way as in C++, i.e. not polluting the parent
 namespace.
 
+## String formatting
+
+The project has a (private, header-only) dependency on the
+[fmt](https://fmt.dev/9.1.0) library for efficient string formatting,
+and this should be used by preference over alternative legacy options
+such as `std::stringstream`.
+
+> **Note**
+>
+> Due to a [symbol leakage issue](https://github.com/fmtlib/fmt/issues/3626)
+> in the current latest fmt version v10.1, we recommend (and build/test
+> with) fmt v9.1.
+
 ## C
 
 ### Handles

--- a/resources/build/Dockerfile
+++ b/resources/build/Dockerfile
@@ -16,6 +16,11 @@ RUN cd tomlplusplus && cmake -S . -B build && cmake --build build && cmake --ins
 RUN git clone --branch v42 https://github.com/rollbear/trompeloeil
 RUN cd trompeloeil && cmake -S . -B build && cmake --build build && cmake --install build
 
+# Pull and install fmt
+RUN git clone --branch 9.1.0 https://github.com/fmtlib/fmt
+RUN cd fmt && cmake -S . -B build -DFMT_MASTER_PROJECT=OFF -DFMT_INSTALL=ON && \
+     cmake --build build --parallel && cmake --install build
+
 # Test dependencies
 # Pull and install catch2
 RUN git clone --branch v2.13.10 https://github.com/catchorg/Catch2
@@ -31,6 +36,11 @@ COPY --from=openassetio-dependencies /usr/local/lib64/cmake/tomlplusplus /usr/lo
 COPY --from=openassetio-dependencies /usr/local/include/catch2 /usr/local/include/catch2
 COPY --from=openassetio-dependencies /usr/local/share/Catch2 /usr/local/share/Catch2
 COPY --from=openassetio-dependencies /usr/local/lib64/cmake/Catch2 /usr/local/lib64/cmake/Catch2
+
+# Copy fmt
+COPY --from=openassetio-dependencies /usr/local/include/fmt /usr/local/include/fmt
+COPY --from=openassetio-dependencies /usr/local/lib64/libfmt.a /usr/local/lib64/libfmt.a
+COPY --from=openassetio-dependencies /usr/local/lib64/cmake/fmt /usr/local/lib64/cmake/fmt
 
 # Copy trompeloeil
 # Trompeloeil installs itself into relevent test framework folders, so

--- a/resources/build/Makefile
+++ b/resources/build/Makefile
@@ -11,7 +11,7 @@ default: docker-image
 ##
 
 # This container version mimicks the VFX reference platform versioning.
-CONTAINER_VERSION=2022.1
+CONTAINER_VERSION=2022.2
 CONTAINER_NAME=openassetio-build
 
 ##

--- a/resources/build/conanfile.py
+++ b/resources/build/conanfile.py
@@ -40,3 +40,10 @@ class OpenAssetIOConan(ConanFile):
         self.requires("catch2/2.13.8")
         # Mocking library
         self.requires("trompeloeil/42")
+        # TODO(DF): fmt v10 forcibly exports the symbol for its
+        #  `format_error` exception in GCC, making it not a true private
+        #  dependency. So pin to v9 for now.
+        self.requires("fmt/9.1.0")
+
+    def configure(self):
+        self.options["fmt"].header_only = True

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -90,9 +90,13 @@ target_include_directories(openassetio-core
     # Use includes from install tree for installed lib.
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
-target_link_libraries(openassetio-core
+target_link_libraries(
+    openassetio-core
     PRIVATE
-    $<BUILD_INTERFACE:tomlplusplus::tomlplusplus>)
+    # Header-only private dependencies:
+    $<BUILD_INTERFACE:tomlplusplus::tomlplusplus>
+    $<BUILD_INTERFACE:fmt::fmt-header-only>
+)
 
 #-----------------------------------------------------------------------
 # API export header

--- a/src/openassetio-core/src/hostApi/Manager.cpp
+++ b/src/openassetio-core/src/hostApi/Manager.cpp
@@ -3,6 +3,8 @@
 #include <stdexcept>
 #include <utility>
 
+#include <fmt/format.h>
+
 #include <openassetio/Context.hpp>
 #include <openassetio/TraitsData.hpp>
 #include <openassetio/constants.hpp>
@@ -53,12 +55,11 @@ std::optional<Str> entityReferencePrefixFromInfo(const log::LoggerInterfacePtr &
   if (auto iter = info.find(Str{constants::kInfoKey_EntityReferencesMatchPrefix});
       iter != info.end()) {
     if (const auto *prefixPtr = std::get_if<openassetio::Str>(&iter->second)) {
-      std::string msg = "Entity reference prefix '";
-      msg += *prefixPtr;
-      msg +=
-          "' provided by manager's info() dict. Subsequent calls to isEntityReferenceString will"
-          " use this prefix rather than call the manager's implementation.";
-      logger->debugApi(msg);
+      logger->debugApi(
+          fmt::format("Entity reference prefix '{}' provided by manager's info() dict. Subsequent"
+                      " calls to isEntityReferenceString will use this prefix rather than call the"
+                      " manager's implementation.",
+                      *prefixPtr));
 
       return *prefixPtr;
     }


### PR DESCRIPTION
## Description

Closes #1070.

fmtlib allows for easy, safe string substitution in C++, adding advanced formatting functionality (e.g. rounding), and reducing bloat.

So add as a new private build-only header-only dependency.

Using header-only increases compile times, but subjectively it's not noticeable, and has the benefit of avoiding a possible public library dependency (if OpenAssetIO is built as a static library).

Tweak a single existing, tested, log string to make use of libfmt, to ensure basic usage is validated.

Added to openassetio-build Docker image: https://github.com/OpenAssetIO/OpenAssetIO/pkgs/container/openassetio-build

- [x] I have updated the release notes.
- ~~[ ] I have updated all relevant user documentation.~~

## Reviewer Notes

<!--- Provide any notes to the reviewer that might help them more easily
      understand the changeset. --->

## Test Instructions

<!--- Provide instructions to the reviewer on how to explicitly test
      these changes. --->
