### PR TITLE
[Core] Relax checks in `TraitsData::getTraitProperty`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,18 @@
 Release Notes
 =============
 
+v1.0.0-alpha.xx
+---------------
+
+### Breaking changes
+
+- Attempting to retrieve a trait property with
+  `TraitsData.getTraitProperty` or using trait view classes no longer
+  raises an exception if the trait itself is missing. This simplifies
+  many common access patterns, and can remove the need for
+  `hasTrait`/`isImbuedTo` checks.
+  [#970](https://github.com/OpenAssetIO/OpenAssetIO/issues/970)
+
 v1.0.0-alpha.14
 ---------------
 

--- a/src/openassetio-core/src/TraitsData.cpp
+++ b/src/openassetio-core/src/TraitsData.cpp
@@ -41,14 +41,16 @@ class TraitsData::Impl {
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
   bool getTraitProperty(trait::property::Value* out, const trait::TraitId& traitId,
                         const trait::property::Key& propertyKey) const {
-    // Use `at` deliberately to trigger exception if trait doesn't exist
-    const auto& traitDict = data_.at(traitId);
-
-    const auto& iter = traitDict.find(propertyKey);
-    if (iter == traitDict.end()) {
+    const auto& traitIter = data_.find(traitId);
+    if (traitIter == data_.end()) {
       return false;
     }
-    *out = iter->second;
+    const auto& traitDict = traitIter->second;
+    const auto& propertyIter = traitDict.find(propertyKey);
+    if (propertyIter == traitDict.end()) {
+      return false;
+    }
+    *out = propertyIter->second;
     return true;
   }
 

--- a/src/openassetio-python/tests/package/test_traitsdata.py
+++ b/src/openassetio-python/tests/package/test_traitsdata.py
@@ -123,9 +123,8 @@ class Test_TraitsData_getsetTraitProperty:
         assert new_trait_id in a_traitsdata.traitSet()
         assert a_traitsdata.getTraitProperty(new_trait_id, a_property) == a_value
 
-    def test_when_trait_is_not_found_then_get_raises_IndexError(self, a_traitsdata):
-        with pytest.raises(IndexError):
-            _ = a_traitsdata.getTraitProperty("unknown_trait", "a string")
+    def test_when_trait_is_not_found_then_get_returns_None(self, a_traitsdata):
+        assert a_traitsdata.getTraitProperty("unknown_trait", "a string") is None
 
     def test_when_value_is_not_supported_then_set_raises_TypeError(self, a_traitsdata):
         with pytest.raises(TypeError):


### PR DESCRIPTION
Raising if the trait was missing added significant boilerplate to many common access patterns.

Closes #970

Note: This felt too easy. Im sure I've missed something.