### PR TITLE
[Docs] Switch to inclusive terminology in `Doxyfile`

### DIFF
--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -1340,7 +1340,7 @@ CHM_FILE               =
 HHC_LOCATION           =
 
 # The GENERATE_CHI flag controls if a separate .chi index file is generated
-# (YES) or that it should be included in the master .chm file (NO).
+# (YES) or that it should be included in the main .chm file (NO).
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 


### PR DESCRIPTION
On the whole - we were in pretty reasonable shape. Checked 'black', 'white', 'master' and 'slave'. The remaining references are to either colors, or 'whitespace'.