### PR TITLE
Don't scan Python hoists

### DIFF
--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -796,10 +796,15 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../../src/openassetio-python/package \
-                         ./src \
+ # In the Python world, only include the specific paths to pure-python
+ # implementations. This avoids unhelpful double-listings of the C++
+ # hoists in the class index.
+INPUT                  = ./src \
                          ../../src/openassetio-core/include \
-                         ../../src/openassetio-python/bridge/include
+                         ../../src/openassetio-python/bridge/include \
+                         ../../src/openassetio-python/package/openassetio/hostApi/terminology.py \
+                         ../../src/openassetio-python/package/openassetio/pluginSystem \
+                         ../../src/openassetio-python/package/openassetio/test \
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/doxygen/src/ForHosts.dox
+++ b/doc/doxygen/src/ForHosts.dox
@@ -12,7 +12,7 @@
  *   represent an asset management system.
  *
  * - Hosts interact with an @ref asset_management_system through an
- *   instance of the @ref openassetio.hostApi.Manager "Manager" class.
+ *   instance of the @fqref{hostApi.Manager} "Manager" class.
  *   The @fqref{hostApi.ManagerFactory} "ManagerFactory" class is used
  *   to instantiate this instance for any given manager. The Manager
  *   class wraps the implementation of the API by a specific asset
@@ -38,11 +38,11 @@
  *   considered to be opaque handles by the host, even if they look like
  *   well-formed strings.
  *
- * - Nearly all interactions with a @ref openassetio.hostApi.Manager
- *   "Manager" require an appropriately configured @ref Context. This
- *   tells the @ref asset_management_system about the intended actions
- *   of the host. For example, whether an @ref entity_reference is being
- *   @ref glossary_resolve "resolved" for read or for write.
+ * - Nearly all interactions with a @fqref{hostApi.Manager} "Manager"
+ *   require an appropriately configured @ref Context. This tells the
+ *   @ref asset_management_system about the intended actions of the
+ *   host. For example, whether an @ref entity_reference is being @ref
+ *   glossary_resolve "resolved" for read or for write.
  *
  * - The lifetime of the Context can be carefully managed by the host
  *   to allow the manager to correlate and time-lock disparate API calls.
@@ -82,10 +82,10 @@
  *    - An instance of the custom class derived from
  *      @fqref{hostApi.HostInterface} "HostInterface".
  *    - A `logger` (derived from
- *      @ref openassetio.log.LoggerInterface "LoggerInterface"), for
+ *      @fqref{log.LoggerInterface} "LoggerInterface"), for
  *      simple console logging you can use a
- *      @ref openassetio.log.ConsoleLogger "ConsoleLogger" wrapped
- *      in a @ref openassetio.log.SeverityFilter "SeverityFilter".
+ *      @fqref{log.ConsoleLogger} "ConsoleLogger" wrapped
+ *      in a @fqref{log.SeverityFilter} "SeverityFilter".
  *    - A @fqref{hostApi.ManagerImplementationFactoryInterface}
  *      "ManagerImplementationFactoryInterface" capable of instantiating
  *      managers. In the majority of cases a default-configured @ref

--- a/doc/doxygen/src/ForManagers.dox
+++ b/doc/doxygen/src/ForManagers.dox
@@ -69,10 +69,10 @@
  *   details on this mechanism.
  *
  * - The @ref ManagerInterface implementation will be passed a
- *   @ref openassetio.managerApi.HostSession "HostSession" to the
+ *   @fqref{managerApi.HostSession} "HostSession" to the
  *   majority of API calls. This should be used for *all* logging, and
  *   any generic host queries via the supplied
- *   @ref openassetio.managerApi.Host "Host" object. Managers may wish
+ *   @fqref{managerApi.Host} "Host" object. Managers may wish
  *   to use details of the @ref host obtained from this object to adapt
  *   their behavior if desired.
  *
@@ -220,7 +220,7 @@
  * @see @ref openassetio.pluginSystem.PythonPluginSystemManagerPlugin
  * "PythonPluginSystemManagerPlugin"
  * @see @fqref{Context} "Context"
- * @see @ref openassetio.managerApi.Host "Host"
+ * @see @fqref{managerApi.Host} "Host"
  * @see @needsref ManagerUIDelegate
  * @see @needsref ui.widgets
  */

--- a/doc/doxygen/src/Glossary.dox
+++ b/doc/doxygen/src/Glossary.dox
@@ -193,11 +193,10 @@
  * > asset_management_system.
  *
  * The host itself is made available to a @ref manager "manager's" @ref
- * ManagerInterface via the @ref
- * openassetio.managerApi.HostSession "HostSession" supplied to each API
- * call. This allows the manager to adapt its behavior accordingly (if
- * required), and perform any additional actions it may wish to as part
- * of @ref publish "publishing".
+ * ManagerInterface via the @fqref{managerApi.HostSession} "HostSession"
+ * supplied to each API call. This allows the manager to adapt its
+ * behavior accordingly (if required), and perform any additional
+ * actions it may wish to as part of @ref publish "publishing".
  *
  *
  * @section HostInterface
@@ -208,8 +207,8 @@
  * features of the host into the well-known terms defined by this API.
  *
  * The HostInterface is never used directly by a @ref manager, and is
- * instead accessed through the @ref openassetio.managerApi.Host
- * abstraction, provided by the @ref openassetio.managerApi.HostSession
+ * instead accessed through the @fqref{managerApi.Host} "Host"
+ * abstraction, provided by the @fqref{managerApi.HostSession} "HostSession"
  * passed to the manager's implementation. This allows assorted
  * house-keeping and auditing to be performed by the API middleware.
  *
@@ -241,7 +240,7 @@
  * the well-known terms defined by this API.
  *
  * The ManagerInterface is never used directly by a @ref host, and is
- * instead accessed through the @ref openassetio.hostApi.Manager
+ * instead accessed through the @fqref{hostApi.Manager} "Manager"
  * abstraction. This allows assorted house-keeping and state management
  * to be performed by the API middleware.
  *
@@ -364,7 +363,7 @@
  * derived from the @ref ManagerInterface.
  *
  * A @ref host never uses the ManagerInterface class directly, but instead
- * uses the @ref openassetio.hostApi.Manager "Manager" class. This
+ * uses the @fqref{hostApi.Manager} "Manager" class. This
  * indirection allows sundry house keeping and state management.
  *
  *

--- a/doc/doxygen/src/MainPage.dox
+++ b/doc/doxygen/src/MainPage.dox
@@ -161,8 +161,8 @@
  * @enduml
  *
  * It attempts to show that the API is organized into two main
- * namespaces - the @ref openassetio.hostApi "hostApi" and @ref
- * openassetio.managerApi "managerApi". Within each of these, you will
+ * namespaces - the @fqref{hostApi} "hostApi" and
+ * @fqref{managerApi} "managerApi". Within each of these, you will
  * find the components you need depending on whether you are adopting
  * the API in a @ref host or providing support for a @ref manager
  * through a plugin.

--- a/doc/doxygen/src/ManagerState.dox
+++ b/doc/doxygen/src/ManagerState.dox
@@ -7,7 +7,7 @@
  * held by the caller and supplied to the manager as part of the method
  * signature. This is to allow multi-threaded access to the @ref ManagerInterface
  * and avoid the need for any additional internal state to exist within
- * its implementation. The @ref openassetio.hostApi.Manager "Manager"
+ * its implementation. The @fqref{hostApi.Manager} "Manager"
  * class wraps the interface implementation to help the @ref host
  * with basic session state management.
  *

--- a/src/openassetio-core/include/openassetio/hostApi/HostInterface.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/HostInterface.hpp
@@ -30,7 +30,7 @@ OPENASSETIO_DECLARE_PTR(HostInterface)
  * "ManagerFactory" class upon construction.
  *
  * A @ref manager does not call the HostInterface directly, it is
- * always accessed via the @ref openassetio.managerApi.Host wrapper.
+ * always accessed via the @fqref{managerApi.Host} "Host" wrapper.
  * This allows the API to insert suitable house-keeping and auditing
  * functionality in between.
  *

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -38,7 +38,7 @@ OPENASSETIO_DECLARE_PTR(ManagerInterface)
  * This Interface binds a @ref asset_management_system into
  * OpenAssetIO. It is not called directly by a @ref host, but by the
  * middleware that presents a more object-oriented model of this to
- * the @ref host - namely, the @ref openassetio.hostApi.Manager.
+ * the @ref host - namely, the @fqref{hostApi.Manager} "Manager".
  *
  * It is structured around the following principles:
  *
@@ -93,7 +93,7 @@ OPENASSETIO_DECLARE_PTR(ManagerInterface)
  * kind will be correctly passed across the plug-in C boundary,
  * and re-thrown. Other exceptions should not be used.
  *
- *  @see @ref openassetio.errors "errors"
+ *  @see @fqref{errors} "errors"
  *
  * Threading
  * ---------
@@ -120,14 +120,14 @@ OPENASSETIO_DECLARE_PTR(ManagerInterface)
  * -----
  *
  * Sometimes you may need to know more information about the API host.
- * A @ref openassetio.managerApi.Host object is available through the
- * @ref openassetio.managerApi.HostSession object passed to each method
- * of this class. This provides a standardised interface that all API
- * hosts guarantee to implement. This can be used to identify exactly
- * which host you are being called for, and query various entity
+ * A @fqref{managerApi.Host} "Host" object is available through the
+ * @fqref{managerApi.HostSession} "HostSession" object passed to each
+ * method of this class. This provides a standardised interface that all
+ * API hosts guarantee to implement. This can be used to identify
+ * exactly which host you are being called for, and query various entity
  * related specifics of the hosts data model.
  *
- * @see @ref openassetio.managerApi.Host "Host"
+ * @see @fqref{managerApi.Host} "Host"
  *
  * Initialization
  * --------------
@@ -264,7 +264,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * @param hostSession The host session that maps to the caller. This
    * should be used for all logging and provides access to the
-   * openassetio.managerApi.Host object representing the process that
+   * @fqref{managerApi.Host} "Host" object representing the process that
    * initiated the API session.
    *
    * @return Substituted map of terms.

--- a/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystemManagerPlugin.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystemManagerPlugin.py
@@ -76,7 +76,7 @@ class PythonPluginSystemManagerPlugin(PythonPluginSystemPlugin):
         @fqref{managerApi.ManagerInterface} "ManagerInterface".
 
         This is an instance of some class derived from ManagerInterface
-        to be bound to the Host-facing @ref openassetio.hostApi.Manager.
+        to be bound to the Host-facing @fqref{hostApi.Manager} "Manager".
 
         Generally this is only directly called by the @ref
         openassetio.pluginSystem.PythonPluginSystemManagerImplementationFactory.


### PR DESCRIPTION
We were accidentally `@ref`ing Python hoists. This updates those refs, and then removes the hoists from scanning, which cleans up the class index.

Closes #1093 