### PR TITLE
[CI] Re-enable disabled integration tests

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -67,22 +67,21 @@ jobs:
           repository: OpenAssetIO/OpenAssetIO-Manager-BAL
           path: external/BAL
 
-      # Disabled pending https://github.com/OpenAssetIO/OpenAssetIO/issues/997
-      # - name: Test BAL
-      #   run: |
-      #     python -m pip install external/BAL
-      #     # We can't install BAL's requirements.txt as this includes
-      #     # openassetio... we really need to sort
-      #     # https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/72
-      #     python -m pip install openassetio-mediacreation
-      #     python -m pip install -r external/BAL/tests/requirements.txt
-      #     python -m pytest -v external/BAL/tests
-      #
-      #- name: Test Simple Resolver
-      #  run: |
-      #    python -m pytest -v examples/host/simpleResolver
-      #  env:
-      #    OPENASSETIO_PLUGIN_PATH: ${{ github.workspace }}/external/BAL/plugin
+      - name: Test BAL
+        run: |
+          python -m pip install external/BAL
+          # We can't install BAL's requirements.txt as this includes
+          # openassetio... we really need to sort
+          # https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/72
+          python -m pip install openassetio-mediacreation
+          python -m pip install -r external/BAL/tests/requirements.txt
+          python -m pytest -v external/BAL/tests
+
+      - name: Test Simple Resolver
+        run: |
+          python -m pytest -v examples/host/simpleResolver
+        env:
+          OPENASSETIO_PLUGIN_PATH: ${{ github.workspace }}/external/BAL/plugin
 
       - name: Checkout TraitGen
         uses: actions/checkout@v4


### PR DESCRIPTION
This reverts commit 0766ded50f4e791e47bca67c956cc1afd65d2700. Re-enable integrations tests now that the exception hierarchy change has been made, and BAL tests work again.

Draft PR due to not working until https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/pull/75 goes in. Just getting this PR ready pre-emptively.