### PR TITLE
Improve `pylint` coverage

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -35,7 +35,7 @@ jobs:
         uses: TheFoundryVisionmongers/fn-pylint-action@v2
         with:
           pylint-args: >
-            --disable=fixme
+            --recursive=y --disable=fixme
             --rcfile=src/openassetio-python/pyproject.toml
             src/openassetio-python/package/openassetio
             src/openassetio-python/tests/package

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -32,11 +32,11 @@ jobs:
           CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/.conan/conan_paths.cmake
 
       - name: Lint
-        uses: TheFoundryVisionmongers/fn-pylint-action@v1.1
+        uses: TheFoundryVisionmongers/fn-pylint-action@v2
         with:
-          pylint-disable: fixme # We track 'todo's through other means
-          pylint-rcfile: src/openassetio-python/pyproject.toml
-          pylint-paths: >
+          pylint-args: >
+            --disable=fixme
+            --rcfile=src/openassetio-python/pyproject.toml
             src/openassetio-python/package/openassetio
             src/openassetio-python/tests/package
 

--- a/resources/build/linter-requirements.txt
+++ b/resources/build/linter-requirements.txt
@@ -1,3 +1,3 @@
 cpplint==1.5.5
 black==22.8.0
-pylint==2.12.2
+pylint==2.17.6

--- a/src/openassetio-python/package/openassetio/__init__.py
+++ b/src/openassetio-python/package/openassetio/__init__.py
@@ -72,7 +72,6 @@ The documentation for OpenAssetIO can be found here:
 """
 
 # pylint: disable=wrong-import-position,import-error
-
 from ._openassetio import (
     constants,
     Context,

--- a/src/openassetio-python/package/openassetio/test/manager/_implementation.py
+++ b/src/openassetio-python/package/openassetio/test/manager/_implementation.py
@@ -193,7 +193,7 @@ class _ValidatorHarnessHostInterface(hostApi.HostInterface):
     @private
     """
 
-    # pylint: disable=missing-function-docstring,no-self-use
+    # pylint: disable=missing-function-docstring
     def identifier(self):
         return "org.openassetio.test.manager.harness"
 

--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -125,6 +125,9 @@ function-rgx = "(_|test_)?[a-z0-9]+([A-Z][a-z0-9]*)*"
 const-rgx = "k([A-Z0-9]+[a-z0-9]*)+_?([A-Z0-9]+[a-z0-9]*)*"
 class-const-rgx = "k([A-Z0-9]+[a-z0-9]*)+_?([A-Z0-9]+[a-z0-9]*)*"
 
+# TODO(DF): Fails on submodules: https://github.com/pylint-dev/pylint/issues/2556
+# extension-pkg-allow-list = ["openassetio._openassetio"]
+
 [tool.pylint.similarities]
 # Ignore imports when computing similarities.
 ignore-imports = true

--- a/src/openassetio-python/tests/package/_core/test_audit.py
+++ b/src/openassetio-python/tests/package/_core/test_audit.py
@@ -26,7 +26,6 @@ import os
 import pytest
 
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name
 # pylint: disable=import-outside-toplevel
 # pylint: disable=missing-class-docstring,missing-function-docstring

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -21,9 +21,9 @@ Tests that cover the openassetio.hostApi.Manager wrapper class.
 # pylint: disable=too-many-lines,too-many-locals
 # pylint: disable=missing-class-docstring,missing-function-docstring
 from unittest import mock
+import re
 
 import pytest
-import re
 
 from openassetio import (
     Context,
@@ -173,7 +173,7 @@ class Test_Manager_updateTerminology:
         method = mock_manager_interface.mock.updateTerminology
         method.return_value = {"k": "v", "l": "b"}
 
-        ret = manager.updateTerminology(input_dict)
+        _ret = manager.updateTerminology(input_dict)
         assert input_dict == {"k": "v"}
 
 
@@ -2792,7 +2792,10 @@ def make_expected_err_msg(batch_element_error, index, access, entityRef):
     error_type_name = batch_element_error_codes_names[
         batch_element_error_codes.index(batch_element_error.code)
     ]
-    return f"{error_type_name}: {batch_element_error.message} [index={index}] [access={kAccessNames[access]}] [entity={entityRef}]"
+    return (
+        f"{error_type_name}: {batch_element_error.message} [index={index}]"
+        f" [access={kAccessNames[access]}] [entity={entityRef}]"
+    )
 
 
 # Conveniences to allow us to paramaterize singular and batch

--- a/src/openassetio-python/tests/package/hostApi/test_managerfactory.py
+++ b/src/openassetio-python/tests/package/hostApi/test_managerfactory.py
@@ -17,7 +17,6 @@
 Tests that cover the openassetio.hostApi.ManagerFactory class.
 """
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 import os

--- a/src/openassetio-python/tests/package/hostApi/test_managerimplementationfactoryinterface.py
+++ b/src/openassetio-python/tests/package/hostApi/test_managerimplementationfactoryinterface.py
@@ -18,7 +18,6 @@ Tests for the default implementations of
 ManagerImplementationFactoryIntreface methods.
 """
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 

--- a/src/openassetio-python/tests/package/hostApi/test_terminology.py
+++ b/src/openassetio-python/tests/package/hostApi/test_terminology.py
@@ -17,7 +17,6 @@
 Tests that cover the openassetio.hostApi.terminology module.
 """
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 

--- a/src/openassetio-python/tests/package/managerApi/test_host.py
+++ b/src/openassetio-python/tests/package/managerApi/test_host.py
@@ -17,7 +17,6 @@
 Tests that cover the openassetio.managerApi.host class.
 """
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 

--- a/src/openassetio-python/tests/package/managerApi/test_hostsession.py
+++ b/src/openassetio-python/tests/package/managerApi/test_hostsession.py
@@ -17,7 +17,6 @@
 Tests that cover the openassetio.managerApi.HostSession class.
 """
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 

--- a/src/openassetio-python/tests/package/managerApi/test_managerinterface.py
+++ b/src/openassetio-python/tests/package/managerApi/test_managerinterface.py
@@ -17,7 +17,6 @@
 Tests for the default implementations of ManagerInterface methods.
 """
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 
@@ -276,7 +275,7 @@ class Test_ManagerInterface_getWithRelationshipPaged:
 
             # The default pager behaviour is to return no data and
             # report no new pages.
-            for idx, x in enumerate(refs):
+            for idx, _ in enumerate(refs):
                 pager = success_callback.call_args_list[idx][0][1]
                 assert_is_default_pager(a_host_session, pager)
 
@@ -315,7 +314,7 @@ class Test_ManagerInterface_getWithRelationshipsPaged:
 
             error_callback.assert_not_called()
 
-            for idx, x in enumerate(rels):
+            for idx, _ in enumerate(rels):
                 pager = success_callback.call_args_list[idx][0][1]
                 assert_is_default_pager(a_host_session, pager)
 
@@ -326,10 +325,10 @@ def assert_is_default_pager(a_host_session, pager):
     # The default pager behaviour is to return no data and
     # report no new pages.
     assert isinstance(pager, EntityReferencePagerInterface)
-    assert pager.hasNext(a_host_session) == False
+    assert pager.hasNext(a_host_session) is False
     assert pager.get(a_host_session) == []
     pager.next(a_host_session)
-    assert pager.hasNext(a_host_session) == False
+    assert pager.hasNext(a_host_session) is False
     assert pager.get(a_host_session) == []
 
 

--- a/src/openassetio-python/tests/package/managerApi/test_managestatebase.py
+++ b/src/openassetio-python/tests/package/managerApi/test_managestatebase.py
@@ -17,7 +17,6 @@
 Tests that cover the openassetio.managerApi.ManagerStateBase class.
 """
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 

--- a/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystem.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystem.py
@@ -17,7 +17,6 @@
 These tests check the functionality of the PythonPluginSystem class.
 """
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 

--- a/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystemmanagerimplementationfactory.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystemmanagerimplementationfactory.py
@@ -18,7 +18,7 @@ These tests check the functionality of the plugin system based
 ManagerImplementationFactoryInterface implementation.
 """
 
-# pylint: disable=no-self-use, unused-argument
+# pylint: disable=unused-argument
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 # pylint: disable=use-implicit-booleaness-not-comparison

--- a/src/openassetio-python/tests/package/test/manager/conftest.py
+++ b/src/openassetio-python/tests/package/test/manager/conftest.py
@@ -25,7 +25,7 @@ from unittest import mock
 
 import pytest
 
-from openassetio import hostApi, EntityReference
+from openassetio import hostApi
 from openassetio.trait import TraitsData
 
 

--- a/src/openassetio-python/tests/package/test/manager/test__implementation.py
+++ b/src/openassetio-python/tests/package/test/manager/test__implementation.py
@@ -17,7 +17,6 @@
 Unit tests for the _implementation module of the manager test harness.
 """
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 # pylint: disable=too-many-arguments,too-few-public-methods
@@ -166,9 +165,10 @@ class Test_Loader_loadTestsFromTestCase:
         test_case_one_locale,
         test_case_two_locale,
     ):
+        # pylint: disable=unused-argument
         # setup
 
-        def create_manager(initialize=True):
+        def create_manager(initialize=True):  # pylint: disable=unused-argument
             return Mock()
 
         manager_create_fn = Mock(wraps=create_manager)
@@ -180,7 +180,7 @@ class Test_Loader_loadTestsFromTestCase:
 
         # action
 
-        suite = loader.loadTestsFromTestCase(mock_test_case_class)
+        _suite = loader.loadTestsFromTestCase(mock_test_case_class)
 
         # confirm
 

--- a/src/openassetio-python/tests/package/test/manager/test_harness.py
+++ b/src/openassetio-python/tests/package/test/manager/test_harness.py
@@ -17,7 +17,6 @@
 Tests for public API of the manager test harness.
 """
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 
@@ -32,7 +31,7 @@ from unittest.case import SkipTest
 import uuid
 import pytest
 
-from openassetio import constants, Context, EntityReference, errors
+from openassetio import constants, EntityReference, errors
 from openassetio.test.manager.harness import (
     executeSuite,
     fixturesFromPyFile,

--- a/src/openassetio-python/tests/package/test/manager/test_main.py
+++ b/src/openassetio-python/tests/package/test/manager/test_main.py
@@ -17,7 +17,6 @@
 Integration tests for CLI operation of the manager test harness.
 """
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 

--- a/src/openassetio-python/tests/package/test_batchelementerror.py
+++ b/src/openassetio-python/tests/package/test_batchelementerror.py
@@ -17,12 +17,12 @@
 Tests for the BatchElementError type.
 """
 
-# pylint: disable=no-self-use, too-few-public-methods
+# pylint: disable=too-few-public-methods
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
+import re
 
 import pytest
-import re
 
 from openassetio.errors import BatchElementError, BatchElementException, OpenAssetIOException
 

--- a/src/openassetio-python/tests/package/test_context.py
+++ b/src/openassetio-python/tests/package/test_context.py
@@ -17,7 +17,7 @@
 Tests that cover the openassetio.Context class.
 """
 
-# pylint: disable=invalid-name,no-self-use,redefined-outer-name
+# pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 import pytest
 

--- a/src/openassetio-python/tests/package/test_entityreference.py
+++ b/src/openassetio-python/tests/package/test_entityreference.py
@@ -17,7 +17,7 @@
 Tests for the EntityReference type.
 """
 
-# pylint: disable=no-self-use, too-few-public-methods
+# pylint: disable=too-few-public-methods
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 

--- a/src/openassetio-python/tests/package/test_imports.py
+++ b/src/openassetio-python/tests/package/test_imports.py
@@ -27,7 +27,6 @@ Cases should be added for any of the following:
 import pytest
 
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name
 # pylint: disable=unused-import,import-outside-toplevel
 # pylint: disable=missing-class-docstring,missing-function-docstring

--- a/src/openassetio-python/tests/package/test_log.py
+++ b/src/openassetio-python/tests/package/test_log.py
@@ -17,7 +17,6 @@
 Tests that cover the openassetio.log module.
 """
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 

--- a/src/openassetio-python/tests/package/test_traitsdata.py
+++ b/src/openassetio-python/tests/package/test_traitsdata.py
@@ -2,7 +2,7 @@
 Tests for the traits data container
 """
 # pylint: disable=invalid-name,missing-class-docstring
-# pylint: disable=redefined-outer-name,no-self-use
+# pylint: disable=redefined-outer-name
 # pylint: disable=missing-function-docstring
 import pytest
 


### PR DESCRIPTION
## Description

Closes #807. The `--recursive` option added in Pylint v2.13.5 allows Pylint to use a directory of test modules that are not structured as a Python package, i.e. it avoids errors like

> No such file or directory: [...] \_\_init\_\_.py

This particular error, frustratingly, does not actually fail the check on CI, so we built up quite a backlog of Pylint warnings in the `tests` directory.

So pin to the latest v2 of Pylint, which supports this feature, and use it in the CI config.

Also fix the backlog of Pylint warnings.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~

## Reviewer Notes

As evidenced by the commits, this change relies on an upstream change to `fn-pylint-action`: https://github.com/TheFoundryVisionmongers/fn-pylint-action/pull/10

See [here](https://github.com/OpenAssetIO/OpenAssetIO/actions/runs/6352847630/job/17256455739) for a recent example showing the problem in CI (expand the "Lint" dropdown).

## Test Instructions

The new version of Pylint can be executed locally as it is used in CI using

```
pylint --disable=I --recursive=y --disable=fixme --rcfile=src/openassetio-python/pyproject.toml src/openassetio-python/package/openassetio src/openassetio-python/tests/package
```
The `--disable=I` disables "info" log messages, which for some reason don't show up in CI.  Maybe something to do with using JSON output, or a stderr vs stdout difference?
