### PR TITLE
Move `TraitsData` into `trait` namespace

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,17 +4,6 @@ Release Notes
 v1.0.0-alpha.xx
 ---------------
 
-### New Features
-
-- Added new exception types, allowing all OpenAssetIO exceptions to
-  share a common base.
-  [#1071](https://github.com/OpenAssetIO/OpenAssetIO/issues/1071)
-
-- Exceptional conveniences now provide additional information such
-  as entityReference, index, access, and error type in the message
-  of the exception.
-  [#1073](https://github.com/OpenAssetIO/OpenAssetIO/issues/1073)
-
 ### Breaking changes
 
 - Attempting to retrieve a trait property with
@@ -49,14 +38,25 @@ v1.0.0-alpha.xx
   an empty optional in the success callback, rather than error.
   [#1100](https://github.com/OpenAssetIO/OpenAssetIO/issues/1100)
 
- - Moved `BatchElementError` and `BatchElementException` into the
+- Moved `BatchElementError` and `BatchElementException` into the
   `errors` namespace.
   [#1071](https://github.com/OpenAssetIO/OpenAssetIO/issues/1071)
   [#1073](https://github.com/OpenAssetIO/OpenAssetIO/issues/1071)
 
-  - Removed all subtypes of `BatchElementException`, in favour of a
+- Removed all subtypes of `BatchElementException`, in favour of a
   single exception type for exceptional type for batch errors in
   exceptional conveniences.
+  [#1073](https://github.com/OpenAssetIO/OpenAssetIO/issues/1073)
+
+### New Features
+
+- Added new exception types, allowing all OpenAssetIO exceptions to
+  share a common base.
+  [#1071](https://github.com/OpenAssetIO/OpenAssetIO/issues/1071)
+
+- Exceptional conveniences now provide additional information such
+  as entityReference, index, access, and error type in the message
+  of the exception.
   [#1073](https://github.com/OpenAssetIO/OpenAssetIO/issues/1073)
 
 ### Improvements

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,13 @@ Release Notes
 v1.0.0-alpha.xx
 ---------------
 
+### Deprecated
+
+- Moved `TraitsData` into the `trait` namespace along with its peer
+  container/type definitions. Aliases in the deprecated top-level
+  namespace will be removed in a future release.
+  [#1127](https://github.com/OpenAssetIO/OpenAssetIO/issues/1127)
+
 ### Breaking changes
 
 - Attempting to retrieve a trait property with

--- a/doc/doxygen/src/ForManagers.dox
+++ b/doc/doxygen/src/ForManagers.dox
@@ -112,8 +112,8 @@
  *   "managementPolicy" to control which Host-side data types you wish
  *   to be involved in managing, and specify which property-holding
  *   traits you are capable of resolving. To request not to be involved
- *   in publishing, return an empty @fqref{TraitsData} "TraitsData"
- *   for any queries with a context with `kWrite` access.
+ *   in publishing, return an empty @fqref{trait.TraitsData}
+ *   "TraitsData" for any queries with a context with `kWrite` access.
  *
  * - Implement the methods grouped under the "Entity Reference Inspection"
  *   and "Entity Reference Resolution" sections of the

--- a/doc/doxygen/src/Glossary.dox
+++ b/doc/doxygen/src/Glossary.dox
@@ -217,7 +217,7 @@
  *
  * Within OpenAssetIO, the term "locale" is used to define which part of
  * a @ref host "host's" implementation is making a particular call to
- * the API. A suitably configured @fqref{TraitsData} "TraitsData"
+ * the API. A suitably configured @fqref{trait.TraitsData} "TraitsData"
  * instance is supplied through the @fqref{Context.locale}
  * "locale" property of the @fqref{Context} "Context", which is in turn
  * supplied to most @ref ManagerInterface method calls.

--- a/examples/manager/SampleAssetManager/python/SampleAssetManager/SampleAssetManagerInterface.py
+++ b/examples/manager/SampleAssetManager/python/SampleAssetManager/SampleAssetManagerInterface.py
@@ -1,0 +1,71 @@
+#
+#   Copyright 2013-2021 [The Foundry Visionmongers Ltd]
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+A single-class module, providing the SampleAssetManagerInterface class.
+
+The manager currently ignores all entity types.
+"""
+
+# Note that it should always be light-weight to construct instances of
+# the this class. See the notes under the "Initialization" section of:
+#   https://openassetio.github.io/OpenAssetIO/classopenassetio_1_1manager_a_p_i_1_1_manager_interface_1_1_manager_interface.html#details (pylint: disable=line-too-long)
+# As such, any expensive module imports should be deferred.
+from openassetio import constants
+from openassetio.managerApi import ManagerInterface
+from openassetio.trait import TraitsData
+
+
+__all__ = [
+    "SampleAssetManagerInterface",
+]
+
+
+# TODO(TC): @pylint-disable
+# As we are building out the implementation vertically, we have known
+# fails for missing abstract methods.
+# pylint: disable=abstract-method
+
+
+class SampleAssetManagerInterface(ManagerInterface):
+    """
+    Binds the SampleAssetManager to the OpenAssetIO ManagerInterface.
+
+    This class contains none of the actual business logic implementing
+    asset management, just bindings to the OpenAssetIO interface
+    methods.
+    """
+
+    def identifier(self):
+        return "org.openassetio.examples.manager.sam"
+
+    def initialize(self, managerSettings, hostSession):
+        pass
+
+    def displayName(self):
+        return "Sample Asset Manager (SAM)"
+
+    def info(self):
+        # This hint allows the API middleware to short-circuit calls to
+        # `isEntityReferenceString` using string prefix comparisons. If
+        # your implementation's entity reference format supports this
+        # kind of matching, you should set this key. It allows for
+        # multi-threaded reference testing in C++ as it avoids the need
+        # to acquire the GIL and enter Python.
+        return {constants.kInfoKey_EntityReferencesMatchPrefix: "sam:///"}
+
+    def managementPolicy(self, traitSets, policyAccess, context, hostSession):
+        # pylint: disable=unused-argument
+        return [TraitsData() for _ in traitSets]

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -65,7 +65,6 @@ target_sources(
     openassetio-core
     PRIVATE
     src/Context.cpp
-    src/TraitsData.cpp
     src/errors/exceptionMessages.cpp
     src/hostApi/HostInterface.cpp
     src/hostApi/Manager.cpp
@@ -79,6 +78,7 @@ target_sources(
     src/managerApi/HostSession.cpp
     src/managerApi/ManagerInterface.cpp
     src/managerApi/EntityReferencePagerInterface.cpp
+    src/trait/TraitsData.cpp
 )
 
 # Public header dependency.

--- a/src/openassetio-core/include/openassetio/Context.hpp
+++ b/src/openassetio-core/include/openassetio/Context.hpp
@@ -8,7 +8,7 @@
 #include <openassetio/export.h>
 #include <openassetio/typedefs.hpp>
 
-OPENASSETIO_FWD_DECLARE(TraitsData)
+OPENASSETIO_FWD_DECLARE(trait, TraitsData)
 OPENASSETIO_FWD_DECLARE(managerApi, ManagerStateBase)
 
 namespace openassetio {
@@ -50,13 +50,13 @@ class OPENASSETIO_CORE_EXPORT Context final {
    * than a 'Write node' from a comp tree could result in different
    * behavior.
    *
-   * The Locale uses a @fqref{TraitsData} "TraitsData" to describe in
+   * The Locale uses a @fqref{trait.TraitsData} "TraitsData" to describe in
    * more detail, what specific part of a @ref host is requesting an
    * action. In the case of a file browser for example, it may also
    * include information such as whether or not multi-selection is
    * required.
    */
-  TraitsDataPtr locale;
+  trait::TraitsDataPtr locale;
 
   /**
    * The opaque state token owned by the @ref manager, used to
@@ -73,11 +73,11 @@ class OPENASSETIO_CORE_EXPORT Context final {
    * @fqref{hostApi.Manager.createContext} "Manager.createContext"
    * should always be used instead.
    */
-  [[nodiscard]] static ContextPtr make(TraitsDataPtr locale = nullptr,
+  [[nodiscard]] static ContextPtr make(trait::TraitsDataPtr locale = nullptr,
                                        managerApi::ManagerStateBasePtr managerState = nullptr);
 
  private:
-  Context(TraitsDataPtr locale, managerApi::ManagerStateBasePtr managerState);
+  Context(trait::TraitsDataPtr locale, managerApi::ManagerStateBasePtr managerState);
 };
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/TraitsData.hpp
+++ b/src/openassetio-core/include/openassetio/TraitsData.hpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#pragma once
+
+// Deprecated: https://github.com/OpenAssetIO/OpenAssetIO/issues/1127
+
+#include <openassetio/trait/TraitsData.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+// 'typedef' allows attributes, 'using' does not
+[[deprecated("Moved to 'trait' namespace")]] typedef trait::TraitsData TraitsData;        // NOLINT
+[[deprecated("Moved to 'trait' namespace")]] typedef trait::TraitsDataPtr TraitsDataPtr;  // NOLINT
+// NOLINTEND
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/errors/BatchElementError.hpp
+++ b/src/openassetio-core/include/openassetio/errors/BatchElementError.hpp
@@ -112,7 +112,7 @@ class BatchElementError final {
 
     /**
      * Error code response from @ref glossary_preflight if the provided
-     * @fqref{TraitsData} "traits data" hint holds insufficient or
+     * @fqref{trait.TraitsData} "traits data" hint holds insufficient or
      * invalid information.
      *
      * This will occur when the manager requires information that the

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -222,10 +222,10 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * you to adapt application logic or user-facing behaviour
    * accordingly.
    *
-   * Queries return a @fqref{TraitsData} "TraitsData" for each supplied
-   * @ref trait_set, imbued with traits that describe the manager's
-   * policy for entities with those traits, and which traits they are
-   * capable of resolving/storing data for.
+   * Queries return a @fqref{trait.TraitsData} "TraitsData" for each
+   * supplied @ref trait_set, imbued with traits that describe the
+   * manager's policy for entities with those traits, and which traits
+   * they are capable of resolving/storing data for.
    *
    * This is an opt-in mechanism, such that if result is empty, then
    * the manager does not handle entities with the supplied traits.
@@ -253,9 +253,10 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    *
    * Along with the traits that describe the manager's desired
    * interaction pattern (ones with the `managementPolicy` usage
-   * metadata), the resulting @fqref{TraitsData} "TraitsData" will be
-   * imbued with (potentially a subset of) the requested traits, which
-   * the manager is capable of resolving/persisting the properties for.
+   * metadata), the resulting @fqref{trait.TraitsData} "TraitsData" will
+   * be imbued with (potentially a subset of) the requested traits,
+   * which the manager is capable of resolving/persisting the properties
+   * for.
    *
    * If a requested trait is not present, then the manager will never
    * return properties for that trait in @ref resolve, or be able to
@@ -271,8 +272,9 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * target="_blank">OpenAssetIO-MediaCreation</a> project provides
    * traits for common data types used in computer graphics and media
    * production. Use the concrete Trait/Specification classes provided
-   * by these projects to retrieve data from the supplied TraitsData
-   * instead of querying directly using string literals.
+   * by these projects to retrieve data from the supplied
+   * trait::TraitsData instead of querying directly using string
+   * literals.
    *
    * @warning The @p policyAccess that is supplied will be considered by
    * the manager. If it is set to read, then its response applies to
@@ -313,7 +315,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    *  Creates a new Context for use with the manager.
    *
    *  The @fqref{Context.locale} "locale" will be initialized with an
-   *  empty @fqref{TraitsData} "TraitsData" instance.
+   *  empty @fqref{trait.TraitsData} "TraitsData" instance.
    *
    *  @warning Contexts should never be directly constructed, always
    *  use this method or @ref createChildContext to create a new one.
@@ -425,7 +427,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
     /**
      * Variant policy overloads, when used in a batch context, will be
      * exhaustive for all elements in the batch, a variant result
-     * containing either a @ref TraitsData or @ref
+     * containing either a @ref trait::TraitsData or @ref
      * errors.BatchElementError will be provided for each @ref
      * EntityReference provided as an argument to the operation.
      */
@@ -622,10 +624,10 @@ class OPENASSETIO_CORE_EXPORT Manager final {
   /**
    * Callback signature used for a successful entity resolution.
    */
-  using ResolveSuccessCallback = std::function<void(std::size_t, TraitsDataPtr)>;
+  using ResolveSuccessCallback = std::function<void(std::size_t, trait::TraitsDataPtr)>;
 
   /**
-   * Provides a @fqref{TraitsData} "TraitsData" populated with the
+   * Provides a @fqref{trait.TraitsData} "TraitsData" populated with the
    * available property data for the requested set of traits for each
    * given @ref entity_reference.
    *
@@ -704,7 +706,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
                const BatchElementErrorCallback& errorCallback);
 
   /**
-   * Provides a @fqref{TraitsData} "TraitsData" populated with the
+   * Provides a @fqref{trait.TraitsData} "TraitsData" populated with the
    * available data for the requested set of traits for the given @ref
    * entity_reference.
    *
@@ -736,13 +738,14 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    *
    * @return Populated data.
    */
-  TraitsDataPtr resolve(const EntityReference& entityReference, const trait::TraitSet& traitSet,
-                        access::ResolveAccess resolveAccess, const ContextConstPtr& context,
-                        const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
+  trait::TraitsDataPtr resolve(const EntityReference& entityReference,
+                               const trait::TraitSet& traitSet,
+                               access::ResolveAccess resolveAccess, const ContextConstPtr& context,
+                               const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
 
   /**
-   * Provides either a populated @fqref{TraitsData} "TraitsData" or a
-   * @fqref{errors.BatchElementError} "BatchElementError".
+   * Provides either a populated @fqref{trait.TraitsData} "TraitsData"
+   * or a @fqref{errors.BatchElementError} "BatchElementError".
    *
    * If successful, the result is populated with the
    * available data for the requested set of traits for the given @ref
@@ -778,13 +781,13 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * @return Object containing either the populated data or an error
    * object.
    */
-  std::variant<errors::BatchElementError, TraitsDataPtr> resolve(
+  std::variant<errors::BatchElementError, trait::TraitsDataPtr> resolve(
       const EntityReference& entityReference, const trait::TraitSet& traitSet,
       access::ResolveAccess resolveAccess, const ContextConstPtr& context,
       const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
 
   /**
-   * Provides a @fqref{TraitsData} "TraitsData" populated with the
+   * Provides a @fqref{trait.TraitsData} "TraitsData" populated with the
    * available data for the requested set of traits for each given @ref
    * entity_reference.
    *
@@ -817,15 +820,15 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    *
    * @return List of populated data objects.
    */
-  std::vector<TraitsDataPtr> resolve(
+  std::vector<trait::TraitsDataPtr> resolve(
       const EntityReferences& entityReferences, const trait::TraitSet& traitSet,
       access::ResolveAccess resolveAccess, const ContextConstPtr& context,
       const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
 
   /**
-   * Provides either a populated @fqref{TraitsData} "TraitsData" or a
-   * @fqref{errors.BatchElementError} "BatchElementError" for each given
-   * @ref entity_reference.
+   * Provides either a populated @fqref{trait.TraitsData} "TraitsData"
+   * or a @fqref{errors.BatchElementError} "BatchElementError" for each
+   * given @ref entity_reference.
    *
    * For successful references, the corresponding element of the result
    * is populated with the available data for the requested set of
@@ -862,7 +865,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * @return List of objects, each containing either the populated data
    * or an error.
    */
-  std::vector<std::variant<errors::BatchElementError, TraitsDataPtr>> resolve(
+  std::vector<std::variant<errors::BatchElementError, trait::TraitsDataPtr>> resolve(
       const EntityReferences& entityReferences, const trait::TraitSet& traitSet,
       access::ResolveAccess resolveAccess, const ContextConstPtr& context,
       const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
@@ -1022,7 +1025,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * handles relationships of that type.
    */
   void getWithRelationship(const EntityReferences& entityReferences,
-                           const TraitsDataPtr& relationshipTraitsData,
+                           const trait::TraitsDataPtr& relationshipTraitsData,
                            access::RelationsAccess relationsAccess, const ContextConstPtr& context,
                            const RelationshipSuccessCallback& successCallback,
                            const BatchElementErrorCallback& errorCallback,
@@ -1135,8 +1138,8 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * @throws errors.InputValidationException if @p pageSize is zero.
    */
   void getWithRelationshipPaged(const EntityReferences& entityReferences,
-                                const TraitsDataPtr& relationshipTraitsData, size_t pageSize,
-                                access::RelationsAccess relationsAccess,
+                                const trait::TraitsDataPtr& relationshipTraitsData,
+                                size_t pageSize, access::RelationsAccess relationsAccess,
                                 const ContextConstPtr& context,
                                 const PagedRelationshipSuccessCallback& successCallback,
                                 const BatchElementErrorCallback& errorCallback,
@@ -1216,8 +1219,8 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * determined is beyond the scope of this layer of the API, and
    * functions exists in higher levels that combine browsing and
    * publishing etc... Here, we simply assert that there must be a
-   * meaningful reference given the @fqref{TraitsData} "TraitsData" of
-   * the entity that is being created or published.
+   * meaningful reference given the @fqref{trait.TraitsData}
+   * "TraitsData" of the entity that is being created or published.
    *
    * @note 'Meaningful' is best defined by the asset manager itself. For
    * example, in a system that versions each 'asset' by creating
@@ -1302,9 +1305,9 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * the Manager may even use this opportunity to switch to some
    * temporary working path or some such.
    *
-   * @note If the supplied @fqref{TraitsData} "trait data" is missing
-   * traits or properties required by the manager for any input entity
-   * reference, then that element will error. See @ref
+   * @note If the supplied @fqref{trait.TraitsData} "trait data" is
+   * missing traits or properties required by the manager for any input
+   * entity reference, then that element will error. See @ref
    * glossary_preflight "glossary entry" for details.
    *
    * @warning The working @ref entity_reference returned by this
@@ -1390,7 +1393,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * the publishing operation
    */
   EntityReference preflight(const EntityReference& entityReference,
-                            const TraitsDataPtr& traitsHint,
+                            const trait::TraitsDataPtr& traitsHint,
                             access::PublishingAccess publishingAccess,
                             const ContextConstPtr& context,
                             const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
@@ -1439,7 +1442,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * entity.
    */
   std::variant<errors::BatchElementError, EntityReference> preflight(
-      const EntityReference& entityReference, const TraitsDataPtr& traitsHint,
+      const EntityReference& entityReference, const trait::TraitsDataPtr& traitsHint,
       access::PublishingAccess publishingAccess, const ContextConstPtr& context,
       const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
 
@@ -1568,7 +1571,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * manager (either in response to delegation of UI/etc... or as a
    * return from another call), then it can be assumed that the
    * Manager will understand what it means for you to call `register`
-   * on this reference with the supplied @fqref{TraitsData}
+   * on this reference with the supplied @fqref{trait.TraitsData}
    * "TraitsData". The conceptual meaning of the call is:
    *
    * "I have this reference you gave me, and I would like to register
@@ -1584,7 +1587,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * `ShotSpecification` entity to without error. The resulting entity
    * reference should then reference the newly created Shot.
    *
-   * @note All supplied TraitsDatas should have the same trait
+   * @note All supplied trait::TraitsDatas should have the same trait
    * sets. If you wish to register different "types" of entity, they
    * need to be registered in separate calls.
    *
@@ -1635,7 +1638,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * Other exceptions may be raised for fatal runtime errors, for
    * example server communication failure.
    *
-   * @see @fqref{TraitsData} "TraitsData"
+   * @see @fqref{trait.TraitsData} "TraitsData"
    * @see @ref preflight
    */
   // NOLINTNEXTLINE(readability-identifier-naming)
@@ -1684,7 +1687,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    */
   // NOLINTNEXTLINE(readability-identifier-naming)
   EntityReference register_(const EntityReference& entityReference,
-                            const TraitsDataPtr& entityTraitsData,
+                            const trait::TraitsDataPtr& entityTraitsData,
                             access::PublishingAccess publishingAccess,
                             const ContextConstPtr& context,
                             const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
@@ -1732,10 +1735,9 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    */
   // NOLINTNEXTLINE(readability-identifier-naming)
   std::variant<errors::BatchElementError, EntityReference> register_(
-      const EntityReference& entityReference, const TraitsDataPtr& entityTraitsData,
+      const EntityReference& entityReference, const trait::TraitsDataPtr& entityTraitsData,
       access::PublishingAccess publishingAccess, const ContextConstPtr& context,
       const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
-
   /**
    * Register should be used to 'publish' new entities either when
    * originating new data within the application process, or

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -377,10 +377,10 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * traits (fear not, there is a simple and established failure mode
    * for this situation).
    *
-   * This method must return a @fqref{TraitsData} "TraitsData" for each
-   * requested @ref trait_set. The implementation of this method should
-   * carefully consider the given @fqref{access.PolicyAccess} "access",
-   * and imbue suitable traits in the result to define:
+   * This method must return a @fqref{trait.TraitsData} "TraitsData" for
+   * each requested @ref trait_set. The implementation of this method
+   * should carefully consider the given @fqref{access.PolicyAccess}
+   * "access", and imbue suitable traits in the result to define:
    *
    *   - Whether and how that kind of entity is managed (traits with the
    *    `managementPolicy` usage metadata)
@@ -716,12 +716,12 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
   /**
    * Callback signature used for a successful entity resolution.
    */
-  using ResolveSuccessCallback = std::function<void(std::size_t, TraitsDataPtr)>;
+  using ResolveSuccessCallback = std::function<void(std::size_t, trait::TraitsDataPtr)>;
 
   /**
-   * Provides the host with a @fqref{TraitsData} "TraitsData" populated
-   * with the available data for the properties of the requested set of
-   * traits for each given @ref entity_reference.
+   * Provides the host with a @fqref{trait.TraitsData} "TraitsData"
+   * populated with the available data for the properties of the
+   * requested set of traits for each given @ref entity_reference.
    *
    * This call should block until all resolutions are complete and
    * callbacks have been called. Callbacks must be called on the
@@ -977,7 +977,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * capable of handling queries for those relationships in this method.
    */
   virtual void getWithRelationship(const EntityReferences& entityReferences,
-                                   const TraitsDataPtr& relationshipTraitsData,
+                                   const trait::TraitsDataPtr& relationshipTraitsData,
                                    const trait::TraitSet& resultTraitSet,
                                    access::RelationsAccess relationsAccess,
                                    const ContextConstPtr& context,
@@ -1109,7 +1109,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * entities should have.
    */
   virtual void getWithRelationshipPaged(const EntityReferences& entityReferences,
-                                        const TraitsDataPtr& relationshipTraitsData,
+                                        const trait::TraitsDataPtr& relationshipTraitsData,
                                         const trait::TraitSet& resultTraitSet, size_t pageSize,
                                         access::RelationsAccess relationsAccess,
                                         const ContextConstPtr& context,
@@ -1279,11 +1279,11 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * supplied references, and callbacks have been called on the same
    * thread that called `preflight`
    *
-   * @warning If the supplied @fqref{TraitsData} "trait data" is missing
-   * required traits for any of the provided references (maybe they are
-   * mismatched with the target entity), or the populated properties are
-   * insufficient or invalid for upcoming @ref resolve for
-   * @fqref{access.ResolveAccess.kWrite} "write" requests or the
+   * @warning If the supplied @fqref{trait.TraitsData} "trait data" is
+   * missing required traits for any of the provided references (maybe
+   * they are mismatched with the target entity), or the populated
+   * properties are insufficient or invalid for upcoming @ref resolve
+   * for @fqref{access.ResolveAccess.kWrite} "write" requests or the
    * eventual @ref register_, then error that element with an
    * appropriate @fqref{errors.BatchElementError.ErrorCode}.
    *
@@ -1358,10 +1358,10 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    *
    * This instructs the implementation to ensure a valid entity exists
    * for each given reference and to persist the data provided in the
-   * @fqref{TraitsData}. This will be called either in isolation or
-   * after calling preflight, depending on whether there is work needed
-   * to be done to generate the data. Preflight is omitted if the data
-   * is already available at the time of publishing.
+   * @fqref{trait.TraitsData}. This will be called either in isolation
+   * or after calling preflight, depending on whether there is work
+   * needed to be done to generate the data. Preflight is omitted if the
+   * data is already available at the time of publishing.
    *
    * This call must block until registration is complete for all
    * supplied references, and callbacks have been called on the same
@@ -1439,7 +1439,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * callback must be called on the same thread that initiated the call
    * to `register`.
    *
-   * @see @fqref{TraitsData} "TraitsData"
+   * @see @fqref{trait.TraitsData} "TraitsData"
    * @see @ref preflight
    */
   // NOLINTNEXTLINE(readability-identifier-naming)

--- a/src/openassetio-core/include/openassetio/trait/TraitsData.hpp
+++ b/src/openassetio-core/include/openassetio/trait/TraitsData.hpp
@@ -15,6 +15,7 @@
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace trait {
 OPENASSETIO_DECLARE_PTR(TraitsData)
 
 /**
@@ -173,5 +174,6 @@ class OPENASSETIO_CORE_EXPORT TraitsData final {
   class Impl;
   std::unique_ptr<Impl> impl_;
 };
+}  // namespace trait
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/trait/collection.hpp
+++ b/src/openassetio-core/include/openassetio/trait/collection.hpp
@@ -12,7 +12,7 @@
 #include <openassetio/trait/property.hpp>
 #include <openassetio/typedefs.hpp>
 
-OPENASSETIO_FWD_DECLARE(TraitsData)
+OPENASSETIO_FWD_DECLARE(trait, TraitsData)
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -32,7 +32,7 @@ using TraitSet = std::unordered_set<TraitId>;
 using TraitSets = std::vector<TraitSet>;
 
 /**
- * An ordered list of @fqref{TraitsData} "TraitsData" instances.
+ * An ordered list of @fqref{trait.TraitsData} "TraitsData" instances.
  */
 using TraitsDatas = std::vector<TraitsDataPtr>;
 }  // namespace trait

--- a/src/openassetio-core/include/openassetio/typedefs.hpp
+++ b/src/openassetio-core/include/openassetio/typedefs.hpp
@@ -17,8 +17,8 @@ inline namespace OPENASSETIO_CORE_ABI_VERSION {
  * @name Primitive Types
  *
  * These types are used throughout OpenAssetIO, especially within
- * dictionary-like types such as @fqref{TraitsData} "TraitsData" or
- * @fqref{InfoDictionary} "InfoDictionary".
+ * dictionary-like types such as @fqref{trait.TraitsData} "TraitsData"
+ * or @fqref{InfoDictionary} "InfoDictionary".
  *
  * OpenAssetIO must be able to bridge disparate platforms, including
  * serialization of data. It is therefore useful to ensure that our core

--- a/src/openassetio-core/src/Context.cpp
+++ b/src/openassetio-core/src/Context.cpp
@@ -4,11 +4,12 @@
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
-ContextPtr Context::make(TraitsDataPtr locale, managerApi::ManagerStateBasePtr managerState) {
+ContextPtr Context::make(trait::TraitsDataPtr locale,
+                         managerApi::ManagerStateBasePtr managerState) {
   return std::shared_ptr<Context>(new Context(std::move(locale), std::move(managerState)));
 }
 
-Context::Context(TraitsDataPtr locale_, managerApi::ManagerStateBasePtr managerState_)
+Context::Context(trait::TraitsDataPtr locale_, managerApi::ManagerStateBasePtr managerState_)
     : locale{std::move(locale_)}, managerState{std::move(managerState_)} {}
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/src/managerApi/ManagerInterface.cpp
+++ b/src/openassetio-core/src/managerApi/ManagerInterface.cpp
@@ -2,11 +2,12 @@
 // Copyright 2013-2023 The Foundry Visionmongers Ltd
 #include <stdexcept>
 
-#include <openassetio/TraitsData.hpp>
 #include <openassetio/errors/exceptions.hpp>
 #include <openassetio/hostApi/EntityReferencePager.hpp>
 #include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/trait/TraitsData.hpp>
+
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace managerApi {
@@ -73,7 +74,7 @@ void ManagerInterface::defaultEntityReference(
 
 void ManagerInterface::getWithRelationship(
     const EntityReferences& entityReferences,
-    [[maybe_unused]] const TraitsDataPtr& relationshipTraitsData,
+    [[maybe_unused]] const trait::TraitsDataPtr& relationshipTraitsData,
     [[maybe_unused]] const trait::TraitSet& resultTraitSet,
     [[maybe_unused]] const access::RelationsAccess relationsAccess,
     [[maybe_unused]] const ContextConstPtr& context,
@@ -116,7 +117,7 @@ class EmptyEntityReferencePagerInterface : public managerApi::EntityReferencePag
 
 void ManagerInterface::getWithRelationshipPaged(
     const EntityReferences& entityReferences,
-    [[maybe_unused]] const TraitsDataPtr& relationshipTraitsData,
+    [[maybe_unused]] const trait::TraitsDataPtr& relationshipTraitsData,
     [[maybe_unused]] const trait::TraitSet& resultTraitSet, [[maybe_unused]] size_t pageSize,
     [[maybe_unused]] const access::RelationsAccess relationsAccess,
     [[maybe_unused]] const ContextConstPtr& context,

--- a/src/openassetio-core/src/trait/TraitsData.cpp
+++ b/src/openassetio-core/src/trait/TraitsData.cpp
@@ -3,10 +3,12 @@
 
 #include <unordered_map>
 
-#include <openassetio/TraitsData.hpp>
+#include <openassetio/trait/TraitsData.hpp>
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace trait {
+
 class TraitsData::Impl {
  public:
   Impl() = default;
@@ -124,5 +126,6 @@ trait::property::KeySet TraitsData::traitPropertyKeys(const trait::TraitId& trai
 }
 
 bool TraitsData::operator==(const TraitsData& other) const { return *impl_ == *other.impl_; }
+}  // namespace trait
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/tests/CMakeLists.txt
+++ b/src/openassetio-core/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(openassetio-core-cpp-test-exe
     BatchElementErrorTest.cpp
     ContextTest.cpp
     TraitsDataTest.cpp
+    deprecationsTest.cpp
     hostApi/ManagerTest.cpp
     managerApi/HostTest.cpp
     managerApi/HostSessionTest.cpp

--- a/src/openassetio-core/tests/ContextTest.cpp
+++ b/src/openassetio-core/tests/ContextTest.cpp
@@ -6,12 +6,12 @@
 
 #include <openassetio/Context.hpp>
 
-OPENASSETIO_FWD_DECLARE(TraitsData)
+OPENASSETIO_FWD_DECLARE(trait, TraitsData)
 OPENASSETIO_FWD_DECLARE(managerApi, ManagerStateBase)
 
 using openassetio::Context;
 
 SCENARIO("Context constructor is private") {
-  STATIC_REQUIRE_FALSE(std::is_constructible_v<Context, openassetio::TraitsDataPtr,
+  STATIC_REQUIRE_FALSE(std::is_constructible_v<Context, openassetio::trait::TraitsDataPtr,
                                                openassetio::managerApi::ManagerStateBasePtr>);
 }

--- a/src/openassetio-core/tests/TraitsDataTest.cpp
+++ b/src/openassetio-core/tests/TraitsDataTest.cpp
@@ -4,13 +4,13 @@
 
 #include <catch2/catch.hpp>
 
-#include <openassetio/TraitsData.hpp>
+#include <openassetio/trait/TraitsData.hpp>
 #include <openassetio/trait/collection.hpp>
 #include <openassetio/trait/property.hpp>
 
 using openassetio::Int;
-using openassetio::TraitsData;
-using openassetio::TraitsDataPtr;
+using openassetio::trait::TraitsData;
+using openassetio::trait::TraitsDataPtr;
 using openassetio::trait::property::Key;
 using openassetio::trait::property::Value;
 
@@ -23,7 +23,7 @@ SCENARIO("TraitsData trait set constructor is private") {
 }
 
 SCENARIO("TraitsData copy constructor is private") {
-  STATIC_REQUIRE_FALSE(std::is_constructible_v<TraitsData, const openassetio::TraitsData&>);
+  STATIC_REQUIRE_FALSE(std::is_constructible_v<TraitsData, const TraitsData&>);
 }
 
 SCENARIO("TraitsData make from other creates a deep copy") {

--- a/src/openassetio-core/tests/deprecationsTest.cpp
+++ b/src/openassetio-core/tests/deprecationsTest.cpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#include <type_traits>
+
+#include <catch2/catch.hpp>
+
+#include <openassetio/TraitsData.hpp>
+#include <openassetio/trait/TraitsData.hpp>
+
+// Disable deprecation warning that triggers -Werror, failing the build.
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+// Tests for deprecated functionality.
+// All cases must have links to the relevant GitHub issues.

--- a/src/openassetio-core/tests/deprecationsTest.cpp
+++ b/src/openassetio-core/tests/deprecationsTest.cpp
@@ -16,3 +16,8 @@
 
 // Tests for deprecated functionality.
 // All cases must have links to the relevant GitHub issues.
+
+// https://github.com/OpenAssetIO/OpenAssetIO/issues/1127
+SCENARIO("TraitsData still accessible in top level namespace") {
+  STATIC_REQUIRE(std::is_same_v<openassetio::TraitsData, openassetio::trait::TraitsData>);
+}

--- a/src/openassetio-core/tests/hostApi/ManagerTest.cpp
+++ b/src/openassetio-core/tests/hostApi/ManagerTest.cpp
@@ -9,7 +9,6 @@
 #include <catch2/trompeloeil.hpp>
 
 #include <openassetio/Context.hpp>
-#include <openassetio/TraitsData.hpp>
 #include <openassetio/errors/exceptions.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/hostApi/Manager.hpp>
@@ -17,6 +16,8 @@
 #include <openassetio/managerApi/Host.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/trait/TraitsData.hpp>
+
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace {
@@ -118,7 +119,7 @@ SCENARIO("Resolving entities") {
       const openassetio::EntityReference ref = openassetio::EntityReference{"testReference"};
       const openassetio::EntityReferences refs = {ref};
 
-      const openassetio::TraitsDataPtr expected = openassetio::TraitsData::make();
+      const openassetio::trait::TraitsDataPtr expected = openassetio::trait::TraitsData::make();
       expected->addTrait("aTestTrait");
 
       // With success callback side effect
@@ -127,23 +128,23 @@ SCENARIO("Resolving entities") {
           .LR_SIDE_EFFECT(_6(0, expected));
 
       WHEN("singular resolve is called with default errorPolicyTag") {
-        const openassetio::TraitsDataPtr actual =
+        const openassetio::trait::TraitsDataPtr actual =
             manager->resolve(ref, traits, resolveAccess, context);
         THEN("returned TraitsData is as expected") { CHECK(expected.get() == actual.get()); }
       }
       WHEN("singular resolve is called with kException errorPolicyTag") {
-        const openassetio::TraitsDataPtr actual =
+        const openassetio::trait::TraitsDataPtr actual =
             manager->resolve(ref, traits, resolveAccess, context,
                              hostApi::Manager::BatchElementErrorPolicyTag::kException);
         THEN("returned TraitsData is as expected") { CHECK(expected.get() == actual.get()); }
       }
       WHEN("singular resolve is called with kVariant errorPolicyTag") {
-        std::variant<openassetio::errors::BatchElementError, openassetio::TraitsDataPtr> actual =
-            manager->resolve(ref, traits, resolveAccess, context,
-                             hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
+        std::variant<openassetio::errors::BatchElementError, openassetio::trait::TraitsDataPtr>
+            actual = manager->resolve(ref, traits, resolveAccess, context,
+                                      hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
         THEN("returned variant contains the expected TraitsData") {
-          CHECK(std::holds_alternative<openassetio::TraitsDataPtr>(actual));
-          auto actualVal = std::get<openassetio::TraitsDataPtr>(actual);
+          CHECK(std::holds_alternative<openassetio::trait::TraitsDataPtr>(actual));
+          auto actualVal = std::get<openassetio::trait::TraitsDataPtr>(actual);
           CHECK(expected.get() == actualVal.get());
         }
       }
@@ -153,13 +154,13 @@ SCENARIO("Resolving entities") {
                                                   openassetio::EntityReference{"testReference2"},
                                                   openassetio::EntityReference{"testReference3"}};
 
-      const openassetio::TraitsDataPtr expected1 = openassetio::TraitsData::make();
+      const openassetio::trait::TraitsDataPtr expected1 = openassetio::trait::TraitsData::make();
       expected1->addTrait("aTestTrait1");
-      const openassetio::TraitsDataPtr expected2 = openassetio::TraitsData::make();
+      const openassetio::trait::TraitsDataPtr expected2 = openassetio::trait::TraitsData::make();
       expected2->addTrait("aTestTrait2");
-      const openassetio::TraitsDataPtr expected3 = openassetio::TraitsData::make();
+      const openassetio::trait::TraitsDataPtr expected3 = openassetio::trait::TraitsData::make();
       expected3->addTrait("aTestTrait3");
-      std::vector<openassetio::TraitsDataPtr> expectedVec{expected1, expected2, expected3};
+      std::vector<openassetio::trait::TraitsDataPtr> expectedVec{expected1, expected2, expected3};
 
       // With success callback side effect
       REQUIRE_CALL(mockManagerInterface,
@@ -169,26 +170,26 @@ SCENARIO("Resolving entities") {
           .LR_SIDE_EFFECT(_6(2, expectedVec[2]));
 
       WHEN("batch resolve is called with default errorPolicyTag") {
-        const std::vector<openassetio::TraitsDataPtr> actualVec =
+        const std::vector<openassetio::trait::TraitsDataPtr> actualVec =
             manager->resolve(refs, traits, resolveAccess, context);
         THEN("returned list of TraitsDatas is as expected") { CHECK(expectedVec == actualVec); }
       }
       WHEN("batch resolve is called with kException errorPolicyTag") {
-        const std::vector<openassetio::TraitsDataPtr> actualVec =
+        const std::vector<openassetio::trait::TraitsDataPtr> actualVec =
             manager->resolve(refs, traits, resolveAccess, context,
                              hostApi::Manager::BatchElementErrorPolicyTag::kException);
         THEN("returned list of TraitsDatas is as expected") { CHECK(expectedVec == actualVec); }
       }
       WHEN("batch resolve is called with kVariant errorPolicyTag") {
-        std::vector<
-            std::variant<openassetio::errors::BatchElementError, openassetio::TraitsDataPtr>>
+        std::vector<std::variant<openassetio::errors::BatchElementError,
+                                 openassetio::trait::TraitsDataPtr>>
             actualVec = manager->resolve(refs, traits, resolveAccess, context,
                                          hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
         THEN("returned lists of variants contains the expected TraitsDatas") {
           CHECK(expectedVec.size() == actualVec.size());
           for (size_t i = 0; i < actualVec.size(); ++i) {
-            CHECK(std::holds_alternative<openassetio::TraitsDataPtr>(actualVec[i]));
-            auto actualVal = std::get<openassetio::TraitsDataPtr>(actualVec[i]);
+            CHECK(std::holds_alternative<openassetio::trait::TraitsDataPtr>(actualVec[i]));
+            auto actualVal = std::get<openassetio::trait::TraitsDataPtr>(actualVec[i]);
             CHECK(expectedVec[i].get() == actualVal.get());
           }
         }
@@ -199,13 +200,13 @@ SCENARIO("Resolving entities") {
                                                   openassetio::EntityReference{"testReference2"},
                                                   openassetio::EntityReference{"testReference3"}};
 
-      const openassetio::TraitsDataPtr expected1 = openassetio::TraitsData::make();
+      const openassetio::trait::TraitsDataPtr expected1 = openassetio::trait::TraitsData::make();
       expected1->addTrait("aTestTrait1");
-      const openassetio::TraitsDataPtr expected2 = openassetio::TraitsData::make();
+      const openassetio::trait::TraitsDataPtr expected2 = openassetio::trait::TraitsData::make();
       expected2->addTrait("aTestTrait2");
-      const openassetio::TraitsDataPtr expected3 = openassetio::TraitsData::make();
+      const openassetio::trait::TraitsDataPtr expected3 = openassetio::trait::TraitsData::make();
       expected3->addTrait("aTestTrait3");
-      std::vector<openassetio::TraitsDataPtr> expectedVec{expected1, expected2, expected3};
+      std::vector<openassetio::trait::TraitsDataPtr> expectedVec{expected1, expected2, expected3};
 
       // With success callback side effect, given out of order.
       REQUIRE_CALL(mockManagerInterface,
@@ -215,14 +216,14 @@ SCENARIO("Resolving entities") {
           .LR_SIDE_EFFECT(_6(1, expectedVec[1]));
 
       WHEN("batch resolve is called with default errorPolicyTag") {
-        const std::vector<openassetio::TraitsDataPtr> actualVec =
+        const std::vector<openassetio::trait::TraitsDataPtr> actualVec =
             manager->resolve(refs, traits, resolveAccess, context);
         THEN("returned list of TraitsDatas is ordered in index order") {
           CHECK(expectedVec == actualVec);
         }
       }
       WHEN("batch resolve is called with kException errorPolicyTag") {
-        const std::vector<openassetio::TraitsDataPtr> actualVec =
+        const std::vector<openassetio::trait::TraitsDataPtr> actualVec =
             manager->resolve(refs, traits, resolveAccess, context,
                              hostApi::Manager::BatchElementErrorPolicyTag::kException);
         THEN("returned list of TraitsDatas is ordered in index order") {
@@ -230,15 +231,15 @@ SCENARIO("Resolving entities") {
         }
       }
       WHEN("batch resolve is called with kVariant errorPolicyTag") {
-        std::vector<
-            std::variant<openassetio::errors::BatchElementError, openassetio::TraitsDataPtr>>
+        std::vector<std::variant<openassetio::errors::BatchElementError,
+                                 openassetio::trait::TraitsDataPtr>>
             actualVec = manager->resolve(refs, traits, resolveAccess, context,
                                          hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
         THEN("returned lists of variants is ordered in index order") {
           CHECK(expectedVec.size() == actualVec.size());
           for (size_t i = 0; i < actualVec.size(); ++i) {
-            CHECK(std::holds_alternative<openassetio::TraitsDataPtr>(actualVec[i]));
-            auto actualVal = std::get<openassetio::TraitsDataPtr>(actualVec[i]);
+            CHECK(std::holds_alternative<openassetio::trait::TraitsDataPtr>(actualVec[i]));
+            auto actualVal = std::get<openassetio::trait::TraitsDataPtr>(actualVec[i]);
             CHECK(expectedVec[i].get() == actualVal.get());
           }
         }
@@ -275,9 +276,9 @@ SCENARIO("Resolving entities") {
         }
       }
       WHEN("singular resolve is called with kVariant errorPolicyTag") {
-        std::variant<openassetio::errors::BatchElementError, openassetio::TraitsDataPtr> actual =
-            manager->resolve(ref, traits, resolveAccess, context,
-                             hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
+        std::variant<openassetio::errors::BatchElementError, openassetio::trait::TraitsDataPtr>
+            actual = manager->resolve(ref, traits, resolveAccess, context,
+                                      hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
         THEN("returned variant contains the expected BatchElementError") {
           CHECK(std::holds_alternative<openassetio::errors::BatchElementError>(actual));
           const auto& actualVal = std::get<openassetio::errors::BatchElementError>(actual);
@@ -292,7 +293,8 @@ SCENARIO("Resolving entities") {
                                                   openassetio::EntityReference{"testReference2"},
                                                   openassetio::EntityReference{"testReference3"}};
 
-      const openassetio::TraitsDataPtr expectedValue2 = openassetio::TraitsData::make();
+      const openassetio::trait::TraitsDataPtr expectedValue2 =
+          openassetio::trait::TraitsData::make();
       expectedValue2->addTrait("aTestTrait");
       const openassetio::errors::BatchElementError expectedError0{
           openassetio::errors::BatchElementError::ErrorCode::kMalformedEntityReference,
@@ -325,8 +327,8 @@ SCENARIO("Resolving entities") {
         }
       }
       WHEN("batch resolve is called with kVariant errorPolicyTag") {
-        std::vector<
-            std::variant<openassetio::errors::BatchElementError, openassetio::TraitsDataPtr>>
+        std::vector<std::variant<openassetio::errors::BatchElementError,
+                                 openassetio::trait::TraitsDataPtr>>
             actualVec = manager->resolve(refs, traits, resolveAccess, context,
                                          hostApi::Manager::BatchElementErrorPolicyTag::kVariant);
         THEN("returned lists of variants contains the expected objects") {
@@ -336,7 +338,7 @@ SCENARIO("Resolving entities") {
           auto error1 = std::get<openassetio::errors::BatchElementError>(actualVec[1]);
           CHECK(error1 == expectedError1);
 
-          CHECK(std::get<openassetio::TraitsDataPtr>(actualVec[2]) == expectedValue2);
+          CHECK(std::get<openassetio::trait::TraitsDataPtr>(actualVec[2]) == expectedValue2);
         }
       }
     }
@@ -356,8 +358,8 @@ SCENARIO("Preflighting entities") {
         openassetio::EntityReference{"testReference2"},
         openassetio::EntityReference{"testReference3"}};
 
-    const openassetio::TraitsDataPtr traitsData =
-        openassetio::TraitsData::make({"fakeTrait", "secondFakeTrait"});
+    const openassetio::trait::TraitsDataPtr traitsData =
+        openassetio::trait::TraitsData::make({"fakeTrait", "secondFakeTrait"});
     const openassetio::trait::TraitsDatas threeTraitsDatas{traitsData, traitsData, traitsData};
 
     const openassetio::ManagerFixture fixture;
@@ -594,10 +596,10 @@ SCENARIO("Registering entities") {
     // Create TraitSets used in the register method calls
     const openassetio::trait::TraitSet traits = {"fakeTrait", "secondFakeTrait"};
     const openassetio::trait::TraitsDatas threeTraitsDatas = {
-        openassetio::TraitsData::make(traits), openassetio::TraitsData::make(traits),
-        openassetio::TraitsData::make(traits)};
+        openassetio::trait::TraitsData::make(traits), openassetio::trait::TraitsData::make(traits),
+        openassetio::trait::TraitsData::make(traits)};
 
-    auto singleTraitsData = openassetio::TraitsData::make(traits);
+    auto singleTraitsData = openassetio::trait::TraitsData::make(traits);
     const openassetio::trait::TraitsDatas singleTraitsDatas = {singleTraitsData};
 
     GIVEN("manager plugin successfully registers a single entity reference") {

--- a/src/openassetio-core/tests/typedefsTest.cpp
+++ b/src/openassetio-core/tests/typedefsTest.cpp
@@ -6,7 +6,6 @@
 #include <catch2/catch.hpp>
 
 #include <openassetio/Context.hpp>
-#include <openassetio/TraitsData.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/hostApi/Manager.hpp>
 #include <openassetio/hostApi/ManagerFactory.hpp>
@@ -18,6 +17,7 @@
 #include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/managerApi/ManagerStateBase.hpp>
+#include <openassetio/trait/TraitsData.hpp>
 
 namespace {
 
@@ -30,7 +30,7 @@ namespace managerApi = openassetio::managerApi;
 // clang-format off
 using ClassesWithPtrAlias = std::tuple<
     CLASS_AND_PTRS(openassetio::Context),
-    CLASS_AND_PTRS(openassetio::TraitsData),
+    CLASS_AND_PTRS(openassetio::trait::TraitsData),
     CLASS_AND_PTRS(hostApi::HostInterface),
     CLASS_AND_PTRS(hostApi::Manager),
     CLASS_AND_PTRS(hostApi::ManagerFactory),

--- a/src/openassetio-python/bridge/src/python/converter.cpp
+++ b/src/openassetio-python/bridge/src/python/converter.cpp
@@ -5,7 +5,6 @@
 #include <pybind11/embed.h>
 
 #include <openassetio/Context.hpp>
-#include <openassetio/TraitsData.hpp>
 #include <openassetio/errors/exceptions.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/hostApi/Manager.hpp>
@@ -18,6 +17,7 @@
 #include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/managerApi/ManagerStateBase.hpp>
+#include <openassetio/trait/TraitsData.hpp>
 
 // Private headers
 #include <openassetio/private/python/pointers.hpp>
@@ -86,7 +86,7 @@ typename T::Ptr castFromPyObject(PyObject* pyObject) {
   template OPENASSETIO_PYTHON_BRIDGE_EXPORT Class::Ptr castFromPyObject<Class>(PyObject*);
 
 OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(openassetio::Context)
-OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(openassetio::TraitsData)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(trait::TraitsData)
 OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(hostApi::HostInterface)
 OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(hostApi::Manager)
 OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(hostApi::ManagerFactory)

--- a/src/openassetio-python/cmodule/CMakeLists.txt
+++ b/src/openassetio-python/cmodule/CMakeLists.txt
@@ -45,7 +45,6 @@ target_sources(
     src/constantsBinding.cpp
     src/ContextBinding.cpp
     src/EntityReferenceBinding.cpp
-    src/TraitsDataBinding.cpp
     src/errors/exceptionsBinding.cpp
     src/errors/BatchElementErrorBinding.cpp
     src/hostApi/EntityReferencePagerBinding.cpp
@@ -61,6 +60,7 @@ target_sources(
     src/managerApi/EntityReferencePagerInterfaceBinding.cpp
     src/managerApi/ManagerInterfaceBinding.cpp
     src/managerApi/ManagerStateBaseBinding.cpp
+    src/trait/TraitsDataBinding.cpp
 )
 
 target_link_libraries(openassetio-python-module

--- a/src/openassetio-python/cmodule/src/ContextBinding.cpp
+++ b/src/openassetio-python/cmodule/src/ContextBinding.cpp
@@ -4,8 +4,8 @@
 #include <pybind11/stl.h>
 
 #include <openassetio/Context.hpp>
-#include <openassetio/TraitsData.hpp>
 #include <openassetio/managerApi/ManagerStateBase.hpp>
+#include <openassetio/trait/TraitsData.hpp>
 
 #include "PyRetainingSharedPtr.hpp"
 #include "_openassetio.hpp"
@@ -13,8 +13,8 @@
 void registerContext(const py::module& mod) {
   using openassetio::Context;
   using openassetio::ContextPtr;
-  using openassetio::TraitsDataPtr;
   using openassetio::managerApi::ManagerStateBasePtr;
+  using openassetio::trait::TraitsDataPtr;
   using PyRetainingManagerStateBasePtr =
       openassetio::PyRetainingSharedPtr<openassetio::managerApi::ManagerStateBase>;
 

--- a/src/openassetio-python/cmodule/src/_openassetio.cpp
+++ b/src/openassetio-python/cmodule/src/_openassetio.cpp
@@ -18,13 +18,14 @@ PYBIND11_MODULE(_openassetio, mod) {
   const py::module log = mod.def_submodule("log");
   const py::module constants = mod.def_submodule("constants");
   const py::module errors = mod.def_submodule("errors");
+  const py::module trait = mod.def_submodule("trait");
 
   registerAccess(access);
   registerConstants(constants);
   registerLoggerInterface(log);
   registerConsoleLogger(log);
   registerSeverityFilter(log);
-  registerTraitsData(mod);
+  registerTraitsData(trait);
   registerManagerStateBase(managerApi);
   registerContext(mod);
   registerBatchElementError(errors);

--- a/src/openassetio-python/cmodule/src/hostApi/EntityReferencePagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/EntityReferencePagerBinding.cpp
@@ -6,7 +6,6 @@
 #include <pybind11/stl.h>
 
 #include <openassetio/Context.hpp>
-#include <openassetio/TraitsData.hpp>
 #include <openassetio/errors/BatchElementError.hpp>
 #include <openassetio/hostApi/EntityReferencePager.hpp>
 #include <openassetio/managerApi/EntityReferencePagerInterface.hpp>

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -6,20 +6,20 @@
 #include <pybind11/stl.h>
 
 #include <openassetio/Context.hpp>
-#include <openassetio/TraitsData.hpp>
 #include <openassetio/errors/BatchElementError.hpp>
 #include <openassetio/errors/exceptions.hpp>
 #include <openassetio/hostApi/Manager.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/trait/TraitsData.hpp>
 #include <openassetio/trait/collection.hpp>
 
 #include "../_openassetio.hpp"
 
 namespace {
 using openassetio::EntityReferences;
-using openassetio::TraitsDataPtr;
 using openassetio::hostApi::Manager;
+using openassetio::trait::TraitsDataPtr;
 using openassetio::trait::TraitsDatas;
 
 void validateTraitsDatas(const TraitsDatas& traitsDatas) {
@@ -38,12 +38,12 @@ void registerManager(const py::module& mod) {
   using openassetio::ContextConstPtr;
   using openassetio::EntityReference;
   using openassetio::EntityReferences;
-  using openassetio::TraitsDataPtr;
   using openassetio::errors::BatchElementError;
   using openassetio::hostApi::Manager;
   using openassetio::hostApi::ManagerPtr;
   using openassetio::managerApi::HostSessionPtr;
   using openassetio::managerApi::ManagerInterfacePtr;
+  using openassetio::trait::TraitsDataPtr;
 
   py::class_<Manager, ManagerPtr> pyManager{mod, "Manager"};
 

--- a/src/openassetio-python/cmodule/src/managerApi/EntityReferencePagerInterfaceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/managerApi/EntityReferencePagerInterfaceBinding.cpp
@@ -5,7 +5,6 @@
 
 #include <openassetio/Context.hpp>
 #include <openassetio/InfoDictionary.hpp>
-#include <openassetio/TraitsData.hpp>
 #include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/trait/collection.hpp>

--- a/src/openassetio-python/cmodule/src/managerApi/ManagerInterfaceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/managerApi/ManagerInterfaceBinding.cpp
@@ -5,12 +5,12 @@
 
 #include <openassetio/Context.hpp>
 #include <openassetio/InfoDictionary.hpp>
-#include <openassetio/TraitsData.hpp>
 #include <openassetio/hostApi/EntityReferencePager.hpp>
 #include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/managerApi/ManagerStateBase.hpp>
+#include <openassetio/trait/TraitsData.hpp>
 #include <openassetio/trait/collection.hpp>
 #include <openassetio/typedefs.hpp>
 
@@ -120,7 +120,7 @@ struct PyManagerInterface : ManagerInterface {
   }
 
   void getWithRelationship(
-      const EntityReferences& entityReferences, const TraitsDataPtr& relationshipTraitsData,
+      const EntityReferences& entityReferences, const trait::TraitsDataPtr& relationshipTraitsData,
       const trait::TraitSet& resultTraitSet, const access::RelationsAccess relationsAccess,
       const ContextConstPtr& context, const HostSessionPtr& hostSession,
       const ManagerInterface::RelationshipSuccessCallback& successCallback,
@@ -142,7 +142,7 @@ struct PyManagerInterface : ManagerInterface {
   }
 
   void getWithRelationshipPaged(
-      const EntityReferences& entityReferences, const TraitsDataPtr& relationshipTraitsData,
+      const EntityReferences& entityReferences, const trait::TraitsDataPtr& relationshipTraitsData,
       const trait::TraitSet& resultTraitSet, size_t pageSize,
       const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
       const HostSessionPtr& hostSession,
@@ -200,12 +200,12 @@ void registerManagerInterface(const py::module& mod) {
   using openassetio::ContextConstPtr;
   using openassetio::EntityReference;
   using openassetio::EntityReferences;
-  using openassetio::TraitsDataPtr;
   using openassetio::managerApi::HostSessionPtr;
   using openassetio::managerApi::ManagerInterface;
   using openassetio::managerApi::ManagerInterfacePtr;
   using openassetio::managerApi::ManagerStateBasePtr;
   using openassetio::managerApi::PyManagerInterface;
+  using openassetio::trait::TraitsDataPtr;
 
   py::class_<ManagerInterface, PyManagerInterface, ManagerInterfacePtr>(mod, "ManagerInterface")
       .def(py::init())

--- a/src/openassetio-python/cmodule/src/trait/TraitsDataBinding.cpp
+++ b/src/openassetio-python/cmodule/src/trait/TraitsDataBinding.cpp
@@ -5,15 +5,15 @@
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
-#include <openassetio/TraitsData.hpp>
+#include <openassetio/trait/TraitsData.hpp>
 #include <openassetio/trait/collection.hpp>
 
-#include "_openassetio.hpp"
+#include "../_openassetio.hpp"
 
 void registerTraitsData(const py::module& mod) {
-  using openassetio::TraitsData;
-  using openassetio::TraitsDataConstPtr;
-  using openassetio::TraitsDataPtr;
+  using openassetio::trait::TraitsData;
+  using openassetio::trait::TraitsDataConstPtr;
+  using openassetio::trait::TraitsDataPtr;
   namespace trait = openassetio::trait;
   namespace property = openassetio::trait::property;
   using MaybeValue = std::optional<property::Value>;

--- a/src/openassetio-python/package/openassetio/__init__.py
+++ b/src/openassetio-python/package/openassetio/__init__.py
@@ -70,11 +70,20 @@ API documentation
 The documentation for OpenAssetIO can be found here:
    https://openassetio.github.io/OpenAssetIO.
 """
-# TODO(DF): @pylint
-from ._openassetio import (  # pylint: disable=import-error
+
+# pylint: disable=wrong-import-position,import-error
+
+from ._openassetio import (
     constants,
     Context,
     EntityReference,
 )
 
-# pylint: disable=wrong-import-position
+
+#
+# Deprecated: https://github.com/OpenAssetIO/OpenAssetIO/issues/1127
+#
+from ._openassetio import trait
+
+TraitsData = trait.TraitsData
+del trait

--- a/src/openassetio-python/package/openassetio/__init__.py
+++ b/src/openassetio-python/package/openassetio/__init__.py
@@ -73,7 +73,6 @@ The documentation for OpenAssetIO can be found here:
 # TODO(DF): @pylint
 from ._openassetio import (  # pylint: disable=import-error
     constants,
-    TraitsData,
     Context,
     EntityReference,
 )

--- a/src/openassetio-python/package/openassetio/test/manager/_implementation.py
+++ b/src/openassetio-python/package/openassetio/test/manager/_implementation.py
@@ -20,7 +20,8 @@ Private implementation classes for the manager test framework.
 """
 import unittest
 
-from openassetio import hostApi, log, pluginSystem, TraitsData
+from openassetio import hostApi, log, pluginSystem
+from openassetio.trait import TraitsData
 from .. import kTestHarnessTraitId, kCasePropertyKey
 
 

--- a/src/openassetio-python/package/openassetio/test/manager/apiComplianceSuite.py
+++ b/src/openassetio-python/package/openassetio/test/manager/apiComplianceSuite.py
@@ -37,9 +37,10 @@ import weakref
 # pylint: disable=too-many-lines,unbalanced-tuple-unpacking
 
 from .harness import FixtureAugmentedTestCase
-from ... import EntityReference, TraitsData
+from ... import EntityReference
 from ...errors import BatchElementError
 from ...access import PolicyAccess, ResolveAccess, RelationsAccess, PublishingAccess
+from ...trait import TraitsData
 
 
 __all__ = []

--- a/src/openassetio-python/package/openassetio/test/manager/harness.py
+++ b/src/openassetio-python/package/openassetio/test/manager/harness.py
@@ -188,8 +188,8 @@ class FixtureAugmentedTestCase(unittest.TestCase):
         @param manager hostApi.Manager.Manager The OpenAssetIO
         @ref manager to be used by test cases.
 
-        @param locale @fqref{TraitsData} "TraitsData" The @ref locale to
-        use by test cases.
+        @param locale @fqref{trait.TraitsData} "TraitsData" The @ref
+        locale to use by test cases.
 
         @param args `List[Any]` Additional args passed along to the
         base class.

--- a/src/openassetio-python/package/openassetio/trait.py
+++ b/src/openassetio-python/package/openassetio/trait.py
@@ -1,0 +1,24 @@
+#
+#   Copyright 2023 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+@namespace openassetio.trait
+Provides the classes related to traits and their data.
+"""
+
+from . import _openassetio  # pylint: disable=no-name-in-module
+
+
+TraitsData = _openassetio.trait.TraitsData

--- a/src/openassetio-python/tests/bridge/python/test_converter.cpp
+++ b/src/openassetio-python/tests/bridge/python/test_converter.cpp
@@ -11,7 +11,6 @@
 #include <openassetio/python/converter.hpp>
 
 #include <openassetio/Context.hpp>
-#include <openassetio/TraitsData.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/hostApi/Manager.hpp>
 #include <openassetio/hostApi/ManagerFactory.hpp>
@@ -23,6 +22,7 @@
 #include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/managerApi/ManagerStateBase.hpp>
+#include <openassetio/trait/TraitsData.hpp>
 
 /*
  * The below tests exercise the to/from python converter functions.
@@ -48,7 +48,7 @@ SCENARIO("Mutations in one language are reflected in the other") {
   py::module_::import("openassetio");
 
   GIVEN("A C++ object casted to a Python object") {
-    const TraitsDataPtr traitsData = TraitsData::make();
+    const trait::TraitsDataPtr traitsData = trait::TraitsData::make();
     PyObject* pyTraitsData = openassetio::python::converter::castToPyObject(traitsData);
     REQUIRE(pyTraitsData != nullptr);
 
@@ -76,11 +76,11 @@ SCENARIO("Mutations in one language are reflected in the other") {
 
   GIVEN("A Python object casted to a C++ object") {
     // Use pybind to conveniently create a CPython object with a ref count of 1.
-    const py::object pyClass = py::module_::import("openassetio").attr("TraitsData");
+    const py::object pyClass = py::module_::import("openassetio.trait").attr("TraitsData");
     py::object pyInstance = pyClass();
     PyObject* pyTraitsData = pyInstance.release().ptr();
-    const TraitsDataPtr traitsData =
-        openassetio::python::converter::castFromPyObject<TraitsData>(pyTraitsData);
+    const trait::TraitsDataPtr traitsData =
+        openassetio::python::converter::castFromPyObject<trait::TraitsData>(pyTraitsData);
 
     WHEN("data is set via the C++ object") {
       traitsData->addTrait(kTestTraitId);
@@ -106,7 +106,7 @@ SCENARIO("Mutations in one language are reflected in the other") {
 
 SCENARIO("Casting to PyObject extends object lifetime") {
   GIVEN("A Python object casted from a C++ object") {
-    TraitsDataPtr traitsData = TraitsData::make();
+    trait::TraitsDataPtr traitsData = trait::TraitsData::make();
     traitsData->addTrait(kTestTraitId);
     PyObject* pyTraitsData = openassetio::python::converter::castToPyObject(traitsData);
 
@@ -134,14 +134,14 @@ SCENARIO("Casting to a C++ object binds object lifetime") {
     py::module_::import("openassetio");
 
     // Use pybind to conveniently create a CPython object with a ref count of 1.
-    const py::object pyClass = py::module_::import("openassetio").attr("TraitsData");
+    const py::object pyClass = py::module_::import("openassetio.trait").attr("TraitsData");
     py::object pyInstance = pyClass();
     PyObject* pyTraitsData = pyInstance.release().ptr();
     CHECK(Py_REFCNT(pyTraitsData) == 1);
 
     WHEN("Python object is converted to a C++ object") {
-      TraitsDataPtr traitsData =
-          openassetio::python::converter::castFromPyObject<TraitsData>(pyTraitsData);
+      trait::TraitsDataPtr traitsData =
+          openassetio::python::converter::castFromPyObject<trait::TraitsData>(pyTraitsData);
 
       THEN("Python reference is obtained") { CHECK(Py_REFCNT(pyTraitsData) == 2); }
 
@@ -202,13 +202,13 @@ SCENARIO("Error attempting to convert API objects without openassetio module loa
     REQUIRE_FALSE(py::module_::import("sys").attr("modules").contains("openassetio"));
 
     AND_GIVEN("an OpenAssetIO C++ API object") {
-      const TraitsDataPtr traitsData = TraitsData::make();
+      const trait::TraitsDataPtr traitsData = trait::TraitsData::make();
 
       WHEN("the C++ object is casted to a Python object") {
         THEN("cast throws expected exception") {
           REQUIRE_THROWS_WITH(openassetio::python::converter::castToPyObject(traitsData),
                               std::string("Unregistered type : openassetio::" STRINGIFY(
-                                  OPENASSETIO_CORE_ABI_VERSION) "::TraitsData"));
+                                  OPENASSETIO_CORE_ABI_VERSION) "::trait::TraitsData"));
         }
       }
 
@@ -227,7 +227,7 @@ SCENARIO("Error attempting to convert API objects without openassetio module loa
           THEN("cast throws expected exception") {
             REQUIRE_THROWS_WITH(openassetio::python::converter::castToPyObject(traitsData),
                                 std::string("Unregistered type : openassetio::" STRINGIFY(
-                                    OPENASSETIO_CORE_ABI_VERSION) "::TraitsData"));
+                                    OPENASSETIO_CORE_ABI_VERSION) "::trait::TraitsData"));
 
             AND_THEN("CPython error state is maintained") {
               // castToPyObject, despite messing with the PyErr state
@@ -252,7 +252,7 @@ namespace managerApi = openassetio::managerApi;
 // clang-format off
 using CastableClasses = std::tuple<
     openassetio::Context,
-    openassetio::TraitsData,
+    openassetio::trait::TraitsData,
     hostApi::HostInterface,
     hostApi::Manager,
     hostApi::ManagerFactory,

--- a/src/openassetio-python/tests/conftest.py
+++ b/src/openassetio-python/tests/conftest.py
@@ -23,7 +23,7 @@ import sys
 
 import pytest
 
-from openassetio import Context, EntityReference, TraitsData
+from openassetio import Context, EntityReference
 from openassetio.access import (
     PolicyAccess,
     ResolveAccess,
@@ -39,6 +39,7 @@ from openassetio.managerApi import (
     EntityReferencePagerInterface,
 )
 from openassetio.hostApi import HostInterface
+from openassetio.trait import TraitsData
 
 
 # pylint: disable=invalid-name

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -28,7 +28,6 @@ import re
 from openassetio import (
     Context,
     EntityReference,
-    TraitsData,
     managerApi,
     constants,
     access,
@@ -41,6 +40,7 @@ from openassetio.errors import (
 )
 from openassetio.hostApi import Manager, EntityReferencePager
 from openassetio.managerApi import EntityReferencePagerInterface
+from openassetio.trait import TraitsData
 
 
 ## @todo Remove comments regarding Entity methods when splitting them from core API

--- a/src/openassetio-python/tests/package/managerApi/test_managerinterface.py
+++ b/src/openassetio-python/tests/package/managerApi/test_managerinterface.py
@@ -25,13 +25,14 @@ from unittest.mock import Mock, call
 
 import pytest
 
-from openassetio import EntityReference, TraitsData, Context, errors
+from openassetio import EntityReference, Context, errors
+from openassetio.access import RelationsAccess, DefaultEntityAccess
 from openassetio.managerApi import (
     ManagerInterface,
     ManagerStateBase,
     EntityReferencePagerInterface,
 )
-from openassetio.access import RelationsAccess, DefaultEntityAccess
+from openassetio.trait import TraitsData
 
 
 class Test_ManagerInterface_identifier:

--- a/src/openassetio-python/tests/package/test/manager/conftest.py
+++ b/src/openassetio-python/tests/package/test/manager/conftest.py
@@ -25,7 +25,8 @@ from unittest import mock
 
 import pytest
 
-from openassetio import hostApi, TraitsData, EntityReference
+from openassetio import hostApi, EntityReference
+from openassetio.trait import TraitsData
 
 
 @pytest.fixture

--- a/src/openassetio-python/tests/package/test/manager/resources/plugins/StubManager.py
+++ b/src/openassetio-python/tests/package/test/manager/resources/plugins/StubManager.py
@@ -19,9 +19,9 @@ implementation providing dummy data and input validation for the manager
 test suite.
 """
 
-from openassetio import TraitsData
 from openassetio.managerApi import ManagerInterface
 from openassetio.pluginSystem import PythonPluginSystemManagerPlugin
+from openassetio.trait import TraitsData
 
 
 class StubManager(ManagerInterface):

--- a/src/openassetio-python/tests/package/test/manager/test__implementation.py
+++ b/src/openassetio-python/tests/package/test/manager/test__implementation.py
@@ -28,13 +28,13 @@ from unittest.mock import Mock, call
 
 import pytest
 
-from openassetio import TraitsData
 from openassetio.test import kTestHarnessTraitId, kCasePropertyKey
 from openassetio.test.manager.harness import FixtureAugmentedTestCase
 from openassetio.test.manager._implementation import (
     _ValidatorHarnessHostInterface,
     _ValidatorTestLoader,
 )
+from openassetio.trait import TraitsData
 
 
 class Test_Loader_loadTestsFromTestCase:

--- a/src/openassetio-python/tests/package/test_context.py
+++ b/src/openassetio-python/tests/package/test_context.py
@@ -21,7 +21,8 @@ Tests that cover the openassetio.Context class.
 # pylint: disable=missing-class-docstring,missing-function-docstring
 import pytest
 
-from openassetio import Context, managerApi, TraitsData
+from openassetio import Context, managerApi
+from openassetio.trait import TraitsData
 
 
 class Test_Context_init:
@@ -47,7 +48,7 @@ class Test_Context_init:
 class Test_Context_locale:
     def test_when_set_to_unknown_value_then_raises_ValueError(self, a_context):
         expected_msg = (
-            r"incompatible function arguments.*\n.*arg0: openassetio._openassetio.TraitsData"
+            r"incompatible function arguments.*\n.*arg0: openassetio._openassetio.trait.TraitsData"
         )
 
         with pytest.raises(TypeError, match=expected_msg):

--- a/src/openassetio-python/tests/package/test_deprecations.py
+++ b/src/openassetio-python/tests/package/test_deprecations.py
@@ -36,3 +36,11 @@ def test_renamed_kField_constants():
         == constants.kInfoKey_EntityReferencesMatchPrefix
     )
 
+
+def test_top_level_TraitsData_import():
+    """
+    https://github.com/OpenAssetIO/OpenAssetIO/issues/1127
+    """
+    from openassetio import trait, TraitsData
+
+    assert TraitsData is trait.TraitsData

--- a/src/openassetio-python/tests/package/test_deprecations.py
+++ b/src/openassetio-python/tests/package/test_deprecations.py
@@ -14,15 +14,25 @@
 #   limitations under the License.
 #
 """
-Tests for the constants module.
+Tests for deprecated functionality.
+
+All cases must have a link to the relevant GitHub issue in their
+docstrings.
 """
 
-# pylint: disable=missing-function-docstring
-
-from openassetio import constants
+# pylint: disable=missing-function-docstring,import-outside-toplevel
 
 
-def test():
-    assert constants.kInfoKey_SmallIcon == "smallIcon"
-    assert constants.kInfoKey_Icon == "icon"
-    assert constants.kInfoKey_EntityReferencesMatchPrefix == "entityReferencesMatchPrefix"
+def test_renamed_kField_constants():
+    """
+    https://github.com/OpenAssetIO/OpenAssetIO/issues/998
+    """
+    from openassetio import constants
+
+    assert constants.kField_SmallIcon == constants.kInfoKey_SmallIcon
+    assert constants.kField_Icon == constants.kInfoKey_Icon
+    assert (
+        constants.kField_EntityReferencesMatchPrefix
+        == constants.kInfoKey_EntityReferencesMatchPrefix
+    )
+

--- a/src/openassetio-python/tests/package/test_imports.py
+++ b/src/openassetio-python/tests/package/test_imports.py
@@ -59,9 +59,6 @@ class Test_package_imports:
     def test_importing_log_succeeds(self):
         from openassetio import log
 
-    def test_importing_TraitsData_succeeds(self):
-        from openassetio import TraitsData
-
 
 class Test_core_imports:
     def test_importing_audit_succeeds(self):
@@ -133,6 +130,11 @@ class Test_errors_imports:
 
     def test_importing_UnhandledException_succeeds(self):
         from openassetio.errors import UnhandledException
+
+
+class Test_trait_imports:
+    def test_importing_TraitsData_succeeds(self):
+        from openassetio.trait import TraitsData
 
 
 class Test_test_imports:

--- a/src/openassetio-python/tests/package/test_traitsdata.py
+++ b/src/openassetio-python/tests/package/test_traitsdata.py
@@ -8,7 +8,7 @@ import pytest
 
 # TODO(DF): @pylint - re-enable once Python dev vs. install mess sorted.
 # pylint: disable=no-name-in-module
-from openassetio import TraitsData
+from openassetio.trait import TraitsData
 
 
 class Test_TraitsData_Inheritance:


### PR DESCRIPTION
I'm sure I've probably missed something here, but all seems well.

Took at stab at setting up a new framework for testing deprecations, that aims to make it easier to remove them later. We had previously keep tests of the deprecated functionality in with the main tests, which makes it harder to see at a glance which parts could be safely removed later.

The idea of the `[Deprecation]` commits is that they could (hopefully) be trivially reverted at the point compatibility with older code is no longer required.

Closes #1127