### PR TITLE
Remove non-paged relationship query methods

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -61,27 +61,28 @@ jobs:
           # `openassetio` package.
           python -m pip install pytest
 
-      - name: Checkout BAL
-        uses: actions/checkout@v4
-        with:
-          repository: OpenAssetIO/OpenAssetIO-Manager-BAL
-          path: external/BAL
-
-      - name: Test BAL
-        run: |
-          python -m pip install external/BAL
-          # We can't install BAL's requirements.txt as this includes
-          # openassetio... we really need to sort
-          # https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/72
-          python -m pip install openassetio-mediacreation
-          python -m pip install -r external/BAL/tests/requirements.txt
-          python -m pytest -v external/BAL/tests
-
-      - name: Test Simple Resolver
-        run: |
-          python -m pytest -v examples/host/simpleResolver
-        env:
-          OPENASSETIO_PLUGIN_PATH: ${{ github.workspace }}/external/BAL/plugin
+      # Disabled pending https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL
+#      - name: Checkout BAL
+#        uses: actions/checkout@v4
+#        with:
+#          repository: OpenAssetIO/OpenAssetIO-Manager-BAL
+#          path: external/BAL
+#
+#      - name: Test BAL
+#        run: |
+#          python -m pip install external/BAL
+#          # We can't install BAL's requirements.txt as this includes
+#          # openassetio... we really need to sort
+#          # https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/72
+#          python -m pip install openassetio-mediacreation
+#          python -m pip install -r external/BAL/tests/requirements.txt
+#          python -m pytest -v external/BAL/tests
+#
+#      - name: Test Simple Resolver
+#        run: |
+#          python -m pytest -v examples/host/simpleResolver
+#        env:
+#          OPENASSETIO_PLUGIN_PATH: ${{ github.workspace }}/external/BAL/plugin
 
       - name: Checkout TraitGen
         uses: actions/checkout@v4

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,13 @@ v1.0.0-alpha.xx
 
 ### Breaking changes
 
+- Renamed the `Manager`/`ManagerInterface`
+  `PagedRelationshipSuccessCallback` to
+  `RelationshipQuerySuccessCallback` to better reflect the default of
+  pagnation, and reduce ambiguity when relationship creation methods are
+  added in the future.
+  [#1125](https://github.com/OpenAssetIO/OpenAssetIO/issues/1125)
+
 - Removed non-paged versions of the `Manager`/`ManagerInterface`
   relationship query methods, and renamed the paged methods to remove
   the `Paged` suffix.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,11 @@ v1.0.0-alpha.xx
 
 ### Breaking changes
 
+- Removed non-paged versions of the `Manager`/`ManagerInterface`
+  relationship query methods, and renamed the paged methods to remove
+  the `Paged` suffix.
+  [#1125](https://github.com/OpenAssetIO/OpenAssetIO/issues/1125)
+
 - Attempting to retrieve a trait property with
   `TraitsData.getTraitProperty` or using trait view classes no longer
   raises an exception if the trait itself is missing. This simplifies

--- a/src/openassetio-core/include/openassetio/hostApi/EntityReferencePager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/EntityReferencePager.hpp
@@ -22,8 +22,8 @@ OPENASSETIO_DECLARE_PTR(EntityReferencePager)
  * @note Instances of this class should not be constructed directly by
  * the host.
  *
- * @see @ref Manager.getWithRelationshipPaged
- * @see @ref Manager.getWithRelationshipsPaged
+ * @see @ref Manager.getWithRelationship
+ * @see @ref Manager.getWithRelationships
  *
  * None of the functions of this class should be considered thread-safe.
  * Hosts should add their own synchronization around concurrent usage.

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -973,7 +973,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * Callback signature used for a successful paged entity relationship
    * query.
    */
-  using PagedRelationshipSuccessCallback =
+  using RelationshipQuerySuccessCallback =
       std::function<void(std::size_t, EntityReferencePagerPtr)>;
 
   /**
@@ -1033,7 +1033,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
   void getWithRelationship(const EntityReferences& entityReferences,
                            const trait::TraitsDataPtr& relationshipTraitsData, size_t pageSize,
                            access::RelationsAccess relationsAccess, const ContextConstPtr& context,
-                           const PagedRelationshipSuccessCallback& successCallback,
+                           const RelationshipQuerySuccessCallback& successCallback,
                            const BatchElementErrorCallback& errorCallback,
                            const trait::TraitSet& resultTraitSet = {});
 
@@ -1098,7 +1098,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
                             const trait::TraitsDatas& relationshipTraitsDatas, size_t pageSize,
                             access::RelationsAccess relationsAccess,
                             const ContextConstPtr& context,
-                            const PagedRelationshipSuccessCallback& successCallback,
+                            const RelationshipQuerySuccessCallback& successCallback,
                             const BatchElementErrorCallback& errorCallback,
                             const trait::TraitSet& resultTraitSet = {});
   /// @}

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -970,9 +970,11 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    */
 
   /**
-   * Callback signature used for a successful entity relationship query.
+   * Callback signature used for a successful paged entity relationship
+   * query.
    */
-  using RelationshipSuccessCallback = std::function<void(std::size_t, EntityReferences)>;
+  using PagedRelationshipSuccessCallback =
+      std::function<void(std::size_t, EntityReferencePagerPtr)>;
 
   /**
    * Query entity references that are related to the input
@@ -996,6 +998,10 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * @param relationshipTraitsData The traits of the relationship to
    * query.
    *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
    * @param relationsAccess The intended usage of the returned
    * references.
    *
@@ -1003,12 +1009,14 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    *
    * @param successCallback Callback that will be called for each
    * successful relationship query. It will be given the corresponding
-   * index of the entity reference in @p entityReferences along with a
-   * list of entity references for entities that have the relationship
-   * specified by @p relationshipTraitsData. If there are no relations,
-   * the callback will receive an empty list. The callback will be
-   * called on the same thread that initiated the call to
-   * `getWithRelationship`.
+   * index of the entity reference in @p entityReferences as well as a
+   * pager capable of returning pages of entities that have the
+   * relationship to the entity at the corresponding index, specified by
+   * @p relationshipTraitsData. If there are no relations, the pager
+   * will have no pages. The callback will be called on the same thread
+   * that initiated the call to `getWithRelationship`. To access
+   * the data, retrieve the @ref EntityReferencePager from the callback,
+   * and use its interface to traverse pages.
    *
    * @param errorCallback Callback that will be called for each failed
    * relationship query. It will be given the corresponding index of the
@@ -1020,14 +1028,12 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * @param resultTraitSet A hint as to what traits the returned
    * entities should have.
    *
-   * @note The @ref trait_set of the queried relationship can be passed
-   * to @ref managementPolicy in order to determine if the manager
-   * handles relationships of that type.
+   * @throws errors.InputValidationException if @p pageSize is zero.
    */
   void getWithRelationship(const EntityReferences& entityReferences,
-                           const trait::TraitsDataPtr& relationshipTraitsData,
+                           const trait::TraitsDataPtr& relationshipTraitsData, size_t pageSize,
                            access::RelationsAccess relationsAccess, const ContextConstPtr& context,
-                           const RelationshipSuccessCallback& successCallback,
+                           const PagedRelationshipSuccessCallback& successCallback,
                            const BatchElementErrorCallback& errorCallback,
                            const trait::TraitSet& resultTraitSet = {});
 
@@ -1052,109 +1058,6 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * @param relationshipTraitsDatas The traits of the relationships to
    * query.
    *
-   * @param relationsAccess The intended usage of the returned
-   * references.
-   *
-   * @param context The calling context.
-   *
-   * @param successCallback Callback that will be called for each
-   * successful relationship query. It will be given the corresponding
-   * index of the relationship in @p relationshipTraitsDatas along with
-   * a list of entity references for entities that have that
-   * relationship to the supplied @p entityReference. If there are no
-   * relations, the callback will receive an empty list. The callback
-   * will be called on the same thread that initiated the call to
-   * `getWithRelationships`.
-   *
-   * @param errorCallback Callback that will be called for each failed
-   * relationship query. It will be given the corresponding index of the
-   * relationship in @p relationshipTraitsDatas along with a populated
-   * BatchElementError (see @fqref{errors.BatchElementError.ErrorCode}
-   * "ErrorCodes"). The callback will be called on the same thread that
-   * initiated the call to `getWithRelationships`.
-   *
-   * @param resultTraitSet A hint as to what traits the returned
-   * entities should have.
-   *
-   * @note The @ref trait_set of any queried relationship can be passed
-   * to @ref managementPolicy in order to determine if the manager
-   * handles relationships of that type.
-   */
-  void getWithRelationships(const EntityReference& entityReference,
-                            const trait::TraitsDatas& relationshipTraitsDatas,
-                            access::RelationsAccess relationsAccess,
-                            const ContextConstPtr& context,
-                            const RelationshipSuccessCallback& successCallback,
-                            const BatchElementErrorCallback& errorCallback,
-                            const trait::TraitSet& resultTraitSet = {});
-
-  /**
-   * Callback signature used for a successful paged entity relationship
-   * query.
-   */
-  using PagedRelationshipSuccessCallback =
-      std::function<void(std::size_t, EntityReferencePagerPtr)>;
-
-  /**
-   * Paged version of getWithRelationship. See non-paged
-   * @ref getWithRelationship for further documentation.
-   *
-   * @param relationshipTraitsData The traits of the relationship to
-   * query.
-   *
-   * @param entityReferences A list of @ref entity_reference to query
-   * the specified relationship for.
-   *
-   * @param pageSize The size of each page of data. The page size is
-   * fixed for the lifetime of pager object given to the @p
-   * successCallback. Must be greater than zero.
-   *
-   * @param relationsAccess The intended usage of the returned
-   * references.
-   *
-   * @param context The calling context.
-   *
-   * @param successCallback Callback that will be called for each
-   * successful relationship query. It will be given the corresponding
-   * index of the entity reference in @p entityReferences as well as a
-   * pager capable of returning pages of entities that have the
-   * relationship to the entity at the corresponding index, specified by
-   * @p relationshipTraitsData. If there are no relations, the pager
-   * will have no pages. The callback will be called on the same thread
-   * that initiated the call to `getWithRelationshipPaged`. To access
-   * the data, retrieve the @ref EntityReferencePager from the callback,
-   * and use its interface to traverse pages.
-   *
-   * @param errorCallback Callback that will be called for each failed
-   * relationship query. It will be given the corresponding index of the
-   * entity reference in @p entityReferences along with a populated
-   * BatchElementError (see @ref errors.BatchElementError.ErrorCode
-   * "ErrorCodes"). The callback will be called on the same thread that
-   * initiated the call to `getWithRelationshipPaged`.
-   *
-   * @param resultTraitSet A hint as to what traits the returned
-   * entities should have.
-   *
-   * @throws errors.InputValidationException if @p pageSize is zero.
-   */
-  void getWithRelationshipPaged(const EntityReferences& entityReferences,
-                                const trait::TraitsDataPtr& relationshipTraitsData,
-                                size_t pageSize, access::RelationsAccess relationsAccess,
-                                const ContextConstPtr& context,
-                                const PagedRelationshipSuccessCallback& successCallback,
-                                const BatchElementErrorCallback& errorCallback,
-                                const trait::TraitSet& resultTraitSet = {});
-
-  /**
-   * Paged version of getWithRelationships. See non-paged
-   * @ref getWithRelationships for further documentation.
-   *
-   * @param relationshipTraitsDatas The traits of the relationships to
-   * query.
-   *
-   * @param entityReference The @ref entity_reference to query the
-   * specified relationships for.
-   *
    * @param pageSize The size of each page of data. The page size is
    * fixed for the lifetime of pager object given to the @p
    * successCallback. Must be greater than zero.
@@ -1171,7 +1074,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * entityReference by the relationship at that corresponding index. If
    * there are no relations, the pager will have no pages. The callback
    * will be called on the same thread that initiated the call to
-   * `getWithRelationshipsPaged`. To access the data, retrieve the
+   * `getWithRelationships`. To access the data, retrieve the
    * @ref EntityReferencePager from the callback, and use its interface
    * to traverse pages.
    *
@@ -1180,7 +1083,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * relationship in @p relationshipTraitsDatas along with a populated
    * BatchElementError (see @fqref{errors.BatchElementError.ErrorCode}
    * "ErrorCodes"). The callback will be called on the same thread that
-   * initiated the call to `getWithRelationshipsPaged`.
+   * initiated the call to `getWithRelationships`.
    *
    * @param resultTraitSet A hint as to what traits the returned
    * entities should have.
@@ -1191,13 +1094,13 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    *
    * @throws errors.InputValidationException if @p pageSize is zero.
    */
-  void getWithRelationshipsPaged(const EntityReference& entityReference,
-                                 const trait::TraitsDatas& relationshipTraitsDatas,
-                                 size_t pageSize, access::RelationsAccess relationsAccess,
-                                 const ContextConstPtr& context,
-                                 const PagedRelationshipSuccessCallback& successCallback,
-                                 const BatchElementErrorCallback& errorCallback,
-                                 const trait::TraitSet& resultTraitSet = {});
+  void getWithRelationships(const EntityReference& entityReference,
+                            const trait::TraitsDatas& relationshipTraitsDatas, size_t pageSize,
+                            access::RelationsAccess relationsAccess,
+                            const ContextConstPtr& context,
+                            const PagedRelationshipSuccessCallback& successCallback,
+                            const BatchElementErrorCallback& errorCallback,
+                            const trait::TraitSet& resultTraitSet = {});
   /// @}
 
   /**

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -916,7 +916,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * Callback signature used for a successful paged entity relationship
    * query.
    */
-  using PagedRelationshipSuccessCallback =
+  using RelationshipQuerySuccessCallback =
       std::function<void(std::size_t, managerApi::EntityReferencePagerInterfacePtr)>;
 
   /**
@@ -988,7 +988,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
                                    access::RelationsAccess relationsAccess,
                                    const ContextConstPtr& context,
                                    const HostSessionPtr& hostSession,
-                                   const PagedRelationshipSuccessCallback& successCallback,
+                                   const RelationshipQuerySuccessCallback& successCallback,
                                    const BatchElementErrorCallback& errorCallback);
 
   /**
@@ -1065,7 +1065,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
                                     access::RelationsAccess relationsAccess,
                                     const ContextConstPtr& context,
                                     const HostSessionPtr& hostSession,
-                                    const PagedRelationshipSuccessCallback& successCallback,
+                                    const RelationshipQuerySuccessCallback& successCallback,
                                     const BatchElementErrorCallback& errorCallback);
 
   /// @}

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -913,9 +913,11 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    */
 
   /**
-   * Callback signature used for a successful entity relationship query.
+   * Callback signature used for a successful paged entity relationship
+   * query.
    */
-  using RelationshipSuccessCallback = std::function<void(std::size_t, EntityReferences)>;
+  using PagedRelationshipSuccessCallback =
+      std::function<void(std::size_t, managerApi::EntityReferencePagerInterfacePtr)>;
 
   /**
    * Queries entity references that are related to the input
@@ -934,139 +936,11 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * default implementation returns an empty list for all
    * relationships.
    *
-   * @param entityReferences A list of @ref entity_reference
-   * "entity references" to query the specified relationship for.
-   *
-   * @param relationshipTraitsData The traits of the relationship to
-   * query.
-   *
-   * @param resultTraitSet A hint as to what traits the returned
-   * entities should have. May be empty.
-   *
-   * @param relationsAccess The host's intended usage of the returned
-   * references.
-   *
-   * @param context The calling context.
-   *
-   * @param hostSession The host session that maps to the caller, this
-   * should be used for all logging and provides access to the Host
-   * object representing the process that initiated the API session.
-   *
-   * @param successCallback Callback that must be called for each
-   * successful relationship query for an input entity reference. It
-   * should be given the corresponding index of the entity reference
-   * in @p entityReferences along with a list of entity references for
-   * entities that have the relationship specified by
-   * @p relationshipTraitsData. If there are no relations, an empty
-   * list should be passed to the callback. The callback must be
-   * called on the same thread that initiated the call to
-   * `getWithRelationship`.
-   *
-   * @param errorCallback Callback that must be called for each
-   * failed relationship query for an entity reference. It should be
-   * given the corresponding index of the entity reference in
-   * @p entityReferences along with a populated
-   * @fqref{errors.BatchElementError} "BatchElementError" (see
-   * @fqref{errors.BatchElementError.ErrorCode} "ErrorCodes"). The
-   * callback must be called on the same thread that initiated the call
-   * to `getWithRelationship`.
-   *
-   * @note Ensure that your implementation of @ref managementPolicy
-   * responds appropriately when queried with relationship trait sets
-   * and a read policy to communicate to the host whether or not you are
-   * capable of handling queries for those relationships in this method.
-   */
-  virtual void getWithRelationship(const EntityReferences& entityReferences,
-                                   const trait::TraitsDataPtr& relationshipTraitsData,
-                                   const trait::TraitSet& resultTraitSet,
-                                   access::RelationsAccess relationsAccess,
-                                   const ContextConstPtr& context,
-                                   const HostSessionPtr& hostSession,
-                                   const RelationshipSuccessCallback& successCallback,
-                                   const BatchElementErrorCallback& errorCallback);
-
-  /**
-   * Queries entity references that are related to the input
-   * reference by the relationships defined by a set of traits and
-   * their properties. Each element of @p relationshipTraitsDatas
-   * defines a specific relationship to query.
-   *
-   * This is an essential function in this API - as it is widely used
-   * to query other entities or organisational structure.
-   *
-   * @note Consult the documentation for the relevant relationship
-   * traits to determine if the order of entities in the inner lists
-   * of matching references is required to be meaningful.
-   *
-   * If any relationship definition is unknown, then an empty list
-   * must be returned for that relationship, and no errors raised. The
-   * default implementation returns an empty list for all
-   * relationships.
-   *
-   * @param entityReference The @ref entity_reference to query the
-   * specified relationships for.
-   *
-   * @param relationshipTraitsDatas The traits of the relationships to
-   * query.
-   *
-   * @param resultTraitSet A hint as to what traits the returned
-   * entities should have. May be empty.
-   *
-   * @param relationsAccess The host's intended usage of the returned
-   * references.
-   *
-   * @param context Context The calling context.
-   *
-   * @param hostSession The host session that maps to the caller, this
-   * should be used for all logging and provides access to the Host
-   * object representing the process that initiated the API session.
-   *
-   * @param successCallback Callback that must be called for each
-   * successful relationship query for an input relationship. It should
-   * be given the corresponding index of the relationship definition in
-   * @p relationshipTraitsDatas along with a list of entity references
-   * for entities that are related to @p entityReference by that
-   * relationship. If there are no relations, an empty list should be
-   * passed to the callback. The callback must be called on the same
-   * thread that initiated the call to `getWithRelationships`.
-   *
-   * @param errorCallback Callback that must be called for each failed
-   * query for a relationship. It should be given the corresponding
-   * index of the relationship in @p relationshipTraitsDatas along with
-   * a populated BatchElementError (see BatchElementError.ErrorCode
-   * "ErrorCodes"). The callback must be called on the same thread that
-   * initiated the call to `getWithRelationships`.
-   *
-   * @note Ensure that your implementation of @ref managementPolicy
-   * responds appropriately when queried with relationship trait sets
-   * and a read policy to communicate to the host whether or not you are
-   * capable of handling queries for those relationships in this method.
-   */
-  virtual void getWithRelationships(const EntityReference& entityReference,
-                                    const trait::TraitsDatas& relationshipTraitsDatas,
-                                    const trait::TraitSet& resultTraitSet,
-                                    access::RelationsAccess relationsAccess,
-                                    const ContextConstPtr& context,
-                                    const HostSessionPtr& hostSession,
-                                    const RelationshipSuccessCallback& successCallback,
-                                    const BatchElementErrorCallback& errorCallback);
-
-  /**
-   * Callback signature used for a successful paged entity relationship
-   * query.
-   */
-  using PagedRelationshipSuccessCallback =
-      std::function<void(std::size_t, managerApi::EntityReferencePagerInterfacePtr)>;
-
-  /**
-   * Paged version of getWithRelationship. See non-paged
-   * @ref getWithRelationship for further documentation.
-   *
-   * @param relationshipTraitsData The traits of the relationship to
-   * query.
-   *
    * @param entityReferences A list of @ref entity_reference to query
    * the specified relationship for.
+   *
+   * @param relationshipTraitsData The traits of the relationship to
+   * query.
    *
    * @param pageSize The size of each page of data. The page size must
    * be fixed for the lifetime of pager object given to the @p
@@ -1108,24 +982,38 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * @param resultTraitSet A hint as to what traits the returned
    * entities should have.
    */
-  virtual void getWithRelationshipPaged(const EntityReferences& entityReferences,
-                                        const trait::TraitsDataPtr& relationshipTraitsData,
-                                        const trait::TraitSet& resultTraitSet, size_t pageSize,
-                                        access::RelationsAccess relationsAccess,
-                                        const ContextConstPtr& context,
-                                        const HostSessionPtr& hostSession,
-                                        const PagedRelationshipSuccessCallback& successCallback,
-                                        const BatchElementErrorCallback& errorCallback);
+  virtual void getWithRelationship(const EntityReferences& entityReferences,
+                                   const trait::TraitsDataPtr& relationshipTraitsData,
+                                   const trait::TraitSet& resultTraitSet, size_t pageSize,
+                                   access::RelationsAccess relationsAccess,
+                                   const ContextConstPtr& context,
+                                   const HostSessionPtr& hostSession,
+                                   const PagedRelationshipSuccessCallback& successCallback,
+                                   const BatchElementErrorCallback& errorCallback);
 
   /**
-   * Paged version of getWithRelationships. See non-paged
-   * @ref getWithRelationships for further documentation.
+   * Queries entity references that are related to the input
+   * reference by the relationships defined by a set of traits and
+   * their properties. Each element of @p relationshipTraitsDatas
+   * defines a specific relationship to query.
    *
-   * @param relationshipTraitsDatas The traits of the relationships to
-   * query.
+   * This is an essential function in this API - as it is widely used
+   * to query other entities or organisational structure.
+   *
+   * @note Consult the documentation for the relevant relationship
+   * traits to determine if the order of entities in the inner lists
+   * of matching references is required to be meaningful.
+   *
+   * If any relationship definition is unknown, then an empty list
+   * must be returned for that relationship, and no errors raised. The
+   * default implementation returns an empty list for all
+   * relationships.
    *
    * @param entityReference The @ref entity_reference to query the
    * specified relationships for.
+   *
+   * @param relationshipTraitsDatas The traits of the relationships to
+   * query.
    *
    * @param pageSize The size of each page of data. The page size is
    * fixed for the lifetime of pager object given to the @p
@@ -1171,14 +1059,14 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * to @ref managementPolicy in order to determine if the manager
    * handles relationships of that type.
    */
-  virtual void getWithRelationshipsPaged(const EntityReference& entityReference,
-                                         const trait::TraitsDatas& relationshipTraitsDatas,
-                                         const trait::TraitSet& resultTraitSet, size_t pageSize,
-                                         access::RelationsAccess relationsAccess,
-                                         const ContextConstPtr& context,
-                                         const HostSessionPtr& hostSession,
-                                         const PagedRelationshipSuccessCallback& successCallback,
-                                         const BatchElementErrorCallback& errorCallback);
+  virtual void getWithRelationships(const EntityReference& entityReference,
+                                    const trait::TraitsDatas& relationshipTraitsDatas,
+                                    const trait::TraitSet& resultTraitSet, size_t pageSize,
+                                    access::RelationsAccess relationsAccess,
+                                    const ContextConstPtr& context,
+                                    const HostSessionPtr& hostSession,
+                                    const PagedRelationshipSuccessCallback& successCallback,
+                                    const BatchElementErrorCallback& errorCallback);
 
   /// @}
   /**

--- a/src/openassetio-core/src/hostApi/Manager.cpp
+++ b/src/openassetio-core/src/hostApi/Manager.cpp
@@ -253,34 +253,11 @@ void Manager::defaultEntityReference(const trait::TraitSets &traitSets,
 
 void Manager::getWithRelationship(const EntityReferences &entityReferences,
                                   const trait::TraitsDataPtr &relationshipTraitsData,
-                                  const access::RelationsAccess relationsAccess,
+                                  size_t pageSize, const access::RelationsAccess relationsAccess,
                                   const ContextConstPtr &context,
-                                  const Manager::RelationshipSuccessCallback &successCallback,
+                                  const Manager::PagedRelationshipSuccessCallback &successCallback,
                                   const Manager::BatchElementErrorCallback &errorCallback,
                                   const trait::TraitSet &resultTraitSet) {
-  managerInterface_->getWithRelationship(entityReferences, relationshipTraitsData, resultTraitSet,
-                                         relationsAccess, context, hostSession_, successCallback,
-                                         errorCallback);
-}
-
-void Manager::getWithRelationships(const EntityReference &entityReference,
-                                   const trait::TraitsDatas &relationshipTraitsDatas,
-                                   const access::RelationsAccess relationsAccess,
-                                   const ContextConstPtr &context,
-                                   const Manager::RelationshipSuccessCallback &successCallback,
-                                   const Manager::BatchElementErrorCallback &errorCallback,
-                                   const trait::TraitSet &resultTraitSet) {
-  managerInterface_->getWithRelationships(entityReference, relationshipTraitsDatas, resultTraitSet,
-                                          relationsAccess, context, hostSession_, successCallback,
-                                          errorCallback);
-}
-
-void Manager::getWithRelationshipPaged(
-    const EntityReferences &entityReferences, const trait::TraitsDataPtr &relationshipTraitsData,
-    size_t pageSize, const access::RelationsAccess relationsAccess, const ContextConstPtr &context,
-    const Manager::PagedRelationshipSuccessCallback &successCallback,
-    const Manager::BatchElementErrorCallback &errorCallback,
-    const trait::TraitSet &resultTraitSet) {
   if (pageSize == 0) {
     throw errors::InputValidationException{"pageSize must be greater than zero."};
   }
@@ -297,12 +274,12 @@ void Manager::getWithRelationshipPaged(
         auto pager = hostApi::EntityReferencePager::make(std::move(pagerInterface), hostSession);
         successCallback(idx, std::move(pager));
       };
-  managerInterface_->getWithRelationshipPaged(
-      entityReferences, relationshipTraitsData, resultTraitSet, pageSize, relationsAccess, context,
-      hostSession_, convertingPagerSuccessCallback, errorCallback);
+  managerInterface_->getWithRelationship(entityReferences, relationshipTraitsData, resultTraitSet,
+                                         pageSize, relationsAccess, context, hostSession_,
+                                         convertingPagerSuccessCallback, errorCallback);
 }
 
-void Manager::getWithRelationshipsPaged(
+void Manager::getWithRelationships(
     const EntityReference &entityReference, const trait::TraitsDatas &relationshipTraitsDatas,
     size_t pageSize, const access::RelationsAccess relationsAccess, const ContextConstPtr &context,
     const Manager::PagedRelationshipSuccessCallback &successCallback,
@@ -324,9 +301,9 @@ void Manager::getWithRelationshipsPaged(
         auto pager = hostApi::EntityReferencePager::make(std::move(pagerInterface), hostSession);
         successCallback(idx, std::move(pager));
       };
-  managerInterface_->getWithRelationshipsPaged(
-      entityReference, relationshipTraitsDatas, resultTraitSet, pageSize, relationsAccess, context,
-      hostSession_, convertingPagerSuccessCallback, errorCallback);
+  managerInterface_->getWithRelationships(entityReference, relationshipTraitsDatas, resultTraitSet,
+                                          pageSize, relationsAccess, context, hostSession_,
+                                          convertingPagerSuccessCallback, errorCallback);
 }
 
 void Manager::preflight(const EntityReferences &entityReferences,

--- a/src/openassetio-core/src/hostApi/Manager.cpp
+++ b/src/openassetio-core/src/hostApi/Manager.cpp
@@ -255,7 +255,7 @@ void Manager::getWithRelationship(const EntityReferences &entityReferences,
                                   const trait::TraitsDataPtr &relationshipTraitsData,
                                   size_t pageSize, const access::RelationsAccess relationsAccess,
                                   const ContextConstPtr &context,
-                                  const Manager::PagedRelationshipSuccessCallback &successCallback,
+                                  const Manager::RelationshipQuerySuccessCallback &successCallback,
                                   const Manager::BatchElementErrorCallback &errorCallback,
                                   const trait::TraitSet &resultTraitSet) {
   if (pageSize == 0) {
@@ -282,7 +282,7 @@ void Manager::getWithRelationship(const EntityReferences &entityReferences,
 void Manager::getWithRelationships(
     const EntityReference &entityReference, const trait::TraitsDatas &relationshipTraitsDatas,
     size_t pageSize, const access::RelationsAccess relationsAccess, const ContextConstPtr &context,
-    const Manager::PagedRelationshipSuccessCallback &successCallback,
+    const Manager::RelationshipQuerySuccessCallback &successCallback,
     const Manager::BatchElementErrorCallback &errorCallback,
     const trait::TraitSet &resultTraitSet) {
   if (pageSize == 0) {

--- a/src/openassetio-core/src/managerApi/ManagerInterface.cpp
+++ b/src/openassetio-core/src/managerApi/ManagerInterface.cpp
@@ -72,34 +72,6 @@ void ManagerInterface::defaultEntityReference(
   }
 }
 
-void ManagerInterface::getWithRelationship(
-    const EntityReferences& entityReferences,
-    [[maybe_unused]] const trait::TraitsDataPtr& relationshipTraitsData,
-    [[maybe_unused]] const trait::TraitSet& resultTraitSet,
-    [[maybe_unused]] const access::RelationsAccess relationsAccess,
-    [[maybe_unused]] const ContextConstPtr& context,
-    [[maybe_unused]] const HostSessionPtr& hostSession,
-    const ManagerInterface::RelationshipSuccessCallback& successCallback,
-    [[maybe_unused]] const ManagerInterface::BatchElementErrorCallback& errorCallback) {
-  for (EntityReferences::size_type idx = 0, size = entityReferences.size(); idx < size; ++idx) {
-    successCallback(idx, {});
-  }
-}
-void ManagerInterface::getWithRelationships(
-    [[maybe_unused]] const EntityReference& entityReference,
-    const trait::TraitsDatas& relationshipTraitsDatas,
-    [[maybe_unused]] const trait::TraitSet& resultTraitSet,
-    [[maybe_unused]] const access::RelationsAccess relationsAccess,
-    [[maybe_unused]] const ContextConstPtr& context,
-    [[maybe_unused]] const HostSessionPtr& hostSession,
-    const ManagerInterface::RelationshipSuccessCallback& successCallback,
-    [[maybe_unused]] const ManagerInterface::BatchElementErrorCallback& errorCallback) {
-  for (trait::TraitsDatas::size_type idx = 0, size = relationshipTraitsDatas.size(); idx < size;
-       ++idx) {
-    successCallback(idx, {});
-  }
-}
-
 namespace {
 /*
  * A dummy pager interface that acts as if it has no data. For use in
@@ -115,7 +87,7 @@ class EmptyEntityReferencePagerInterface : public managerApi::EntityReferencePag
 
 }  // namespace
 
-void ManagerInterface::getWithRelationshipPaged(
+void ManagerInterface::getWithRelationship(
     const EntityReferences& entityReferences,
     [[maybe_unused]] const trait::TraitsDataPtr& relationshipTraitsData,
     [[maybe_unused]] const trait::TraitSet& resultTraitSet, [[maybe_unused]] size_t pageSize,
@@ -131,7 +103,7 @@ void ManagerInterface::getWithRelationshipPaged(
   }
 }
 
-void ManagerInterface::getWithRelationshipsPaged(
+void ManagerInterface::getWithRelationships(
     [[maybe_unused]] const EntityReference& entityReference,
     const trait::TraitsDatas& relationshipTraitsDatas,
     [[maybe_unused]] const trait::TraitSet& resultTraitSet, [[maybe_unused]] size_t pageSize,

--- a/src/openassetio-core/src/managerApi/ManagerInterface.cpp
+++ b/src/openassetio-core/src/managerApi/ManagerInterface.cpp
@@ -94,7 +94,7 @@ void ManagerInterface::getWithRelationship(
     [[maybe_unused]] const access::RelationsAccess relationsAccess,
     [[maybe_unused]] const ContextConstPtr& context,
     [[maybe_unused]] const HostSessionPtr& hostSession,
-    const PagedRelationshipSuccessCallback& successCallback,
+    const RelationshipQuerySuccessCallback& successCallback,
     [[maybe_unused]] const BatchElementErrorCallback& errorCallback) {
   const auto size = entityReferences.size();
 
@@ -110,7 +110,7 @@ void ManagerInterface::getWithRelationships(
     [[maybe_unused]] const access::RelationsAccess relationsAccess,
     [[maybe_unused]] const ContextConstPtr& context,
     [[maybe_unused]] const HostSessionPtr& hostSession,
-    const PagedRelationshipSuccessCallback& successCallback,
+    const RelationshipQuerySuccessCallback& successCallback,
     [[maybe_unused]] const BatchElementErrorCallback& errorCallback) {
   const auto size = relationshipTraitsDatas.size();
 

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -162,7 +162,7 @@ void registerManager(const py::module& mod) {
           [](Manager& self, const EntityReference& entityReference,
              const trait::TraitsDatas& relationshipTraitsDatas, size_t pageSize,
              const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
-             const Manager::PagedRelationshipSuccessCallback& successCallback,
+             const Manager::RelationshipQuerySuccessCallback& successCallback,
              const Manager::BatchElementErrorCallback& errorCallback,
              const trait::TraitSet& resultTraitSet) {
             validateTraitsDatas(relationshipTraitsDatas);

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -154,32 +154,11 @@ void registerManager(const py::module& mod) {
            py::arg("defaultEntityAccess"), py::arg("context").none(false),
            py::arg("successCallback"), py::arg("errorCallback"))
       .def("getWithRelationship", &Manager::getWithRelationship, py::arg("entityReferences"),
-           py::arg("relationshipTraitsData").none(false), py::arg("relationsAccess"),
-           py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"),
-           py::arg("resultTraitSet") = trait::TraitSet{})
+           py::arg("relationshipTraitsData").none(false), py::arg("pageSize"),
+           py::arg("relationsAccess"), py::arg("context").none(false), py::arg("successCallback"),
+           py::arg("errorCallback"), py::arg("resultTraitSet") = trait::TraitSet{})
       .def(
           "getWithRelationships",
-          [](Manager& self, const EntityReference& entityReference,
-             const trait::TraitsDatas& relationshipTraitsDatas,
-             const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
-             const Manager::RelationshipSuccessCallback& successCallback,
-             const Manager::BatchElementErrorCallback& errorCallback,
-             const trait::TraitSet& resultTraitSet) {
-            validateTraitsDatas(relationshipTraitsDatas);
-            self.getWithRelationships(entityReference, relationshipTraitsDatas, relationsAccess,
-                                      context, successCallback, errorCallback, resultTraitSet);
-          },
-          py::arg("entityReference"), py::arg("relationshipTraitsDatas"),
-          py::arg("context").none(false), py::arg("context").none(false),
-          py::arg("successCallback"), py::arg("errorCallback"),
-          py::arg("resultTraitSet") = trait::TraitSet{})
-      .def("getWithRelationshipPaged", &Manager::getWithRelationshipPaged,
-           py::arg("entityReferences"), py::arg("relationshipTraitsData").none(false),
-           py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
-           py::arg("successCallback"), py::arg("errorCallback"),
-           py::arg("resultTraitSet") = trait::TraitSet{})
-      .def(
-          "getWithRelationshipsPaged",
           [](Manager& self, const EntityReference& entityReference,
              const trait::TraitsDatas& relationshipTraitsDatas, size_t pageSize,
              const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
@@ -187,9 +166,9 @@ void registerManager(const py::module& mod) {
              const Manager::BatchElementErrorCallback& errorCallback,
              const trait::TraitSet& resultTraitSet) {
             validateTraitsDatas(relationshipTraitsDatas);
-            self.getWithRelationshipsPaged(entityReference, relationshipTraitsDatas, pageSize,
-                                           relationsAccess, context, successCallback,
-                                           errorCallback, resultTraitSet);
+            self.getWithRelationships(entityReference, relationshipTraitsDatas, pageSize,
+                                      relationsAccess, context, successCallback, errorCallback,
+                                      resultTraitSet);
           },
           py::arg("entityReference"), py::arg("relationshipTraitsDatas"), py::arg("pageSize"),
           py::arg("relationsAccess"), py::arg("context").none(false), py::arg("successCallback"),

--- a/src/openassetio-python/cmodule/src/managerApi/ManagerInterfaceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/managerApi/ManagerInterfaceBinding.cpp
@@ -121,42 +121,20 @@ struct PyManagerInterface : ManagerInterface {
 
   void getWithRelationship(
       const EntityReferences& entityReferences, const trait::TraitsDataPtr& relationshipTraitsData,
-      const trait::TraitSet& resultTraitSet, const access::RelationsAccess relationsAccess,
-      const ContextConstPtr& context, const HostSessionPtr& hostSession,
-      const ManagerInterface::RelationshipSuccessCallback& successCallback,
-      const ManagerInterface::BatchElementErrorCallback& errorCallback) override {
-    PYBIND11_OVERRIDE(void, ManagerInterface, getWithRelationship, entityReferences,
-                      relationshipTraitsData, resultTraitSet, relationsAccess, context,
-                      hostSession, successCallback, errorCallback);
-  }
-
-  void getWithRelationships(
-      const EntityReference& entityReference, const trait::TraitsDatas& relationshipTraitsDatas,
-      const trait::TraitSet& resultTraitSet, const access::RelationsAccess relationsAccess,
-      const ContextConstPtr& context, const HostSessionPtr& hostSession,
-      const ManagerInterface::RelationshipSuccessCallback& successCallback,
-      const ManagerInterface::BatchElementErrorCallback& errorCallback) override {
-    PYBIND11_OVERRIDE(void, ManagerInterface, getWithRelationships, entityReference,
-                      relationshipTraitsDatas, resultTraitSet, relationsAccess, context,
-                      hostSession, successCallback, errorCallback);
-  }
-
-  void getWithRelationshipPaged(
-      const EntityReferences& entityReferences, const trait::TraitsDataPtr& relationshipTraitsData,
       const trait::TraitSet& resultTraitSet, size_t pageSize,
       const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
       const HostSessionPtr& hostSession,
       const ManagerInterface::PagedRelationshipSuccessCallback& successCallback,
       const ManagerInterface::BatchElementErrorCallback& errorCallback) override {
     OPENASSETIO_PYBIND11_OVERRIDE_ARGS(
-        void, ManagerInterface, getWithRelationshipPaged,
+        void, ManagerInterface, getWithRelationship,
         (entityReferences, relationshipTraitsData, resultTraitSet, pageSize, relationsAccess,
          context, hostSession, successCallback, errorCallback),
         entityReferences, relationshipTraitsData, resultTraitSet, pageSize, relationsAccess,
         context, hostSession, RetainCommonPyArgs::forFn(successCallback), errorCallback);
   }
 
-  void getWithRelationshipsPaged(
+  void getWithRelationships(
       const EntityReference& entityReference, const trait::TraitsDatas& relationshipTraitsDatas,
       const trait::TraitSet& resultTraitSet, size_t pageSize,
       const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
@@ -164,7 +142,7 @@ struct PyManagerInterface : ManagerInterface {
       const ManagerInterface::PagedRelationshipSuccessCallback& successCallback,
       const ManagerInterface::BatchElementErrorCallback& errorCallback) override {
     OPENASSETIO_PYBIND11_OVERRIDE_ARGS(
-        void, ManagerInterface, getWithRelationshipsPaged,
+        void, ManagerInterface, getWithRelationships,
         (entityReference, relationshipTraitsDatas, resultTraitSet, pageSize, relationsAccess,
          context, hostSession, successCallback, errorCallback),
         entityReference, relationshipTraitsDatas, resultTraitSet, pageSize, relationsAccess,
@@ -240,26 +218,16 @@ void registerManagerInterface(const py::module& mod) {
            py::arg("traitSets"), py::arg("defaultEntityAccess"), py::arg("context").none(false),
            py::arg("hostSession").none(false), py::arg("successCallback"),
            py::arg("errorCallback"))
-      .def("getWithRelationshipPaged", &ManagerInterface::getWithRelationshipPaged,
-           py::arg("entityReferences"), py::arg("relationshipTraitsData").none(false),
-           py::arg("resultTraitSet"), py::arg("pageSize").none(false), py::arg("relationsAccess"),
-           py::arg("context").none(false), py::arg("hostSession").none(false),
-           py::arg("successCallback"), py::arg("errorCallback"))
-      .def("getWithRelationshipsPaged", &ManagerInterface::getWithRelationshipsPaged,
-           py::arg("entityReference"), py::arg("relationshipTraitsDatas"),
-           py::arg("resultTraitSet"), py::arg("pageSize").none(false), py::arg("relationsAccess"),
-           py::arg("context").none(false), py::arg("hostSession").none(false),
-           py::arg("successCallback"), py::arg("errorCallback"))
       .def("getWithRelationship", &ManagerInterface::getWithRelationship,
            py::arg("entityReferences"), py::arg("relationshipTraitsData").none(false),
-           py::arg("resultTraitSet"), py::arg("relationsAccess"), py::arg("context").none(false),
-           py::arg("hostSession").none(false), py::arg("successCallback"),
-           py::arg("errorCallback"))
+           py::arg("resultTraitSet"), py::arg("pageSize"), py::arg("relationsAccess"),
+           py::arg("context").none(false), py::arg("hostSession").none(false),
+           py::arg("successCallback"), py::arg("errorCallback"))
       .def("getWithRelationships", &ManagerInterface::getWithRelationships,
            py::arg("entityReference"), py::arg("relationshipTraitsDatas"),
-           py::arg("resultTraitSet"), py::arg("relationsAccess"), py::arg("context").none(false),
-           py::arg("hostSession").none(false), py::arg("successCallback"),
-           py::arg("errorCallback"))
+           py::arg("resultTraitSet"), py::arg("pageSize"), py::arg("relationsAccess"),
+           py::arg("context").none(false), py::arg("hostSession").none(false),
+           py::arg("successCallback"), py::arg("errorCallback"))
       .def("preflight", &ManagerInterface::preflight, py::arg("entityReferences"),
            py::arg("traitsHints"), py::arg("publishingAccess"), py::arg("context").none(false),
            py::arg("hostSession").none(false), py::arg("successCallback"),

--- a/src/openassetio-python/cmodule/src/managerApi/ManagerInterfaceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/managerApi/ManagerInterfaceBinding.cpp
@@ -124,7 +124,7 @@ struct PyManagerInterface : ManagerInterface {
       const trait::TraitSet& resultTraitSet, size_t pageSize,
       const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
       const HostSessionPtr& hostSession,
-      const ManagerInterface::PagedRelationshipSuccessCallback& successCallback,
+      const ManagerInterface::RelationshipQuerySuccessCallback& successCallback,
       const ManagerInterface::BatchElementErrorCallback& errorCallback) override {
     OPENASSETIO_PYBIND11_OVERRIDE_ARGS(
         void, ManagerInterface, getWithRelationship,
@@ -139,7 +139,7 @@ struct PyManagerInterface : ManagerInterface {
       const trait::TraitSet& resultTraitSet, size_t pageSize,
       const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
       const HostSessionPtr& hostSession,
-      const ManagerInterface::PagedRelationshipSuccessCallback& successCallback,
+      const ManagerInterface::RelationshipQuerySuccessCallback& successCallback,
       const ManagerInterface::BatchElementErrorCallback& errorCallback) override {
     OPENASSETIO_PYBIND11_OVERRIDE_ARGS(
         void, ManagerInterface, getWithRelationships,

--- a/src/openassetio-python/package/openassetio/test/manager/apiComplianceSuite.py
+++ b/src/openassetio-python/package/openassetio/test/manager/apiComplianceSuite.py
@@ -581,7 +581,7 @@ class Test_register(FixtureAugmentedTestCase):
 class Test_getWithRelationship_All(FixtureAugmentedTestCase):
     """
     Check plugin's implementation of
-    managerApi.ManagerInterface.getWithRelationship[s][Paged]
+    managerApi.ManagerInterface.getWithRelationship[s]
     """
 
     def test_when_relation_unknown_then_no_pages_returned(self):
@@ -589,19 +589,11 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
         an_unknown_rel = TraitsData({"🐠🐟🐠🐟"})
 
         with self.subTest("getWithRelationship"):
-            results = self.__test_getWithRelationship_success([a_ref], an_unknown_rel)
-            self.assertListEqual(results, [[]])
-
-        with self.subTest("getWithRelationships"):
-            results = self.__test_getWithRelationships_success(a_ref, [an_unknown_rel])
-            self.assertListEqual(results, [[]])
-
-        with self.subTest("getWithRelationshipPaged"):
-            [pager] = self.__test_getWithRelationshipPaged_success([a_ref], an_unknown_rel)
+            [pager] = self.__test_getWithRelationship_success([a_ref], an_unknown_rel)
             self.__assert_pager_is_at_end(pager)
 
-        with self.subTest("getWithRelationshipsPaged"):
-            [pager] = self.__test_getWithRelationshipsPaged_success(a_ref, [an_unknown_rel])
+        with self.subTest("getWithRelationships"):
+            [pager] = self.__test_getWithRelationships_success(a_ref, [an_unknown_rel])
             self.__assert_pager_is_at_end(pager)
 
     def test_when_batched_then_same_number_of_returned_relationships(self):
@@ -609,19 +601,11 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
         a_ref = self.requireEntityReferenceFixture("a_reference")
 
         with self.subTest("getWithRelationship"):
-            results = self.__test_getWithRelationship_success([a_ref] * 5, a_rel)
-            self.assertEqual(len(results), 5)
-
-        with self.subTest("getWithRelationships"):
-            results = self.__test_getWithRelationships_success(a_ref, [a_rel] * 5)
-            self.assertEqual(len(results), 5)
-
-        with self.subTest("getWithRelationshipPaged"):
-            pagers = self.__test_getWithRelationshipPaged_success([a_ref] * 5, a_rel)
+            pagers = self.__test_getWithRelationship_success([a_ref] * 5, a_rel)
             self.assertEqual(len(pagers), 5)
 
-        with self.subTest("getWithRelationshipsPaged"):
-            pagers = self.__test_getWithRelationshipsPaged_success(a_ref, [a_rel] * 5)
+        with self.subTest("getWithRelationships"):
+            pagers = self.__test_getWithRelationships_success(a_ref, [a_rel] * 5)
             self.assertEqual(len(pagers), 5)
 
     def test_when_relationship_trait_set_known_then_all_with_trait_set_returned(self):
@@ -630,20 +614,12 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
         expected = self.requireEntityReferencesFixture("expected_related_entity_references")
 
         with self.subTest("getWithRelationship"):
-            [actual] = self.__test_getWithRelationship_success([a_ref], a_rel)
-            self.assertListEqual(actual, expected)
-
-        with self.subTest("getWithRelationships"):
-            [actual] = self.__test_getWithRelationships_success(a_ref, [a_rel])
-            self.assertListEqual(actual, expected)
-
-        with self.subTest("getWithRelationshipPaged"):
-            [pager] = self.__test_getWithRelationshipPaged_success([a_ref], a_rel)
+            [pager] = self.__test_getWithRelationship_success([a_ref], a_rel)
             actual = self.__concat_all_pages(pager)
             self.assertListEqual(actual, expected)
 
-        with self.subTest("getWithRelationshipsPaged"):
-            [pager] = self.__test_getWithRelationshipsPaged_success(a_ref, [a_rel])
+        with self.subTest("getWithRelationships"):
+            [pager] = self.__test_getWithRelationships_success(a_ref, [a_rel])
             actual = self.__concat_all_pages(pager)
             self.assertListEqual(actual, expected)
 
@@ -655,20 +631,12 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
         expected = self.requireEntityReferencesFixture("expected_related_entity_references")
 
         with self.subTest("getWithRelationship"):
-            [actual] = self.__test_getWithRelationship_success([a_ref], a_rel)
-            self.assertListEqual(actual, expected)
-
-        with self.subTest("getWithRelationships"):
-            [actual] = self.__test_getWithRelationships_success(a_ref, [a_rel])
-            self.assertListEqual(actual, expected)
-
-        with self.subTest("getWithRelationshipPaged"):
-            [pager] = self.__test_getWithRelationshipPaged_success([a_ref], a_rel)
+            [pager] = self.__test_getWithRelationship_success([a_ref], a_rel)
             actual = self.__concat_all_pages(pager)
             self.assertListEqual(actual, expected)
 
-        with self.subTest("getWithRelationshipsPaged"):
-            [pager] = self.__test_getWithRelationshipsPaged_success(a_ref, [a_rel])
+        with self.subTest("getWithRelationships"):
+            [pager] = self.__test_getWithRelationships_success(a_ref, [a_rel])
             actual = self.__concat_all_pages(pager)
             self.assertListEqual(actual, expected)
 
@@ -679,26 +647,14 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
         expected = self.requireEntityReferencesFixture("expected_related_entity_references")
 
         with self.subTest("getWithRelationship"):
-            [actual] = self.__test_getWithRelationship_success(
-                [a_ref], a_rel, resultTraitSet=result_trait_set
-            )
-            self.assertListEqual(actual, expected)
-
-        with self.subTest("getWithRelationships"):
-            [actual] = self.__test_getWithRelationships_success(
-                a_ref, [a_rel], resultTraitSet=result_trait_set
-            )
-            self.assertListEqual(actual, expected)
-
-        with self.subTest("getWithRelationshipPaged"):
-            [pager] = self.__test_getWithRelationshipPaged_success(
+            [pager] = self.__test_getWithRelationship_success(
                 [a_ref], a_rel, resultTraitSet=result_trait_set
             )
             actual = self.__concat_all_pages(pager)
             self.assertListEqual(actual, expected)
 
-        with self.subTest("getWithRelationshipsPaged"):
-            [pager] = self.__test_getWithRelationshipsPaged_success(
+        with self.subTest("getWithRelationships"):
+            [pager] = self.__test_getWithRelationships_success(
                 a_ref, [a_rel], resultTraitSet=result_trait_set
             )
             actual = self.__concat_all_pages(pager)
@@ -728,22 +684,6 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
                 expected_error_message,
             )
 
-        with self.subTest("getWithRelationshipPaged"):
-            self.__test_getWithRelationshipPaged_error(
-                entity_reference,
-                relationship_trait_set,
-                expected_error_code,
-                expected_error_message,
-            )
-
-        with self.subTest("getWithRelationshipsPaged"):
-            self.__test_getWithRelationshipsPaged_error(
-                entity_reference,
-                relationship_trait_set,
-                expected_error_code,
-                expected_error_message,
-            )
-
     def test_when_querying_malformed_reference_then_malformed_reference_error_is_returned(self):
         relationship_trait_set = self.requireFixture(
             "a_relationship_trait_set", skipTestIfMissing=True
@@ -762,22 +702,6 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
 
         with self.subTest("getWithRelationships"):
             self.__test_getWithRelationships_error(
-                entity_reference,
-                relationship_trait_set,
-                expected_error_code,
-                expected_error_message,
-            )
-
-        with self.subTest("getWithRelationshipPaged"):
-            self.__test_getWithRelationshipPaged_error(
-                entity_reference,
-                relationship_trait_set,
-                expected_error_code,
-                expected_error_message,
-            )
-
-        with self.subTest("getWithRelationshipsPaged"):
-            self.__test_getWithRelationshipsPaged_error(
                 entity_reference,
                 relationship_trait_set,
                 expected_error_code,
@@ -829,17 +753,17 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
             self.__assert_pager_is_at_end(pager)
 
         for page_size in (1, 2):
-            with self.subTest("getWithRelationshipPaged", page_size=page_size):
+            with self.subTest("getWithRelationship", page_size=page_size):
                 test_for_page_size(
                     page_size,
-                    lambda pageSize=page_size: self.__test_getWithRelationshipPaged_success(
+                    lambda pageSize=page_size: self.__test_getWithRelationship_success(
                         [a_ref], a_rel, pageSize=pageSize
                     ),
                 )
-            with self.subTest("getWithRelationshipsPaged", page_size=page_size):
+            with self.subTest("getWithRelationships", page_size=page_size):
                 test_for_page_size(
                     page_size,
-                    lambda pageSize=page_size: self.__test_getWithRelationshipsPaged_success(
+                    lambda pageSize=page_size: self.__test_getWithRelationships_success(
                         a_ref, [a_rel], pageSize=pageSize
                     ),
                 )
@@ -879,11 +803,11 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
                 weakref.ref(result_trait_set),
             )
 
-        with self.subTest("getWithRelationshipPaged"):
+        with self.subTest("getWithRelationship"):
             _pager, *weak_args = get_pager_and_weakref_args(
                 lambda refs, relationships, context, result_trait_set:
                 # Call method to get pager under test.
-                self.__test_getWithRelationshipPaged_success(
+                self.__test_getWithRelationship_success(
                     refs, relationships[0], context=context, resultTraitSet=result_trait_set
                 )
             )
@@ -892,11 +816,11 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
             living_args = [weak_arg() for weak_arg in weak_args]
             self.assertListEqual(living_args, [None] * len(living_args))
 
-        with self.subTest("getWithRelationshipsPaged"):
+        with self.subTest("getWithRelationships"):
             _pager, *weak_args = get_pager_and_weakref_args(
                 lambda refs, relationships, context, result_trait_set:
                 # Call method to get pager under test.
-                self.__test_getWithRelationshipsPaged_success(
+                self.__test_getWithRelationships_success(
                     refs[0], relationships, context=context, resultTraitSet=result_trait_set
                 )
             )
@@ -905,48 +829,7 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
             living_args = [weak_arg() for weak_arg in weak_args]
             self.assertListEqual(living_args, [None] * len(living_args))
 
-    def __test_getWithRelationship_success(self, references, relationship, resultTraitSet=None):
-        if resultTraitSet is None:
-            resultTraitSet = set()
-        context = self.createTestContext()
-        results = []
-
-        self._manager.getWithRelationship(
-            references,
-            relationship,
-            RelationsAccess.kRead,
-            context,
-            lambda _idx, traits_data: results.append(traits_data),
-            lambda idx, batch_element_error: self.fail(
-                f"getWithRelationship should not error for: '{references[idx].toString()}': "
-                f"{batch_element_error.message}"
-            ),
-            resultTraitSet,
-        )
-        return results
-
-    def __test_getWithRelationships_success(self, reference, relationships, resultTraitSet=None):
-        if resultTraitSet is None:
-            resultTraitSet = set()
-        context = self.createTestContext()
-        results = []
-
-        self._manager.getWithRelationships(
-            reference,
-            relationships,
-            RelationsAccess.kRead,
-            context,
-            lambda _idx, traits_data: results.append(traits_data),
-            lambda idx, batch_element_error: self.fail(
-                f"getWithRelationships should not error for index {idx}: "
-                f"{batch_element_error.message}"
-            ),
-            resultTraitSet,
-        )
-
-        return results
-
-    def __test_getWithRelationshipPaged_success(
+    def __test_getWithRelationship_success(
         self, references, relationship, pageSize=10, context=None, resultTraitSet=None
     ):
         if context is None:
@@ -957,7 +840,7 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
 
         pagers = [None] * len(references)
 
-        self._manager.getWithRelationshipPaged(
+        self._manager.getWithRelationship(
             references,
             relationship,
             pageSize,
@@ -965,7 +848,7 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
             context,
             lambda idx, pager: operator.setitem(pagers, idx, pager),
             lambda idx, batch_element_error: self.fail(
-                f"getWithRelationshipPaged should not error for: '{references[idx].toString()}': "
+                f"getWithRelationship should not error for: '{references[idx].toString()}': "
                 f"{batch_element_error.message}"
             ),
             resultTraitSet,
@@ -974,7 +857,7 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
         self.assertTrue(all(pager is not None for pager in pagers))
         return pagers
 
-    def __test_getWithRelationshipsPaged_success(
+    def __test_getWithRelationships_success(
         self, reference, relationships, pageSize=10, context=None, resultTraitSet=None
     ):
         if context is None:
@@ -985,7 +868,7 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
 
         pagers = [None] * len(relationships)
 
-        self._manager.getWithRelationshipsPaged(
+        self._manager.getWithRelationships(
             reference,
             relationships,
             pageSize,
@@ -993,7 +876,7 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
             context,
             lambda idx, pager: operator.setitem(pagers, idx, pager),
             lambda idx, batch_element_error: self.fail(
-                f"getWithRelationshipsPaged should not error for index {idx}: "
+                f"getWithRelationships should not error for index {idx}: "
                 f"{batch_element_error.message}"
             ),
             resultTraitSet,
@@ -1016,12 +899,14 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
         relationship = TraitsData(relationship_trait_set)
 
         results = []
+
         self._manager.getWithRelationship(
             [entity_reference],
             relationship,
+            1,
             RelationsAccess.kRead,
             context,
-            lambda _idx, _refs: self.fail("Unexpected success callback"),
+            lambda _idx, _pager: self.fail("Unexpected success callback"),
             lambda _idx, batch_element_error: results.append(batch_element_error),
         )
         [actual_error] = results  # pylint: disable=unbalanced-tuple-unpacking
@@ -1042,62 +927,8 @@ class Test_getWithRelationship_All(FixtureAugmentedTestCase):
         relationship = TraitsData(relationship_trait_set)
 
         results = []
+
         self._manager.getWithRelationships(
-            entity_reference,
-            [relationship],
-            RelationsAccess.kRead,
-            context,
-            lambda _idx, _refs: self.fail("Unexpected success callback"),
-            lambda _idx, batch_element_error: results.append(batch_element_error),
-        )
-        [actual_error] = results  # pylint: disable=unbalanced-tuple-unpacking
-
-        self.assertEqual(actual_error, expected_error)
-
-    def __test_getWithRelationshipPaged_error(
-        self,
-        entity_reference,
-        relationship_trait_set,
-        expected_error_code,
-        expected_error_message,
-    ):
-        expected_error = BatchElementError(expected_error_code, expected_error_message)
-
-        context = self.createTestContext()
-
-        relationship = TraitsData(relationship_trait_set)
-
-        results = []
-
-        self._manager.getWithRelationshipPaged(
-            [entity_reference],
-            relationship,
-            1,
-            RelationsAccess.kRead,
-            context,
-            lambda _idx, _pager: self.fail("Unexpected success callback"),
-            lambda _idx, batch_element_error: results.append(batch_element_error),
-        )
-        [actual_error] = results  # pylint: disable=unbalanced-tuple-unpacking
-
-        self.assertEqual(actual_error, expected_error)
-
-    def __test_getWithRelationshipsPaged_error(
-        self,
-        entity_reference,
-        relationship_trait_set,
-        expected_error_code,
-        expected_error_message,
-    ):
-        expected_error = BatchElementError(expected_error_code, expected_error_message)
-
-        context = self.createTestContext()
-
-        relationship = TraitsData(relationship_trait_set)
-
-        results = []
-
-        self._manager.getWithRelationshipsPaged(
             entity_reference,
             [relationship],
             1,

--- a/src/openassetio-python/tests/conftest.py
+++ b/src/openassetio-python/tests/conftest.py
@@ -286,6 +286,7 @@ class ValidatingMockManagerInterface(ManagerInterface):
         entityReferences,
         relationshipTraitsData,
         resultTraitSet,
+        pageSize,
         relationsAccess,
         context,
         hostSession,
@@ -298,12 +299,15 @@ class ValidatingMockManagerInterface(ManagerInterface):
         self.__assertCallingContext(context, hostSession)
         assert isinstance(resultTraitSet, set)
         self.__assertIsIterableOf(resultTraitSet, str)
+        assert isinstance(pageSize, int)
+        assert pageSize > 0
         assert callable(successCallback)
         assert callable(errorCallback)
         return self.mock.getWithRelationship(
             entityReferences,
             relationshipTraitsData,
             resultTraitSet,
+            pageSize,
             relationsAccess,
             context,
             hostSession,
@@ -316,6 +320,7 @@ class ValidatingMockManagerInterface(ManagerInterface):
         entityReference,
         relationshipTraitsDatas,
         resultTraitSet,
+        pageSize,
         relationsAccess,
         context,
         hostSession,
@@ -326,80 +331,13 @@ class ValidatingMockManagerInterface(ManagerInterface):
         assert isinstance(entityReference, EntityReference)
         assert isinstance(relationsAccess, RelationsAccess)
         self.__assertCallingContext(context, hostSession)
+        assert isinstance(pageSize, int)
+        assert pageSize > 0
         assert callable(successCallback)
         assert callable(errorCallback)
         assert isinstance(resultTraitSet, set)
         self.__assertIsIterableOf(resultTraitSet, str)
         return self.mock.getWithRelationships(
-            entityReference,
-            relationshipTraitsDatas,
-            resultTraitSet,
-            relationsAccess,
-            context,
-            hostSession,
-            successCallback,
-            errorCallback,
-        )
-
-    # Paged overload
-    def getWithRelationshipPaged(
-        self,
-        entityReferences,
-        relationshipTraitsData,
-        resultTraitSet,
-        pageSize,
-        relationsAccess,
-        context,
-        hostSession,
-        successCallback,
-        errorCallback,
-    ):
-        assert isinstance(relationshipTraitsData, TraitsData)
-        self.__assertIsIterableOf(entityReferences, EntityReference)
-        assert isinstance(relationsAccess, RelationsAccess)
-        self.__assertCallingContext(context, hostSession)
-        assert isinstance(resultTraitSet, set)
-        self.__assertIsIterableOf(resultTraitSet, str)
-        assert isinstance(pageSize, int)
-        assert pageSize > 0
-        assert callable(successCallback)
-        assert callable(errorCallback)
-        return self.mock.getWithRelationshipPaged(
-            entityReferences,
-            relationshipTraitsData,
-            resultTraitSet,
-            pageSize,
-            relationsAccess,
-            context,
-            hostSession,
-            successCallback,
-            errorCallback,
-        )
-
-    # Paged overload
-    def getWithRelationshipsPaged(
-        self,
-        entityReference,
-        relationshipTraitsDatas,
-        resultTraitSet,
-        pageSize,
-        relationsAccess,
-        context,
-        hostSession,
-        successCallback,
-        errorCallback,
-    ):
-        self.__assertIsIterableOf(relationshipTraitsDatas, TraitsData)
-        assert isinstance(entityReference, EntityReference)
-        assert isinstance(relationsAccess, RelationsAccess)
-        self.__assertCallingContext(context, hostSession)
-        assert isinstance(pageSize, int)
-        assert pageSize > 0
-        assert callable(successCallback)
-        assert callable(errorCallback)
-        assert isinstance(resultTraitSet, set)
-        self.__assertIsIterableOf(resultTraitSet, str)
-        return self.mock.getWithRelationshipsPaged(
             entityReference,
             relationshipTraitsDatas,
             resultTraitSet,

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -441,267 +441,6 @@ class Test_Manager_defaultEntityReference:
         error_callback.assert_called_once_with(2, a_batch_element_error)
 
 
-class Test_Manager_getWithRelationship:
-    def test_method_defined_in_cpp(self, method_introspector):
-        assert not method_introspector.is_defined_in_python(Manager.getWithRelationship)
-        assert method_introspector.is_implemented_once(Manager, "getWithRelationship")
-
-    def test_wraps_the_corresponding_method_of_the_held_interface(
-        self,
-        manager,
-        mock_manager_interface,
-        a_host_session,
-        a_ref,
-        a_different_ref,
-        a_batch_element_error,
-        an_empty_traitsdata,
-        an_entity_trait_set,
-        a_context,
-        invoke_getWithRelationship_success_cb,
-        invoke_getWithRelationship_error_cb,
-    ):
-        # pylint: disable=too-many-locals
-
-        two_refs = [a_ref, a_ref]
-        two_different_refs = [a_different_ref, a_different_ref]
-
-        success_callback = mock.Mock()
-        error_callback = mock.Mock()
-
-        method = mock_manager_interface.mock.getWithRelationship
-
-        def call_callbacks(*_args):
-            invoke_getWithRelationship_success_cb(0, two_different_refs)
-            invoke_getWithRelationship_error_cb(1, a_batch_element_error)
-
-        method.side_effect = call_callbacks
-
-        manager.getWithRelationship(
-            two_refs,
-            an_empty_traitsdata,
-            access.RelationsAccess.kWrite,
-            a_context,
-            success_callback,
-            error_callback,
-        )
-
-        method.assert_called_once_with(
-            two_refs,
-            an_empty_traitsdata,
-            set(),
-            access.RelationsAccess.kWrite,
-            a_context,
-            a_host_session,
-            mock.ANY,
-            mock.ANY,
-        )
-
-        success_callback.assert_called_once_with(0, two_different_refs)
-        error_callback.assert_called_once_with(1, a_batch_element_error)
-
-        mock_manager_interface.mock.reset_mock()
-
-        # Check optional resultTraitSet
-
-        manager.getWithRelationship(
-            two_refs,
-            an_empty_traitsdata,
-            access.RelationsAccess.kWrite,
-            a_context,
-            success_callback,
-            error_callback,
-            an_entity_trait_set,
-        )
-
-        method.assert_called_once_with(
-            two_refs,
-            an_empty_traitsdata,
-            an_entity_trait_set,
-            access.RelationsAccess.kWrite,
-            a_context,
-            a_host_session,
-            mock.ANY,
-            mock.ANY,
-        )
-
-    def test_when_default_resultTraitSet_modified_then_modifications_dont_persist(
-        self,
-        manager,
-        mock_manager_interface,
-        a_ref,
-        an_empty_traitsdata,
-        a_context,
-    ):
-        def mutate_resultTraitSet(_, __, result_trait_set, *_args):
-            result_trait_set.add("this shouldn't persist")
-
-        def assert_resultTraitSet_empty(_, __, result_trait_set, *_args):
-            assert result_trait_set == set()
-
-        # First call mutates the defaulted resultTraitSet parameter.
-        mock_manager_interface.mock.getWithRelationship.side_effect = mutate_resultTraitSet
-        manager.getWithRelationship(
-            [a_ref],
-            an_empty_traitsdata,
-            access.RelationsAccess.kWrite,
-            a_context,
-            mock.Mock(),
-            mock.Mock(),
-        )
-
-        # Second call asserts that the mutation of the first call didn't
-        # persist in the default value.
-        mock_manager_interface.mock.getWithRelationship.side_effect = assert_resultTraitSet_empty
-        manager.getWithRelationship(
-            [a_ref],
-            an_empty_traitsdata,
-            access.RelationsAccess.kWrite,
-            a_context,
-            mock.Mock(),
-            mock.Mock(),
-        )
-
-        # Confidence check: ensure we actually called the manager plugin.
-        assert mock_manager_interface.mock.getWithRelationship.call_count == 2
-
-
-class Test_Manager_getWithRelationships:
-    def test_method_defined_in_cpp(self, method_introspector):
-        assert not method_introspector.is_defined_in_python(Manager.getWithRelationships)
-        assert method_introspector.is_implemented_once(Manager, "getWithRelationships")
-
-    def test_wraps_the_corresponding_method_of_the_held_interface(
-        self,
-        manager,
-        mock_manager_interface,
-        a_host_session,
-        a_ref,
-        a_different_ref,
-        a_batch_element_error,
-        an_empty_traitsdata,
-        an_entity_trait_set,
-        a_context,
-        invoke_getWithRelationships_success_cb,
-        invoke_getWithRelationships_error_cb,
-    ):
-        two_datas = [an_empty_traitsdata, an_empty_traitsdata]
-        two_different_refs = [a_different_ref, a_different_ref]
-
-        success_callback = mock.Mock()
-        error_callback = mock.Mock()
-
-        method = mock_manager_interface.mock.getWithRelationships
-
-        def call_callbacks(*_args):
-            invoke_getWithRelationships_success_cb(0, two_different_refs)
-            invoke_getWithRelationships_error_cb(1, a_batch_element_error)
-
-        method.side_effect = call_callbacks
-
-        manager.getWithRelationships(
-            a_ref,
-            two_datas,
-            access.RelationsAccess.kWrite,
-            a_context,
-            success_callback,
-            error_callback,
-        )
-
-        method.assert_called_once_with(
-            a_ref,
-            two_datas,
-            set(),
-            access.RelationsAccess.kWrite,
-            a_context,
-            a_host_session,
-            mock.ANY,
-            mock.ANY,
-        )
-
-        success_callback.assert_called_once_with(0, two_different_refs)
-        error_callback.assert_called_once_with(1, a_batch_element_error)
-
-        mock_manager_interface.mock.reset_mock()
-
-        # Check optional resultTraitSet
-
-        manager.getWithRelationships(
-            a_ref,
-            two_datas,
-            access.RelationsAccess.kWrite,
-            a_context,
-            success_callback,
-            error_callback,
-            an_entity_trait_set,
-        )
-
-        method.assert_called_once_with(
-            a_ref,
-            two_datas,
-            an_entity_trait_set,
-            access.RelationsAccess.kWrite,
-            a_context,
-            a_host_session,
-            mock.ANY,
-            mock.ANY,
-        )
-
-    def test_when_relationship_is_None_then_exception_raised(
-        self, manager, mock_manager_interface, a_ref, a_context
-    ):
-        with pytest.raises(TypeError):
-            manager.getWithRelationships(
-                [TraitsData(), None],
-                a_ref,
-                access.RelationsAccess.kWrite,
-                a_context,
-                mock.Mock(),
-                mock.Mock(),
-            )
-
-        assert not mock_manager_interface.mock.getWithRelationships.called
-
-    def test_when_default_resultTraitSet_modified_then_modifications_dont_persist(
-        self,
-        manager,
-        mock_manager_interface,
-        a_ref,
-        an_empty_traitsdata,
-        a_context,
-    ):
-        def mutate_resultTraitSet(_, __, result_trait_set, *_args):
-            result_trait_set.add("this shouldn't persist")
-
-        def assert_resultTraitSet_empty(_, __, result_trait_set, *_args):
-            assert result_trait_set == set()
-
-        # First call mutates the defaulted resultTraitSet parameter.
-        mock_manager_interface.mock.getWithRelationships.side_effect = mutate_resultTraitSet
-        manager.getWithRelationships(
-            a_ref,
-            [an_empty_traitsdata],
-            access.RelationsAccess.kWrite,
-            a_context,
-            mock.Mock(),
-            mock.Mock(),
-        )
-
-        # Second call asserts that the mutation of the first call didn't
-        # persist in the default value.
-        mock_manager_interface.mock.getWithRelationships.side_effect = assert_resultTraitSet_empty
-        manager.getWithRelationships(
-            a_ref,
-            [an_empty_traitsdata],
-            access.RelationsAccess.kWrite,
-            a_context,
-            mock.Mock(),
-            mock.Mock(),
-        )
-
-        # Confidence check: ensure we actually called the manager plugin.
-        assert mock_manager_interface.mock.getWithRelationships.call_count == 2
-
-
 class FakeEntityReferencePagerInterface(EntityReferencePagerInterface):
     """
     Throwaway pager interface def, so we can create a temporary
@@ -723,7 +462,7 @@ class FakeEntityReferencePagerInterface(EntityReferencePagerInterface):
         pass
 
 
-class Test_Manager_getWithRelationshipPaged:
+class Test_Manager_getWithRelationship:
     def test_wraps_the_corresponding_method_of_the_held_interface(
         self,
         manager,
@@ -736,8 +475,8 @@ class Test_Manager_getWithRelationshipPaged:
         an_entity_trait_set,
         an_entity_reference_pager,
         a_context,
-        invoke_getWithRelationshipPaged_success_cb,
-        invoke_getWithRelationshipPaged_error_cb,
+        invoke_getWithRelationship_success_cb,
+        invoke_getWithRelationship_error_cb,
     ):
         # pylint: disable=too-many-locals
 
@@ -747,15 +486,15 @@ class Test_Manager_getWithRelationshipPaged:
         success_callback = mock.Mock()
         error_callback = mock.Mock()
 
-        method = mock_manager_interface.mock.getWithRelationshipPaged
+        method = mock_manager_interface.mock.getWithRelationship
 
         def call_callbacks(*_args):
-            invoke_getWithRelationshipPaged_success_cb(0, mock_entity_reference_pager_interface)
-            invoke_getWithRelationshipPaged_error_cb(1, a_batch_element_error)
+            invoke_getWithRelationship_success_cb(0, mock_entity_reference_pager_interface)
+            invoke_getWithRelationship_error_cb(1, a_batch_element_error)
 
         method.side_effect = call_callbacks
 
-        manager.getWithRelationshipPaged(
+        manager.getWithRelationship(
             two_refs,
             an_empty_traitsdata,
             page_size,
@@ -792,7 +531,7 @@ class Test_Manager_getWithRelationshipPaged:
 
         # Check optional resultTraitSet
 
-        manager.getWithRelationshipPaged(
+        manager.getWithRelationship(
             two_refs,
             an_empty_traitsdata,
             page_size,
@@ -825,8 +564,8 @@ class Test_Manager_getWithRelationshipPaged:
         an_empty_traitsdata,
         an_entity_trait_set,
         a_context,
-        invoke_getWithRelationshipPaged_success_cb,
-        invoke_getWithRelationshipPaged_error_cb,
+        invoke_getWithRelationship_success_cb,
+        invoke_getWithRelationship_error_cb,
     ):
         # pylint: disable=too-many-locals
 
@@ -835,16 +574,16 @@ class Test_Manager_getWithRelationshipPaged:
 
         error_callback = mock.Mock()
 
-        method = mock_manager_interface.mock.getWithRelationshipPaged
+        method = mock_manager_interface.mock.getWithRelationship
 
         def call_callbacks(*_args):
-            invoke_getWithRelationshipPaged_success_cb(0, FakeEntityReferencePagerInterface())
-            invoke_getWithRelationshipPaged_error_cb(1, a_batch_element_error)
+            invoke_getWithRelationship_success_cb(0, FakeEntityReferencePagerInterface())
+            invoke_getWithRelationship_error_cb(1, a_batch_element_error)
 
         method.side_effect = call_callbacks
 
         pagers = []
-        manager.getWithRelationshipPaged(
+        manager.getWithRelationship(
             two_refs,
             an_empty_traitsdata,
             page_size,
@@ -870,7 +609,7 @@ class Test_Manager_getWithRelationshipPaged:
         error_callback = mock.Mock()
 
         with pytest.raises(InputValidationException):
-            manager.getWithRelationshipPaged(
+            manager.getWithRelationship(
                 two_refs,
                 an_empty_traitsdata,
                 page_size,
@@ -882,7 +621,7 @@ class Test_Manager_getWithRelationshipPaged:
             )
 
 
-class Test_Manager_getWithRelationshipsPaged:
+class Test_Manager_getWithRelationships:
     def test_wraps_the_corresponding_method_of_the_held_interface(
         self,
         manager,
@@ -895,8 +634,8 @@ class Test_Manager_getWithRelationshipsPaged:
         mock_entity_reference_pager_interface,
         an_entity_reference_pager,
         a_context,
-        invoke_getWithRelationshipsPaged_success_cb,
-        invoke_getWithRelationshipsPaged_error_cb,
+        invoke_getWithRelationships_success_cb,
+        invoke_getWithRelationships_error_cb,
     ):
         two_datas = [an_empty_traitsdata, an_empty_traitsdata]
         page_size = 3
@@ -904,15 +643,15 @@ class Test_Manager_getWithRelationshipsPaged:
         success_callback = mock.Mock()
         error_callback = mock.Mock()
 
-        method = mock_manager_interface.mock.getWithRelationshipsPaged
+        method = mock_manager_interface.mock.getWithRelationships
 
         def call_callbacks(*_args):
-            invoke_getWithRelationshipsPaged_success_cb(0, mock_entity_reference_pager_interface)
-            invoke_getWithRelationshipsPaged_error_cb(1, a_batch_element_error)
+            invoke_getWithRelationships_success_cb(0, mock_entity_reference_pager_interface)
+            invoke_getWithRelationships_error_cb(1, a_batch_element_error)
 
         method.side_effect = call_callbacks
 
-        manager.getWithRelationshipsPaged(
+        manager.getWithRelationships(
             a_ref,
             two_datas,
             page_size,
@@ -949,7 +688,7 @@ class Test_Manager_getWithRelationshipsPaged:
 
         # Check optional resultTraitSet
 
-        manager.getWithRelationshipsPaged(
+        manager.getWithRelationships(
             a_ref,
             two_datas,
             page_size,
@@ -981,24 +720,24 @@ class Test_Manager_getWithRelationshipsPaged:
         an_empty_traitsdata,
         an_entity_trait_set,
         a_context,
-        invoke_getWithRelationshipsPaged_success_cb,
-        invoke_getWithRelationshipsPaged_error_cb,
+        invoke_getWithRelationships_success_cb,
+        invoke_getWithRelationships_error_cb,
     ):
         two_datas = [an_empty_traitsdata, an_empty_traitsdata]
         page_size = 3
 
         error_callback = mock.Mock()
 
-        method = mock_manager_interface.mock.getWithRelationshipsPaged
+        method = mock_manager_interface.mock.getWithRelationships
 
         def call_callbacks(*_args):
-            invoke_getWithRelationshipsPaged_success_cb(0, FakeEntityReferencePagerInterface())
-            invoke_getWithRelationshipsPaged_error_cb(1, a_batch_element_error)
+            invoke_getWithRelationships_success_cb(0, FakeEntityReferencePagerInterface())
+            invoke_getWithRelationships_error_cb(1, a_batch_element_error)
 
         method.side_effect = call_callbacks
 
         pagers = []
-        manager.getWithRelationshipsPaged(
+        manager.getWithRelationships(
             a_ref,
             two_datas,
             page_size,
@@ -1024,7 +763,7 @@ class Test_Manager_getWithRelationshipsPaged:
         error_callback = mock.Mock()
 
         with pytest.raises(InputValidationException):
-            manager.getWithRelationshipsPaged(
+            manager.getWithRelationships(
                 a_ref,
                 two_datas,
                 page_size,
@@ -3136,64 +2875,10 @@ def invoke_defaultEntityReference_error_cb(mock_manager_interface):
 
 
 @pytest.fixture
-def invoke_getWithRelationshipPaged_success_cb(mock_manager_interface):
-    def invoke(idx, entityReferencesPagerInterface):
-        callback = mock_manager_interface.mock.getWithRelationshipPaged.call_args[0][7]
-        callback(idx, entityReferencesPagerInterface)
-
-    return invoke
-
-
-@pytest.fixture
-def invoke_getWithRelationshipsPaged_error_cb(mock_manager_interface):
-    def invoke(idx, batch_element_error):
-        callback = mock_manager_interface.mock.getWithRelationshipsPaged.call_args[0][8]
-        callback(idx, batch_element_error)
-
-    return invoke
-
-
-@pytest.fixture
-def invoke_getWithRelationshipsPaged_success_cb(mock_manager_interface):
-    def invoke(idx, entityReferencesPagerInterface):
-        callback = mock_manager_interface.mock.getWithRelationshipsPaged.call_args[0][7]
-        callback(idx, entityReferencesPagerInterface)
-
-    return invoke
-
-
-@pytest.fixture
-def invoke_getWithRelationshipPaged_error_cb(mock_manager_interface):
-    def invoke(idx, batch_element_error):
-        callback = mock_manager_interface.mock.getWithRelationshipPaged.call_args[0][8]
-        callback(idx, batch_element_error)
-
-    return invoke
-
-
-@pytest.fixture
 def invoke_getWithRelationship_success_cb(mock_manager_interface):
-    def invoke(idx, entityReferences):
-        callback = mock_manager_interface.mock.getWithRelationship.call_args[0][6]
-        callback(idx, entityReferences)
-
-    return invoke
-
-
-@pytest.fixture
-def invoke_getWithRelationship_error_cb(mock_manager_interface):
-    def invoke(idx, batch_element_error):
+    def invoke(idx, entityReferencesPagerInterface):
         callback = mock_manager_interface.mock.getWithRelationship.call_args[0][7]
-        callback(idx, batch_element_error)
-
-    return invoke
-
-
-@pytest.fixture
-def invoke_getWithRelationships_success_cb(mock_manager_interface):
-    def invoke(idx, entityReferences):
-        callback = mock_manager_interface.mock.getWithRelationships.call_args[0][6]
-        callback(idx, entityReferences)
+        callback(idx, entityReferencesPagerInterface)
 
     return invoke
 
@@ -3201,7 +2886,25 @@ def invoke_getWithRelationships_success_cb(mock_manager_interface):
 @pytest.fixture
 def invoke_getWithRelationships_error_cb(mock_manager_interface):
     def invoke(idx, batch_element_error):
+        callback = mock_manager_interface.mock.getWithRelationships.call_args[0][8]
+        callback(idx, batch_element_error)
+
+    return invoke
+
+
+@pytest.fixture
+def invoke_getWithRelationships_success_cb(mock_manager_interface):
+    def invoke(idx, entityReferencesPagerInterface):
         callback = mock_manager_interface.mock.getWithRelationships.call_args[0][7]
+        callback(idx, entityReferencesPagerInterface)
+
+    return invoke
+
+
+@pytest.fixture
+def invoke_getWithRelationship_error_cb(mock_manager_interface):
+    def invoke(idx, batch_element_error):
+        callback = mock_manager_interface.mock.getWithRelationship.call_args[0][8]
         callback(idx, batch_element_error)
 
     return invoke

--- a/src/openassetio-python/tests/package/managerApi/test_managerinterface.py
+++ b/src/openassetio-python/tests/package/managerApi/test_managerinterface.py
@@ -180,75 +180,9 @@ class Test_ManagerInterface_defaultEntityReference:
 
 
 class Test_ManagerInterface_getWithRelationship:
-    def test_method_defined_in_python(self, method_introspector):
+    def test_method_defined_in_cpp(self, method_introspector):
         assert not method_introspector.is_defined_in_python(ManagerInterface.getWithRelationship)
         assert method_introspector.is_implemented_once(ManagerInterface, "getWithRelationship")
-
-    def test_returns_empty_list_for_each_input(self, manager_interface, a_host_session):
-        success_callback = Mock()
-        error_callback = Mock()
-
-        for refs in (
-            [],
-            [EntityReference("first")],
-            [EntityReference("second"), EntityReference("third")],
-        ):
-            manager_interface.getWithRelationship(
-                refs,
-                TraitsData(),
-                set(),
-                RelationsAccess.kRead,
-                Context(),
-                a_host_session,
-                success_callback,
-                error_callback,
-            )
-
-            error_callback.assert_not_called()
-            success_callback.assert_has_calls([call(i, []) for i in range(len(refs))])
-
-            success_callback.reset_mock()
-
-
-class Test_ManagerInterface_getWithRelationships:
-    def test_method_defined_in_python(self, method_introspector):
-        assert not method_introspector.is_defined_in_python(ManagerInterface.getWithRelationships)
-        assert method_introspector.is_implemented_once(ManagerInterface, "getWithRelationships")
-
-    def test_returns_empty_list_for_each_input(self, manager_interface, a_host_session):
-        success_callback = Mock()
-        error_callback = Mock()
-
-        for rels in (
-            [],
-            [TraitsData()],
-            [TraitsData(), TraitsData()],
-        ):
-            manager_interface.getWithRelationships(
-                EntityReference(""),
-                rels,
-                set(),
-                RelationsAccess.kRead,
-                Context(),
-                a_host_session,
-                success_callback,
-                error_callback,
-            )
-
-            error_callback.assert_not_called()
-            success_callback.assert_has_calls([call(i, []) for i in range(len(rels))])
-
-            success_callback.reset_mock()
-
-
-class Test_ManagerInterface_getWithRelationshipPaged:
-    def test_method_defined_in_cpp(self, method_introspector):
-        assert not method_introspector.is_defined_in_python(
-            ManagerInterface.getWithRelationshipPaged
-        )
-        assert method_introspector.is_implemented_once(
-            ManagerInterface, "getWithRelationshipPaged"
-        )
 
     def test_returns_dummy_pager_for_each_input(self, manager_interface, a_host_session):
         success_callback = Mock()
@@ -259,7 +193,7 @@ class Test_ManagerInterface_getWithRelationshipPaged:
             [EntityReference("first")],
             [EntityReference("second"), EntityReference("third")],
         ):
-            manager_interface.getWithRelationshipPaged(
+            manager_interface.getWithRelationship(
                 refs,
                 TraitsData(),
                 set(),
@@ -282,14 +216,10 @@ class Test_ManagerInterface_getWithRelationshipPaged:
             success_callback.reset_mock()
 
 
-class Test_ManagerInterface_getWithRelationshipsPaged:
+class Test_ManagerInterface_getWithRelationships:
     def test_method_defined_in_cpp(self, method_introspector):
-        assert not method_introspector.is_defined_in_python(
-            ManagerInterface.getWithRelationshipsPaged
-        )
-        assert method_introspector.is_implemented_once(
-            ManagerInterface, "getWithRelationshipsPaged"
-        )
+        assert not method_introspector.is_defined_in_python(ManagerInterface.getWithRelationships)
+        assert method_introspector.is_implemented_once(ManagerInterface, "getWithRelationships")
 
     def test_returns_dummy_pager_for_each_input(self, manager_interface, a_host_session):
         success_callback = Mock()
@@ -300,7 +230,7 @@ class Test_ManagerInterface_getWithRelationshipsPaged:
             [TraitsData()],
             [TraitsData(), TraitsData()],
         ):
-            manager_interface.getWithRelationshipsPaged(
+            manager_interface.getWithRelationships(
                 EntityReference(""),
                 rels,
                 set(),


### PR DESCRIPTION
Closes #1125 

The commit that renames the callback is certainly up for debate, but it seemed more consistent with the new capabilities, etc, and allows future expansion of the (known) add relationship workflows later without a rename.

Has a drop commit targeting https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/pull/78