### PR TITLE
[Docs] Fix `RELEASE_NOTES` sections

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,12 +11,12 @@ v1.0.0-alpha.xx
   namespace will be removed in a future release.
   [#1127](https://github.com/OpenAssetIO/OpenAssetIO/issues/1127)
 
-- Add the `Manager`/`ManagerInterface` `hasCapability` method. A
-  mechanism for the host to query the manager about which particular
-  optional method-sets, or capabilities, it implements.
-  [#1113](https://github.com/OpenAssetIO/OpenAssetIO/issues/1113)
-
 ### Breaking changes
+
+- Add the (required) `Manager`/`ManagerInterface` `hasCapability`
+  method. A mechanism to query the manager about which particular
+  capabilities it implements.
+  [#1113](https://github.com/OpenAssetIO/OpenAssetIO/issues/1113)
 
 - Renamed the `Manager`/`ManagerInterface`
   `PagedRelationshipSuccessCallback` to


### PR DESCRIPTION
Also slightly tweaks the `hasCapability` wording to denote that it is required, and is used by the middlew too (or soon will be).