### PR TITLE
[Docs] Remove misleading use of the term 'stateless'

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -112,6 +112,10 @@ v1.0.0-alpha.xx
   non-existent functionality.
   [#1150](https://github.com/OpenAssetIO/OpenAssetIO/issues/1150)
 
+- Clarified `ManagerInterface` documentation around the relative
+  "stateless" nature of the API and its reentrant design.
+  [#1143](https://github.com/OpenAssetIO/OpenAssetIO/issues/1143)
+
 v1.0.0-alpha.14
 ---------------
 

--- a/doc/contributing/CODING_STANDARDS.md
+++ b/doc/contributing/CODING_STANDARDS.md
@@ -178,13 +178,10 @@ namespace.
 
 ### Const
 
-Methods of interface classes that are conceptually stateless, and their
-corresponding wrapper class methods should not be marked `const`. For
-example, `ManagerInterface` + `Manager`, `HostInterface` and `Host`.
-This may seem to contradict the "stateless" definition, but it allows
-the implementation to maintain private state to service the API requests
-efficiently, such as server connections or caches. Exceptions to this
-are the identification methods that should be constants.
+Methods of interface classes, and their corresponding wrapper class
+methods should not be marked `const`. For example, `ManagerInterface` +
+`Manager`, `HostInterface` and `Host`. This allows the implementation to
+maintain private state to service the API requests if neccesary.
 
 ## String formatting
 

--- a/doc/doxygen/src/ForManagers.dox
+++ b/doc/doxygen/src/ForManagers.dox
@@ -20,9 +20,6 @@
  *
  * - All interaction between the @ref host and a @ref manager occurs
  *   through the manager's implementation of the @ref ManagerInterface.
- *   This is a publicly stateless interface, where all associated
- *   information about the session, and caller are provided to each method
- *   by the API middleware.
  *
  * - A manager's implementation of the @ref ManagerInterface supplied
  *   through its @ref PythonPluginSystemManagerPlugin is wrapped in the
@@ -31,11 +28,16 @@
  *   session state management and other auditing/logging functionality.
  *   It also provides a degree of isolation against future API changes.
  *
- * - The @ref ManagerInterface is designed to be stateless. The
- *   response to any method should only depend on the underlying asset
- *   data and any other objects passed into each call. The same logical
- *   operation may be spread out over time and space. It is critical that
- *   any particular implementation does not rely on local in-memory state.
+ * - Methods of the @ref ManagerInterface are required to be reentrant
+ *   and thread-safe. The response to any method should only depend on
+ *   the local state established during
+ *   @fqref{managerApi.ManagerInterface.initialize} "initialization",
+ *   the underlying asset data and any other objects passed into each
+ *   call. The same logical operation may be spread out over time and
+ *   across processes. It is critical that any particular implementation
+ *   does not rely on local in-memory state across different API
+ *   requests. The only exception here being read-through caches etc. as
+ *   long as they are suitably invalidated when upstream data changes.
  *
  * - The main currency in the interaction with a host is the @ref
  *   entity_reference. These are URIs that uniquely identify an @ref

--- a/doc/doxygen/src/Glossary.dox
+++ b/doc/doxygen/src/Glossary.dox
@@ -293,11 +293,13 @@
  *
  * @section manager_state Manager State
  *
- * The @ref ManagerInterface is, by design, a stateless, re-entrant API.
- * Consequently, the result of any call to an instance of this class
- * should solely depend on the methods arguments. In real-world use
- * however, it is often required to understand that a series of discreet
- * calls to the API may be part of the same logical user action.
+ * The @ref ManagerInterface is a reentrant API by design, and its
+ * implementation must be thread-safe. Consequently, the result of any
+ * call to an instance of this class should solely depend on the
+ * initialization settings, underlying asset data and the method
+ * arguments. In real-world use however, it is often required to
+ * understand that a series of discreet calls to the API may be part of
+ * the same logical user action.
  *
  * The most common (and extreme) example of this is a distributed
  * render. Where multiple processes, spread across multiple hosts are
@@ -308,8 +310,9 @@
  * A far simpler example of associating API calls is to provide caching
  * relative to the lifetime of a specific action.
  *
- * OpenAssetIO provides a mechanism to support the entire range of use cases
- * for 'session state' whilst keeping the interface itself stateless.
+ * OpenAssetIO provides a mechanism to support the entire range of use
+ * cases for 'session state' without making it part of the interface
+ * instance.
  *
  * This is achieved by allowing the manager to inject state into each
  * @ref Context created by the @ref host. The host guarantees to

--- a/doc/doxygen/src/MainPage.dox
+++ b/doc/doxygen/src/MainPage.dox
@@ -173,7 +173,7 @@
  *
  * - The asset management system implements the
  *   @fqref{managerApi.ManagerInterface} "ManagerInterface". This is a
- *   stateless, re-entrant interface that is the sole entry point for
+ *   thread-safe, reentrant interface that is the sole entry point for
  *   all interactions with the host.
  *
  * - The @fqref{hostApi.HostInterface} "HostInterface" represents the

--- a/doc/doxygen/src/ManagerState.dox
+++ b/doc/doxygen/src/ManagerState.dox
@@ -2,14 +2,18 @@
  * @page stable_resolution Stable Entity Resolution
  *
  * @section stable_resolution_overview Overview
+ *
  * One of the main design principles of the @ref ManagerInterface is
- * that it should be stateless, in the sense that any session state is
- * held by the caller and supplied to the manager as part of the method
- * signature. This is to allow multi-threaded access to the @ref ManagerInterface
- * and avoid the need for any additional internal state to exist within
- * its implementation. The @fqref{hostApi.Manager} "Manager"
- * class wraps the interface implementation to help the @ref host
- * with basic session state management.
+ * that it is a reentrant and thread-safe API. Consequently, the result
+ * of any call to an instance of this class should solely depend on the
+ * initialization settings, underlying asset data and the method
+ * arguments. Any session state is held by the caller and supplied to
+ * the manager as part of the method signature. This is to allow
+ * multi-threaded access to the @ref ManagerInterface and avoid the
+ * inherent need for any additional internal state to exist within its
+ * implementation. The @fqref{hostApi.Manager} "Manager" class wraps the
+ * interface implementation to help the @ref host with basic session
+ * state management.
  *
  * Many common use cases require multiple calls to the API to complete a
  * task. Several textures need to be published together, or multiple

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerStateBase.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerStateBase.hpp
@@ -16,13 +16,14 @@ OPENASSETIO_DECLARE_PTR(ManagerStateBase)
 /**
  * An abstract base for all @ref manager_state objects.
  *
- * The manager interface is by design stateless, the state for a
- * session is held in a separate object, whose lifetime is managed by
- * the host. The state object is considered opaque by the rest of the
- * API, and the manager is free to implement this however desired. This
- * class forms an abstract base whose type is used as a value-type to
- * allow instances of any given managers state to be passed through the
- * various language bindings and API middleware.
+ * The manager interface is reentrant by design, and its implementation
+ * must be thread-safe. The state for a session is held in a separate
+ * object, whose lifetime is managed by the host. The state object is
+ * considered opaque by the rest of the API, and the manager is free to
+ * implement this however desired. This class forms an abstract base
+ * whose type is used as a value-type to allow instances of any given
+ * managers state to be passed through the various language bindings and
+ * API middleware.
  *
  * @see @ref stable_resolution
  * @see @ref manager_state

--- a/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystemManagerPlugin.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystemManagerPlugin.py
@@ -73,10 +73,6 @@ class PythonPluginSystemManagerPlugin(PythonPluginSystemPlugin):
 
         Generally this is only directly called by the @ref
         openassetio.pluginSystem.PythonPluginSystemManagerImplementationFactory.
-        It may be called multiple times in a session, but there as the
-        ManagerInterface API itself is specified as being stateless
-        (aside from any internal caching/etc...) then there is no
-        pre-requisite to always return a new instance.
 
         @return ManagerInterface instance
         """


### PR DESCRIPTION
This came from good intentions but is ultimlately misleading, given the settings mechanism, etc.

This also updates to the American form of 're-enterant' to align with our US English docs poicy.

Closes #1143