### PR TITLE
[Core] Remove `PPSManagerPlugin.uiDelegate`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -107,6 +107,10 @@ v1.0.0-alpha.xx
   `Context` is returned without a `managerState`.
   [#163](https://github.com/OpenAssetIO/OpenAssetIO/issues/163)
 
+- Removed the unused `PythonPluginSystemManagerPlugin.uiDelegate`
+  method, along with associated UI related documentation that referenced
+  non-existent functionality.
+  [#1150](https://github.com/OpenAssetIO/OpenAssetIO/issues/1150)
 
 v1.0.0-alpha.14
 ---------------

--- a/doc/doxygen/src/ForHosts.dox
+++ b/doc/doxygen/src/ForHosts.dox
@@ -180,23 +180,8 @@
  *   "managementPolicy" sets the @needsref WantsThumbnail trait, where
  *   possible, generate thumbnails as requested during publishing.
  *
- * - Allow the @needsref ManagerUIDelegate to participate in
- *   browsing/etc... for any data types they have expressed an interest
- *   in managing via @fqref{hostApi.Manager.managementPolicy}
- *   "Manager.managementPolicy".
- *
- * - Make the drawing of any parameters that may hold an @ref
- *   entity_reference delegatable to the @needsref ManagerUIDeleagate.
- *
  * - Create @ref Specification "specifications" for any custom 'asset
  *   types' you may deal with.
  *
- * - You should map any widgets returned by @needsref ManagerUIDelegate.widgets
- *   with the @needsref ui.widgets.attributes.kCreateApplicationPanel flag set to
- *   some native panel type, if you have one.
- *
  * @see @ref example_generating_a_thumbnail
- *
- * @note The UI classes have not yet been migrated from the
- * `FnAssetAPI` code base.
  */

--- a/doc/doxygen/src/ForManagers.dox
+++ b/doc/doxygen/src/ForManagers.dox
@@ -87,14 +87,6 @@
  *   terms that are meaningful for the user. Eg. the state token will be
  *   shared across distributed multi-host renders.
  *
- * - A manager can provide additional UI elements that interact
- *   with the host, by returning them from @needsref ManagerUIDelegate.getWidgets.
- *   The host will create suitable panels, etc. for them, based on the
- *   flags set in @needsref BaseWidget.getAttributes.
- *
- * @note The UI classes have not yet been migrated from the
- * `FnAssetAPI` code base.
- *
  * @section manager_todo Implementation Check List
  *
  * @note You can use the @ref testing_manager_plugins
@@ -219,13 +211,6 @@
  * - Update your implementation of @fqref{managerApi.ManagerInterface.managementPolicy}
  *   "managementPolicy" to cover the relationship trait sets you support.
  *
- * @subsection manager_todo_ui Embedding Custom UI Within the Host
- *
- * @note The UI layer of OpenAssetIO is yet to be ported to this code base,
- * this documentation section is currently in-progress.
- *
- * - Filter any browsers based on the supplied @ref trait_set.
- *
  * @section manager_reading Recommended Reading
  *
  * @see @ref entities_traits_and_specifications
@@ -234,6 +219,4 @@
  * "PythonPluginSystemManagerPlugin"
  * @see @fqref{Context} "Context"
  * @see @fqref{managerApi.Host} "Host"
- * @see @needsref ManagerUIDelegate
- * @see @needsref ui.widgets
  */

--- a/doc/doxygen/src/Glossary.dox
+++ b/doc/doxygen/src/Glossary.dox
@@ -90,12 +90,10 @@
  * entities, for various reasons detailed below.
  *
  * An entity reference can be any string, and there are no constraints
- * on the content of the reference other than that of a std::string.
- * It's worth noting however, that if no custom UI widgets are supplied
- * by a manager, a @ref host will simply display it as a standard
- * string. It is up to the design of the @ref manager to decide on the
- * format for it's entity references, and whether they are in a human
- * readable form.
+ * on the content of the reference other than that of a std::string. It
+ * is up to the design of the @ref manager to decide on the format for
+ * its entity references, and whether they are in a human readable
+ * form.
  *
  * > Note: We strongly recommend using a human-readable form that
  * > follows <a

--- a/doc/doxygen/src/MainPage.dox
+++ b/doc/doxygen/src/MainPage.dox
@@ -47,8 +47,6 @@
  * - @ref publish "Publishing" data for file-based and non-file-based
  *   assets.
  * - Discovery and registration of related assets.
- * - Replacement/augmentation of in-application UI elements such as
- *   browsers and other panels/controls.
  *
  * The API, by design, does _not_:
  * - Define any standardized data structures for the storage or

--- a/src/openassetio-core/include/openassetio/hostApi/ManagerImplementationFactoryInterface.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/ManagerImplementationFactoryInterface.hpp
@@ -19,8 +19,7 @@ OPENASSETIO_DECLARE_PTR(ManagerImplementationFactoryInterface)
 
 /**
  * Manager Factories are responsible for instantiating classes that
- * derive from @fqref{managerApi.ManagerInterface} or @needsref
- * openassetio-ui.implementation.ManagerUIDelegate for use within an
+ * derive from @fqref{managerApi.ManagerInterface} for use within a
  * host.
  *
  * ManagerImplementationFactoryInterface defines the abstract interface

--- a/src/openassetio-python/package/openassetio/__init__.py
+++ b/src/openassetio-python/package/openassetio/__init__.py
@@ -49,9 +49,6 @@ The API covers the following areas:
 
 - Discovery and registration of related assets.
 
-- Replacement/augmentation of in-application UI elements such as
-  browsers and other panels/controls.
-
 The API, by design, does not:
 
 - Define any standardized data structures for the storage or description

--- a/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystemManagerPlugin.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystemManagerPlugin.py
@@ -44,13 +44,6 @@ class PythonPluginSystemManagerPlugin(PythonPluginSystemPlugin):
     In order to register a new asset management system, simply place a
     python package on the appropriate search path, that has a top-level
     attribute called 'plugin', that holds a class derived from this.
-
-    @warning This class, may be used in a batch, or UI session, so
-    consequently, it is imperative that no ui libraries (QtCore, QtGui
-    etc...) are imported unless @ref uiDelegate() is called, and
-    ideally, even then, this should be deferred until something is
-    requested from the @needsref
-    openassetio-ui.implementation.ManagerUIDelegate.
     """
 
     @staticmethod
@@ -88,29 +81,3 @@ class PythonPluginSystemManagerPlugin(PythonPluginSystemPlugin):
         @return ManagerInterface instance
         """
         raise NotImplementedException("interface not implemented")
-
-    @classmethod
-    def uiDelegate(cls, interfaceInstance):
-        """
-        Constructs an instance of the @needsref
-        openassetio-ui.implementation.ManagerUIDelegate
-
-        This is an instance of some class derived from ManagerUIDelegate
-        that is used by the @needsref UISessionManager to provide
-        widgets to a host that may bind into panels in the application,
-        or to allow the application to delegate asset browsing/picking
-        etc...
-
-        @param interfaceInstance An instance of the plugins interface as
-        returned by @ref interface(), this is to allow UI to be
-        configured in relation to a specific instantiation, which may
-        perhaps target a different endpoint due to its settings, etc...
-
-        @note It is safe to import any UI toolkits, etc... *within in
-        this call*, but generally you may want to deffer this to methods
-        in the delegate.
-
-        @return An instance of some class derived from @needsref
-        ManagerUIDelegate.
-        """
-        return None


### PR DESCRIPTION
This is beyond specuative, also removes documentation referencing the non-existant UI layer. This was confusing people.

Closes #1150
