### PR TITLE
[Core] Verify that managers support required capabilities

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -78,6 +78,11 @@ v1.0.0-alpha.xx
   implementation.
   [#163](https://github.com/OpenAssetIO/OpenAssetIO/issues/163)
 
+- The middleware will validate that the manager's implementation provides
+  the `kEntityReferenceIdentification` and `kManagementPolicyQuery`
+  capabilities upon initialization.
+  [#1148](https://github.com/OpenAssetIO/OpenAssetIO/issues/1148)
+
 ### New Features
 
 - Added new exception types, allowing all OpenAssetIO exceptions to


### PR DESCRIPTION
`Manager` will now verify that the wrapped interface implementation suports the required core capabilities. This is done here, as `hasCapability` can only be called post-initialize so we can support proxy interfaces etc...

Closes #1148

As ever, I have no idea any more what constitutes "best practice c++" these days, so attempted to go for 'readability'. C+C most welcome....