### PR TITLE
[CI] Remove `apt install` of Conan `cpython` deps

### DIFF
--- a/resources/build/bootstrap-ubuntu-20.04.sh
+++ b/resources/build/bootstrap-ubuntu-20.04.sh
@@ -7,19 +7,6 @@ sudo apt-get update
 # Install gcc, linters, build tools used by conan and Python 3.
 sudo apt-get install -y build-essential pkgconf clang-format-12 clang-tidy-12 python3-pip ccache
 
-# Install system packages required for the Python 3.9 conan package.
-# These would be installed as part of the conan package install, but
-# we're caching the conan directory via the `actions/cache` Github
-# action, so a fresh Github VM is left without these system packages.
-sudo apt-get install -y --no-install-recommends libfontenc-dev libice-dev libsm-dev libx11-dev \
- libx11-xcb-dev libxcb-cursor-dev libxau-dev libxaw7-dev libxcb-dri3-dev libxcb-icccm4-dev \
- libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-render0-dev \
- libxcb-render-util0-dev libxcb-shape0-dev libxcb-sync-dev libxcb-util-dev libxcb-xfixes0-dev \
- libxcb-xinerama0-dev libxcb-xkb-dev libxcomposite-dev libxcursor-dev libxdamage-dev \
- libxdmcp-dev libxext-dev libxfixes-dev libxi-dev libxinerama-dev libxkbfile-dev libxmu-dev \
- libxmuu-dev libxpm-dev libxrandr-dev libxrender-dev libxres-dev libxss-dev libxt-dev \
- libxtst-dev libxv-dev libxvmc-dev libxxf86vm-dev uuid-dev xkb-data xtrans-dev
-
 # Install additional build tools.
 sudo pip3 install -r "$WORKSPACE/resources/build/requirements.txt"
 # Use explicit predictable conan root path, where packages are cached.


### PR DESCRIPTION
## Description

Part of #1114. The additional system packages for Linux builds are no longer necessary since #1038 - we now use the system-provided Python rather than the `cpython` Conan package, which required all these extra system dependencies.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~
