### PR TITLE
[Examples] Add `hasCapability` check to `simpleResolver.py`

### DIFF
--- a/examples/host/simpleResolver/simpleResolver.py
+++ b/examples/host/simpleResolver/simpleResolver.py
@@ -174,6 +174,14 @@ def main():
     # traits.
     ###
 
+    # Resolution is an optional capability, first check the configured
+    # manager supports it. If we don't, it will throw a
+    # NotImplementedException.
+    if not manager.hasCapability(manager.Capability.kResolution):
+        raise ConfigurationException(
+            f"The manager '{manager.identifier()}' does not support entity resolution"
+        )
+
     # Extract the entity reference and trait set to resolve from
     # the CLI args
 


### PR DESCRIPTION
Hopefully illustrates best practice.

This is pretty bare-bones as we don't have an easy way to properly test this (as we don't have a mock manager that we can puppet the return value for).  We don't have comprehensive coverage of this example anyway, and so it feels better to at least have one example of `hasCapability` out there...

Closes #1166
