### PR TITLE
[CI] More robust openassetio uninstall regex guard

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -101,7 +101,7 @@ jobs:
         # unmodified, failing the build.
         run : >
           python -m pip install -r external/TraitGen/tests/requirements.txt
-          | awk '{print} /Requirement already satisfied: openassetio/{found=1} END{exit !found}'
+          | awk '{print} /Attempting uninstall: openassetio/{found=1} END{exit found}'
 
       - name: Test TraitGen
         run: |


### PR DESCRIPTION
## Description

Fix regex used to detect if TraitGen's `requirements.txt` tries to uninstall `openassetio`.

In OpenAssetIO/OpenAssetIO-TraitGen#51 we had to remove the PyPI dependency on `openassetio` temporarily, since the project now depends on the breaking changes in the latest OpenAssetIO main branch. So `openassetio` was commented out in `tests/requirements.txt` in that project.

We now have two valid cases, either TraitGen's `requirements.txt` tries to install `openassetio` and short-circuits (saying it's already installed), or it doesn't try at all.

So update the guard regex to catch either case, i.e. assert that `pip` does not attempt to uninstall `openassetio`, for whatever reason.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~

## Test Instructions

Locally, from TraitGen project root
```
$ pip install openassetio==1.0.0a12
$ python -m pip install -r tests/requirements.txt | awk '{print} /Attempting uninstall: openassetio/{found=1} END{exit found}'
$ echo $?
```
should be `0`.

Edit `tests/requirements.txt` to uncomment `openassetio` and change to `openassetio>=1.0.0a13`
```
$ pip install openassetio==1.0.0a12
$ python -m pip install -r tests/requirements.txt | awk '{print} /Attempting uninstall: openassetio/{found=1} END{exit found}'
$ echo $?
```
should be `1`

Try again (now that the newer version is installed)
```
$ python -m pip install -r tests/requirements.txt | awk '{print} /Attempting uninstall: openassetio/{found=1} END{exit found}'
$ echo $?
```
should be `0`