### PR TITLE
[CI] Add TraitGen C++ integration tests

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -89,7 +89,7 @@ jobs:
           repository: OpenAssetIO/OpenAssetIO-TraitGen
           path: external/TraitGen
 
-      - name: Install TraitGen
+      - name: Install TraitGen (Python)
         run : |
           python -m pip install external/TraitGen
 
@@ -115,8 +115,7 @@ jobs:
       matrix:
         config:
         - os: windows-2019
-          preamble: call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64
-          shell: cmd
+          shell: bash
         - os: ubuntu-20.04
           shell: bash
         - os: macos-11
@@ -143,10 +142,10 @@ jobs:
         run: >
           ${{ matrix.config.preamble }}
 
-          cmake -S . -B build -G Ninja --install-prefix ${{ github.workspace }}/dist
+          cmake -S . -B build --install-prefix ${{ github.workspace }}/dist
           -DOPENASSETIO_ENABLE_C=ON
 
-          cmake --build build
+          cmake --build build --parallel
 
           cmake --install build
         env:
@@ -161,6 +160,21 @@ jobs:
       - name: Install TraitGen
         run : |
           python -m pip install external/TraitGen
+
+      - name: Install TraitGen test dependencies
+        run : >
+          python -m pip install -r external/TraitGen/tests/requirements.txt
+          | awk '{print} /Attempting uninstall: openassetio/{found=1} END{exit found}'
+        env:
+          PYTHONPATH: ${{ github.workspace }}/dist/lib/python3.9/site-packages
+
+      - name: Test TraitGen (C++)
+        run: |
+          python -m pytest -v -m ctest external/TraitGen
+        env:
+          PYTHONPATH: ${{ github.workspace }}/dist/lib/python3.9/site-packages
+          CMAKE_PREFIX_PATH: ${{ github.workspace }}/dist
+          OPENASSETIO_TRAITGENTEST_CMAKE_PRESET: ci
 
       - name: Checkout OpenAssetIO-Test-CMake
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Closes #841. Since OpenAssetIO/OpenAssetIO-TraitGen#11 (also see follow-up OpenAssetIO/OpenAssetIO-TraitGen#17) there are C++ specific tests for TraitGen.

We were running the TraitGen tests alongside other Python-only tests that use OpenAssetIO installed as a Python pip package, which the TraitGen CMake CTest project cannot use to build against.

So add a separate test run of TraitGen under the "CMake package" integration tests. Only run the tests labelled `ctest`, since the tests for Python codegen are still executed under the "Python e2e" tests.

Since we use `awk` to assert that TraitGen test dependencies don't overwrite OpenAssetIO, we must use `bash` as the shell for all platforms. This means `vcvarsall.bat` can't be used on Windows. So switch to using the default generator for the platform (rather than Ninja), which on Windows will be MSVC and so not requiring `vcvarsall.bat`.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~
