### PR TITLE
[CI] Add TraitGen C++ integration tests

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -89,7 +89,7 @@ jobs:
           repository: OpenAssetIO/OpenAssetIO-TraitGen
           path: external/TraitGen
 
-      - name: Install TraitGen
+      - name: Install TraitGen (Python)
         run : |
           python -m pip install external/TraitGen
 
@@ -115,10 +115,9 @@ jobs:
       matrix:
         config:
         - os: windows-2019
-          preamble: call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64
-          shell: cmd
+          site-packages: Lib/site-packages
         - os: ubuntu-20.04
-          shell: bash
+          site-packages: lib/python3.9/site-packages
         - os: macos-11
           # MacOS toolchain doesn't search /usr/local by default:
           # https://gitlab.kitware.com/cmake/cmake/-/issues/19120
@@ -126,12 +125,10 @@ jobs:
           # OpenAssetIO-Test-CMake) transitively adds linker flags to
           # system libs, which fail due to this issue.
           preamble: export LDFLAGS="-L/usr/local/lib"
-          shell: bash
+          site-packages: lib/python3.9/site-packages
     defaults:
       run:
-        # Annoyingly required here since `matrix` isn't available in
-        # the `shell` property of individual steps.
-        shell: ${{ matrix.config.shell }}
+        shell: bash
 
     steps:
       - uses: actions/checkout@v4
@@ -143,12 +140,12 @@ jobs:
         run: >
           ${{ matrix.config.preamble }}
 
-          cmake -S . -B build -G Ninja --install-prefix ${{ github.workspace }}/dist
-          -DOPENASSETIO_ENABLE_C=ON
+          cmake -S . -B build --install-prefix '${{ github.workspace }}/dist'
+          -DOPENASSETIO_ENABLE_C=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
-          cmake --build build
+          cmake --build build --parallel --config RelWithDebInfo
 
-          cmake --install build
+          cmake --install build --config RelWithDebInfo
         env:
           CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/.conan/conan_paths.cmake
 
@@ -162,6 +159,24 @@ jobs:
         run : |
           python -m pip install external/TraitGen
 
+      - name: Install TraitGen test dependencies
+        run : >
+          python -m pip install -r external/TraitGen/tests/requirements.txt
+          | awk '{print} /Attempting uninstall: openassetio/{found=1} END{exit found}'
+        env:
+          PYTHONPATH: ${{ github.workspace }}/dist/${{ matrix.config.site-packages }}
+
+      - name: Test TraitGen (C++)
+        run: |
+          python -m pytest -v --capture=tee-sys -m ctest external/TraitGen
+        env:
+          PYTHONPATH: ${{ github.workspace }}/dist/${{ matrix.config.site-packages }}
+          CMAKE_PREFIX_PATH: ${{ github.workspace }}/dist
+          # TODO(DF): Consider adding some linting, e.g. compiler
+          # warnings, sanitizers. Will need additional CMake preset(s).
+          OPENASSETIO_TRAITGENTEST_CMAKE_PRESET: test
+          CONAN_USER_HOME: ~/conan
+
       - name: Checkout OpenAssetIO-Test-CMake
         uses: actions/checkout@v4
         with:
@@ -174,12 +189,17 @@ jobs:
           git submodule update --init --recursive --remote OpenAssetIO-MediaCreation
 
       - name: Test CMake package
-        run: |
+        run: >
           ${{ matrix.config.preamble }}
+
           cd external/OpenAssetIO-Test-CMake
-          cmake -S . -B build -G Ninja -DOPENASSETIOTEST_ENABLE_MEDIACREATION_SUBPROJECT=ON
-          cmake --build build
-          ctest -VV --test-dir build
+
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          -DOPENASSETIOTEST_ENABLE_MEDIACREATION_SUBPROJECT=ON
+
+          cmake --build build --parallel --config RelWithDebInfo
+
+          ctest -VV --test-dir build --build-config RelWithDebInfo
         env:
           CMAKE_PREFIX_PATH: ${{ github.workspace }}/dist
           CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/.conan/conan_paths.cmake


### PR DESCRIPTION
## Description

Closes #841. Since OpenAssetIO/OpenAssetIO-TraitGen#11 (also see follow-up OpenAssetIO/OpenAssetIO-TraitGen#17) there are C++ specific tests for TraitGen.

We were running the TraitGen tests alongside other Python-only tests that use OpenAssetIO installed as a Python pip package, which the TraitGen CMake CTest project cannot use to build against.

So add a separate test run of TraitGen under the "CMake package" integration tests. Only run the tests labelled `ctest`, since the tests for Python codegen are still executed under the "Python e2e" tests.

Since we use `awk` to assert that TraitGen test dependencies don't overwrite OpenAssetIO, we must use `bash` as the shell for all platforms. This means `vcvarsall.bat` can't be used on Windows. So switch to using the default generator for the platform (rather than Ninja), which on Windows will be MSVC and so not requiring `vcvarsall.bat`.

Using bash across all platforms is also part of a broader plan, see #1114.

Since we're using the default CMake generators, MSVC becomes multi-config, so we must specify `--config` when executing CMake command lines. Since we're not using Ninja, builds won't be parallelised automatically, so we must specify `--parallel` on the CMake build command line.

TraitGen hardcodes to `RelWithDebInfo` CMake builds, so use that across the board to ensure compatibility.

Note that TraitGen's `pytest -m ctest` triggers a `conan install`. So update the CONAN_USER_HOME to use the same directory as OpenAssetIO, to try to ensure packages are cached. In practice, this may not work since other jobs may lock the cache (found during dev testing). However, the TraitGen test structure is due to change in
OpenAssetIO/OpenAssetIO-TraitGen#32 so it doesn't seem worth spending too much time on finessing.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~

## Reviewer Notes

<!--- Provide any notes to the reviewer that might help them more easily
      understand the changeset. --->

## Test Instructions

<!--- Provide instructions to the reviewer on how to explicitly test
      these changes. --->
