### PR TITLE
Publish platform artifacts from CI.

### DIFF
--- a/.github/workflows/build-vfx-reference-platform.yml
+++ b/.github/workflows/build-vfx-reference-platform.yml
@@ -1,0 +1,59 @@
+# Build and upload an artifact of a CY2022 VFX Reference platform
+# OpenAssetIO.
+
+name: Build for VFX Reference Platform CY22
+on:
+  pull_request:
+    branches-ignore:
+      - docs
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/openassetio/openassetio-build
+
+    steps:
+    - uses: actions/checkout@v3 #Needs to be V3 because of GLIBC ver.
+      with:
+        path: openassetio-checkout
+
+     # We don't want to publish the test build, it gets too big.
+    - name: Build and Install (No Tests)
+      shell: bash
+      run: >
+        cd openassetio-checkout
+
+        mkdir build
+
+        cmake -G Ninja -S . -B build
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+        cmake --build build
+
+        cmake --install build
+
+    - name: Upload archive
+      uses: actions/upload-artifact@v3
+      with:
+        name: openassetio-CY2022
+        path: openassetio-checkout/build/dist
+
+      # Reconfigure to build with tests.
+    - name: Test
+      run: >
+        cd openassetio-checkout
+
+        cmake --preset test build
+
+        ctest -VV --test-dir build --parallel 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,19 +1,22 @@
-# A simple workflow to run tests using pytest against supported Python versions
+# Build OpenAssetIO, push an artifact, and test it, all in one handy workflow.
 
-name: Tests
+name: Build and Test
 on:
   pull_request:
     branches-ignore:
       - docs
     paths-ignore:
       - 'docs/**'
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test:
+  build:
     name: ${{ matrix.config.os }}
     runs-on: ${{ matrix.config.os }}
     strategy:
@@ -48,18 +51,34 @@ jobs:
     - name: Bootstrap
       uses: ./.github/bootstrap_platform
 
-    - name: Configure CMake build
+     # We don't want to publish the test build, it gets too big.
+    - name: Build and Install (No tests)
       run: >
         ${{ matrix.config.preamble }}
 
         cmake -S . -B build -G Ninja
         --install-prefix ${{ github.workspace }}/dist
         --toolchain ${{ github.workspace }}/.conan/conan_paths.cmake
-        --preset test
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
-    - name: Build, install and test
+        cmake --build build
+
+        cmake --install build
+
+    - name: Upload archive
+      uses: actions/upload-artifact@v3
+      with:
+        name: openassetio-${{ matrix.config.os }}
+        path: |
+          ${{ github.workspace }}/dist
+
+    # Reconfigure to add the test target. Ctest should rebuild using
+    # the cached build from prior.
+    - name: Test
       run: >
         ${{ matrix.config.preamble }}
+
+        cmake --preset test build
 
         ctest -VV --test-dir build --parallel 2
 


### PR DESCRIPTION
A continuation of : https://github.com/OpenAssetIO/OpenAssetIO/pull/1187

New PR because the approach changed significantly.

Part of https://github.com/OpenAssetIO/OpenAssetIO/issues/1181

Add archive behaviour to merges to main, so OpenAssetIO is built on all of our runner platforms and archived in github.

Intent is to unlock much better CI behaviour for us, as we are spending a lot of time and effort building OpenAssetIO across dependent repos, as well as just being generally convenient to have.

This will publish an artifact to every PR run, as well as one for each commit to main. The idea being that dependent repos are by default targetted to the `main` branch with the download-artifact action.