### PR TITLE
Ensure non-null `TraitsData` copy-construction

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,12 @@ v1.0.0-beta.x.x
   in Python.
   [#1186](https://github.com/OpenAssetIO/OpenAssetIO/issues/1186)
 
+### Bug fixes
+
+- Throw an exception when attempting to copy-construct a null
+  `TraitsData`.
+  [#1153](https://github.com/OpenAssetIO/OpenAssetIO/issues/1153)
+
 v1.0.0-beta.1.0
 ---------------
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,10 @@ v1.0.0-beta.x.x
   `TraitsData`.
   [#1153](https://github.com/OpenAssetIO/OpenAssetIO/issues/1153)
 
+- Modified no-argument constructor of `Context` to create an empty (but
+  non-null) `locale`.
+  [#1153](https://github.com/OpenAssetIO/OpenAssetIO/issues/1153)
+
 v1.0.0-beta.1.0
 ---------------
 

--- a/src/openassetio-core/include/openassetio/Context.hpp
+++ b/src/openassetio-core/include/openassetio/Context.hpp
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #pragma once
-#include <array>
-#include <cstddef>
 #include <memory>
 
 #include <openassetio/export.h>
+#include <openassetio/trait/TraitsData.hpp>
 #include <openassetio/typedefs.hpp>
 
-OPENASSETIO_FWD_DECLARE(trait, TraitsData)
 OPENASSETIO_FWD_DECLARE(managerApi, ManagerStateBase)
 
 namespace openassetio {
@@ -73,7 +71,7 @@ class OPENASSETIO_CORE_EXPORT Context final {
    * @fqref{hostApi.Manager.createContext} "Manager.createContext"
    * should always be used instead.
    */
-  [[nodiscard]] static ContextPtr make(trait::TraitsDataPtr locale = nullptr,
+  [[nodiscard]] static ContextPtr make(trait::TraitsDataPtr locale = trait::TraitsData::make(),
                                        managerApi::ManagerStateBasePtr managerState = nullptr);
 
  private:

--- a/src/openassetio-core/src/trait/TraitsData.cpp
+++ b/src/openassetio-core/src/trait/TraitsData.cpp
@@ -3,6 +3,7 @@
 
 #include <unordered_map>
 
+#include <openassetio/errors/exceptions.hpp>
 #include <openassetio/trait/TraitsData.hpp>
 
 namespace openassetio {
@@ -90,6 +91,9 @@ TraitsDataPtr TraitsData::make(const trait::TraitSet& traitSet) {
 }
 
 TraitsDataPtr TraitsData::make(const TraitsDataConstPtr& other) {
+  if (!other) {
+    throw errors::InputValidationException("Cannot copy-construct from a null TraitsData");
+  }
   return std::shared_ptr<TraitsData>(new TraitsData(*other));
 }
 

--- a/src/openassetio-core/tests/ContextTest.cpp
+++ b/src/openassetio-core/tests/ContextTest.cpp
@@ -15,3 +15,11 @@ SCENARIO("Context constructor is private") {
   STATIC_REQUIRE_FALSE(std::is_constructible_v<Context, openassetio::trait::TraitsDataPtr,
                                                openassetio::managerApi::ManagerStateBasePtr>);
 }
+
+SCENARIO("Default construction") {
+  GIVEN("a default constructed Context") {
+    const Context::Ptr context = Context::make();
+
+    THEN("the locale is not null") { CHECK(context->locale); }
+  }
+}

--- a/src/openassetio-core/tests/TraitsDataTest.cpp
+++ b/src/openassetio-core/tests/TraitsDataTest.cpp
@@ -4,6 +4,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <openassetio/errors/exceptions.hpp>
 #include <openassetio/trait/TraitsData.hpp>
 #include <openassetio/trait/collection.hpp>
 #include <openassetio/trait/property.hpp>
@@ -51,6 +52,15 @@ SCENARIO("TraitsData make from other creates a deep copy") {
           CHECK(value == Int{1});
         }
       }
+    }
+  }
+  GIVEN("a null TraitsDataPtr") {
+    const TraitsDataPtr nullTraitsData{};
+
+    THEN("attempting to make a copy results in an InputValidationException") {
+      namespace errors = openassetio::errors;
+      CHECK_THROWS_MATCHES(TraitsData::make(nullTraitsData), errors::InputValidationException,
+                           Catch::Message("Cannot copy-construct from a null TraitsData"));
     }
   }
 }

--- a/src/openassetio-python/cmodule/src/trait/TraitsDataBinding.cpp
+++ b/src/openassetio-python/cmodule/src/trait/TraitsDataBinding.cpp
@@ -23,7 +23,7 @@ void registerTraitsData(const py::module& mod) {
       .def(py::init(static_cast<TraitsDataPtr (*)(const trait::TraitSet&)>(&TraitsData::make)),
            py::arg("traitSet"))
       .def(py::init(static_cast<TraitsDataPtr (*)(const TraitsDataConstPtr&)>(&TraitsData::make)),
-           py::arg("other"))
+           py::arg("other").none(false))
       .def("traitSet", &TraitsData::traitSet)
       .def("hasTrait", &TraitsData::hasTrait, py::arg("traitId"))
       .def("addTrait", &TraitsData::addTrait, py::arg("traitId"))

--- a/src/openassetio-python/tests/package/test_context.py
+++ b/src/openassetio-python/tests/package/test_context.py
@@ -28,8 +28,10 @@ from openassetio.trait import TraitsData
 class Test_Context_init:
     def test_when_constructed_with_no_args_then_has_default_configuration(self):
         context = Context()
-        assert context.locale is None
+        assert isinstance(context.locale, TraitsData)
         assert context.managerState is None
+        # Ensure we're not re-using the same instance.
+        assert Context().locale is not context.locale
 
     def test_when_constructed_with_args_then_has_configuration_from_args(self):
         class TestState(managerApi.ManagerStateBase):
@@ -43,6 +45,13 @@ class Test_Context_init:
         assert a_context.locale is expected_locale
         assert a_context.managerState is expected_state
         assert isinstance(a_context.managerState, TestState)
+
+    def test_when_constructed_with_null_locale_then_raises(self):
+        class TestState(managerApi.ManagerStateBase):
+            pass
+
+        with pytest.raises(TypeError, match="incompatible constructor arguments"):
+            Context(None, TestState())
 
 
 class Test_Context_locale:

--- a/src/openassetio-python/tests/package/test_traitsdata.py
+++ b/src/openassetio-python/tests/package/test_traitsdata.py
@@ -20,6 +20,10 @@ class Test_TraitsData_Inheritance:
 
 
 class Test_TraitsData_Copy_Constructor:
+    def test_when_source_is_None_then_raises(self):
+        with pytest.raises(TypeError, match="incompatible constructor arguments"):
+            TraitsData(None)
+
     def test_when_copying_then_deep_copy_is_made(self):
         data_a = TraitsData()
         data_a.setTraitProperty("a", "p", 1)


### PR DESCRIPTION
## Description

Closes #1153. 

Ensure `TraitsData` copy-construction throws an error, rather than segfaults, if given a null `TraitsDataPtr` to copy from.

Ensure the default no-argument constructor of `Context` creates a blank (rather than null) `locale`, so that copy-construction of the `locale` (e.g. in `createChildContext`) can succeed. Note that direct construction of `Context` is non-standard (`createContext` should be used instead), but is still used e.g. in tests.

- [x] I have updated the release notes.
- [ ] ~~I have updated all relevant user documentation.~~
