### PR TITLE
Add `__repr__` support to `EntityReference`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+v1.0.0-beta.x.x
+---------------
+
+### Improvements
+
+- Added the string representation of an `EntityReference` when `repr`'d
+  in Python.
+  [#1186](https://github.com/OpenAssetIO/OpenAssetIO/issues/1186)
+
 v1.0.0-beta.1.0
 ---------------
 

--- a/src/openassetio-python/cmodule/CMakeLists.txt
+++ b/src/openassetio-python/cmodule/CMakeLists.txt
@@ -68,7 +68,9 @@ target_link_libraries(openassetio-python-module
     # Core C++ library.
     openassetio-core
     # pybind, including its handy transitive Python-specific properties.
-    pybind11::module pybind11::windows_extras)
+    pybind11::module pybind11::windows_extras
+    $<BUILD_INTERFACE:fmt::fmt-header-only>
+)
 
 target_include_directories(openassetio-python-module
     PRIVATE

--- a/src/openassetio-python/cmodule/src/EntityReferenceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/EntityReferenceBinding.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <fmt/format.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 
@@ -14,5 +15,9 @@ void registerEntityReference(const py::module& mod) {
       .def(py::init<openassetio::Str>(), py::arg("entityReferenceString"))
       .def("toString", &EntityReference::toString)
       .def("__str__", &EntityReference::toString)
+      .def("__repr__",
+           [](const EntityReference& self) {
+             return fmt::format("<openassetio.EntityReference {}>", self.toString());
+           })
       .def(py::self == py::self);  // NOLINT(misc-redundant-expression)
 }

--- a/src/openassetio-python/cmodule/src/EntityReferenceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/EntityReferenceBinding.cpp
@@ -7,7 +7,7 @@
 
 #include "_openassetio.hpp"
 
-void registerEntityReference(const py::module &mod) {
+void registerEntityReference(const py::module& mod) {
   using openassetio::EntityReference;
 
   py::class_<EntityReference>{mod, "EntityReference", py::is_final()}

--- a/src/openassetio-python/tests/package/test_entityreference.py
+++ b/src/openassetio-python/tests/package/test_entityreference.py
@@ -41,6 +41,14 @@ class Test_EntityReference_toString:
         assert an_entity_reference.toString() == expected
 
 
+class Test_EntityReferenve_repr:
+    def test_returns_angle_bracket_string_with_class_and_value(self):
+        for ref_str in ("a://ref", "a 🦆 v1"):
+            expected = f"<openassetio.EntityReference {ref_str}>"
+            a_ref = EntityReference(ref_str)
+            assert repr(a_ref) == expected
+
+
 class Test_EntityReference_equality:
     def test_when_same_then_compares_equal(self):
         assert EntityReference("something") == EntityReference("something")


### PR DESCRIPTION
We opted not to go for `EntityReference("theStr")` as it gives the impression they may be directly contructed. Outside of tests, this is discouraged, as `manager.createEntityReference` shoud be used instead.

The present implementation avoids quoting the reference and skirts the issue of escaping angle brackes, as this should only be used for debug introspection.

## Note to reviewers

We were discussing the right way to identify the class. The first commit opts for brevity (`<EntityReference ...>`). The other option, which is perhaps better from a broader software ecosystem perspective in [this commit](https://github.com/OpenAssetIO/OpenAssetIO/pull/1197/commits/e76e5a87f5d2290abf1d779848776d5167659092) extends this to `<openassetio.EntityReference ...>`. This could be dropped if desired. Thoughts? It disambiguates when seen in the context of multiple libraries, as is common in a real-world integration.

Closes #1186 