### PR TITLE
[Docs] Remove `ResolvesFutureEntities` use in examples

### DIFF
--- a/doc/doxygen/src/Examples.dox
+++ b/doc/doxygen/src/Examples.dox
@@ -284,9 +284,7 @@
  * from openassetio.access import (
  *     PolicyAccess, ResolveAccess, PublishingAccess)
  * # Commented imports are illustrative and may not exist yet
- * from openassetio_mediacreation.traits.managementPolicy import (
- *     ManagedTrait, ResolvesFutureEntitiesTrait
- * )
+ * from openassetio_mediacreation.traits.managementPolicy import ManagedTrait
  * from openassetio_mediacreation.specifications.files import (
  *     # TextFileSpecification
  * )
@@ -329,20 +327,24 @@
  *    entity_ref, file_spec, PublishingAccess.kWrite, context)
  *
  * # We then check if the manager can tell us where to save the file.
- * if ResolvesFutureEntitiesTrait.isImbuedTo(policy):
- *
- *     # Note we haven't used  `hasCapability` to check the resolution
- *     # capability, as `ResolvedFutureEntitiesTrait` being imbued
- *     # assures us the functionality is available.
- *
+ * # Not all managers support providing every trait property up front,
+ * # or resolving for write at all. This process is currently quite
+ * # cumbersome, but will be improved soon:
+ * #   https://github.com/OpenAssetIO/OpenAssetIO/issues/1209
+ * if manager.hasCapability(Manager.Capability.kResolution):
+ *   try:
  *     working_data = manager.resolve(
  *             working_ref, TextFileSpecification.kTraitSet,
  *             ResolveAccess.kWrite, context)
  *     working_spec = TextFileSpecification(working_data)
  *     if save_url := working_spec.locatableContentTrait().getLocation():
- *         save_path = pathFromURL(save_url)  # URL decode etc
+ *       save_path = pathFromURL(save_url)  # URL decode etc
  *     if custom_encoding := working_spec.textEncodingTrait().getEncoding():
- *         encoding = custom_encoding
+ *       encoding = custom_encoding
+ *   except BatchElementException as exc:
+ *     # Only ignore the case the manager can't provide data
+ *     if exc.error.code != exc.error.ErrorCode.kEntityAccessError
+ *        raise exc
  *
  * # Now we can write the file
  * with open(save_path, 'w', encoding=encoding) as f:
@@ -395,18 +397,23 @@
  * thumbnail_attr = {"width": 128, "height": 128}
  *
  * # See if the manager can tell us where to put it, and what it should be like
- * if ResolvesFutureEntitiesTrait.isImbuedTo(policy):
+ * #   https://github.com/OpenAssetIO/OpenAssetIO/issues/1209
+ * if manager.hasCapability(Manager.Capability.kResolution):
+ *   try:
  *     requested = manager.resolve(
  *             thumbnail_ref, ThumbnailFileSpecification.kTraitSet,
  *             ResolveAccess.kWrite, context)
  *     requested_spec = ThumbnailFileSpecification(requested)
  *     if requested_path := requested_spec.locatableContentTrait().getLocation():
- *         thumbnail_path = pathFromURL(requested_path)
+ *       thumbnail_path = pathFromURL(requested_path)
  *     raster_trait = requested_spec.rasterTrait()
  *     if raster_trait.isImbued():
- *         # 'get' calls can take a default value to avoid exceptions if missing.
- *         thumbnail_attr["width"] = raster_trait.getWidth(thumbnail_attr["width"])
- *         thumbnail_attr["height"] = raster_trait.getHeight(thumbnail_attr["height"])
+ *       # 'get' calls can take a default value to avoid exceptions if missing.
+ *       thumbnail_attr["width"] = raster_trait.getWidth(thumbnail_attr["width"])
+ *       thumbnail_attr["height"] = raster_trait.getHeight(thumbnail_attr["height"])
+ *   except BatchElementException as exc:
+ *     if exc.error.code != exc.error.ErrorCode.kEntityAccessError
+ *        raise exc
  *
  * # Generate a thumbnail using the supplied criteria
  * mk_thumbnail(thumbnail_path, thumbnail_attr["width"], thumbnail_attr["height"])


### PR DESCRIPTION
This has been removed upstream in MediaCreation pending #1209, which will provide a first-class mechanism for managing resolving future entity properties.

This change hopefully keepps the example essentially "legal" in the mean time, albeit cumbersome.

Closes #1210
