### PR TITLE
[CI] Remove mediacreation workaround

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -70,10 +70,6 @@ jobs:
       - name: Test BAL
         run: |
           python -m pip install external/BAL
-          # We can't install BAL's requirements.txt as this includes
-          # openassetio... we really need to sort
-          # https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/72
-          python -m pip install openassetio-mediacreation
           python -m pip install -r external/BAL/tests/requirements.txt
           python -m pytest -v external/BAL/tests
 


### PR DESCRIPTION
Part of https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/72

Can remove this dependency workaround now that BAL is sorted properly.
I think this is the only case of installing BAL dependencies in CI.

This should be merged after https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/pull/91, which is why this is a draft.