### PR TITLE
Re-enable BAL integration tests

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -67,22 +67,21 @@ jobs:
           repository: OpenAssetIO/OpenAssetIO-Manager-BAL
           path: external/BAL
 
-      # Disabled pending https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/pull/93
-#      - name: Test BAL
-#        run: |
-#          python -m pip install external/BAL
-#          # We can't install BAL's requirements.txt as this includes
-#          # openassetio... we really need to sort
-#          # https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/72
-#          python -m pip install openassetio-mediacreation
-#          python -m pip install -r external/BAL/tests/requirements.txt
-#          python -m pytest -v external/BAL/tests
-#
-#      - name: Test Simple Resolver
-#        run: |
-#          python -m pytest -v examples/host/simpleResolver
-#        env:
-#          OPENASSETIO_PLUGIN_PATH: ${{ github.workspace }}/external/BAL/plugin
+      - name: Test BAL
+        run: |
+          python -m pip install external/BAL
+          # We can't install BAL's requirements.txt as this includes
+          # openassetio... we really need to sort
+          # https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/72
+          python -m pip install openassetio-mediacreation
+          python -m pip install -r external/BAL/tests/requirements.txt
+          python -m pytest -v external/BAL/tests
+
+      - name: Test Simple Resolver
+        run: |
+          python -m pytest -v examples/host/simpleResolver
+        env:
+          OPENASSETIO_PLUGIN_PATH: ${{ github.workspace }}/external/BAL/plugin
 
       - name: Checkout TraitGen
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Following on from https://github.com/OpenAssetIO/OpenAssetIO/pull/1214 and https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/pull/93

Re-enable BAL integration tests now that `entityTraits` is supported in BAL.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~
