### PR TITLE
[CI] Limit cmake version in wheel builds to < 3.28

### DIFF
--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2021-2022 The Foundry Visionmongers Ltd
 
+# https://discourse.cmake.org/t/3-28-segmentation-fault-on-macos-11-runner/9588
+# Revert cmake maximum once cmake is patched.
 [build-system]
 requires = [
     "setuptools>=65.5.0",
-    "cmake>=3.24.1.1",
+    "cmake>=3.24.1.1, <3.28",
     "ninja>=1.10.2.4"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Causing CI to fail when building wheels, because wheel builds request the latest cmake version via pip.
Looks to be due to a genuine cmake bug,
https://discourse.cmake.org/t/3-28-segmentation-fault-on-macos-11-runner/9588

This is temporary, we should revert this once cmake has shipped a patch.