### PR TITLE
Revert Cmake segfault workaround.

### DIFF
--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2021-2022 The Foundry Visionmongers Ltd
 
-# https://discourse.cmake.org/t/3-28-segmentation-fault-on-macos-11-runner/9588
-# Revert cmake maximum once cmake is patched.
 [build-system]
 requires = [
     "setuptools>=65.5.0",
-    "cmake>=3.24.1.1, <3.28",
+    "cmake>=3.24.1.1",
     "ninja>=1.10.2.4"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Cmake has shipped a patch, fixing the segfault on macos devices, revert the workaround.
