### PR TITLE
[Python] Fix HybridException base class RTTI

### DIFF
--- a/src/openassetio-python/tests/cmodule/test_errors.py
+++ b/src/openassetio-python/tests/cmodule/test_errors.py
@@ -84,6 +84,16 @@ class Test_errors:
         )
 
     @pytest.mark.parametrize("exception_type", all_exceptions)
+    def test_when_python_exception_thrown_then_can_be_caught_in_cpp_as_stl_base_type(
+        self, exception_type, exception_thrower
+    ):
+        exception = make_exception(exception_type)
+
+        exception_thrower.callee.side_effect = exception
+
+        _openassetio_test.throwPythonExceptionAndCatchAsStdException(exception_thrower)
+
+    @pytest.mark.parametrize("exception_type", all_exceptions)
     def test_when_python_exception_thrown_then_can_be_caught_in_cpp_rethrown_and_caught_in_python(
         self, exception_type, exception_thrower
     ):


### PR DESCRIPTION
## Description

Closes #1225. 

The `HybridException` mechanism used multiple inheritance to allow an exception to be caught as either an OpenAssetIO exception or a pybind11 exception, allowing it to propagate from Python through C++ and back out to Python without losing information.

However, this entailed diamond inheritance, where the two branches of the inheritance hierarchy had a root base class of `std::exception`.

This meant that a `HybridException` could not be caught as a `std::exception` due to the ambiguity. Frustratingly, this manifests as if `std::exception` wasn't part of the hierarchy at all, at least on GCC, and the exception would simply fall through the `catch`.

So rework the `HybridException` mechanism to use composition, rather than inheritance. I.e. we compose the Python exception proxy object `pybind11::error_already_set` rather than add it to the base class list.

This means we need additional explicit detection of `HybridException`s when translating exceptions from C++ to Python, to ensure we re-raise the original Python exception, rather than creating a new Python exception and losing e.g. stack trace data.

Luckily, when we `throw` a `pybind11::error_already_set` from within a pybind11 `register_exception_translator` callback, it's handled by pybind11 as we expect and the original Python exception is restored.

- [ ] ~~I have updated the release notes.~~ - since bugfix to unreleased feature
- [ ] ~~I have updated all relevant user documentation.~~


## Test Instructions

This was detected via the unit tests for the `usdOpenAssetIOResolver` project. A fix was applied to that repo, but can be reverted to test this PR in a "real" scenario. However, the unit tests added by this PR are sufficient to illustrate the problem.
