### PR TITLE
Publish build artifacts

### DIFF
--- a/.github/workflows/upload-release-builds.yml
+++ b/.github/workflows/upload-release-builds.yml
@@ -1,0 +1,116 @@
+# When a release occurs, do a full matrix build (duplicated logic from
+# build.yml), name the artifacts appropriately, and upload them to
+# the release.
+
+name: Upload Release Builds
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  Build-and-upload-release-builds:
+    name: ${{ matrix.config.os }}-${{matrix.config.build-type}}
+    runs-on: ${{ matrix.config.os }}
+    permissions:
+      contents: write # release changes require contents write
+    strategy:
+      fail-fast: false
+      matrix:
+        # We can't properly align to the VFX Reference Platform as this
+        # requires glibc 2.17, which is older than any of the available
+        # environments.
+        config:
+          # No Windows debug, Dosen't work on actions (easily)
+          # It's hard to get a python debug lib.
+        - os: windows-2019
+          preamble: call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64
+          shell: cmd
+          build-type: RelWithDebInfo
+        - os: windows-2019
+          preamble: call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64
+          shell: cmd
+          build-type: Release
+        - os: ubuntu-20.04
+          shell: bash
+          build-type: Debug
+        - os: ubuntu-20.04
+          shell: bash
+          build-type: RelWithDebInfo
+        - os: ubuntu-20.04
+          shell: bash
+          build-type: Release
+          # MacOS toolchain doesn't search /usr/local by default:
+          # https://gitlab.kitware.com/cmake/cmake/-/issues/19120
+          # The CMake FindPython module's Python::Python target (used
+          # via pybind11::embed in python-bridge-test) transitively adds
+          # linker flags to system libs, which fail due to this issue.
+        - os: macos-11
+          preamble: export LDFLAGS="-L/usr/local/lib"
+          shell: bash
+          build-type: Debug
+        - os: macos-11
+          preamble: export LDFLAGS="-L/usr/local/lib"
+          shell: bash
+          build-type: RelWithDebInfo
+        - os: macos-11
+          preamble: export LDFLAGS="-L/usr/local/lib"
+          shell: bash
+          build-type: Release
+    defaults:
+      run:
+        # Annoyingly required here since `matrix` isn't available in
+        # the `shell` property of individual steps.
+        shell: ${{ matrix.config.shell }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bootstrap
+        uses: ./.github/bootstrap_platform
+
+      # We don't want to publish the test build, it gets too big.
+      - name: Build and Install (No tests)
+        run: >
+          ${{ matrix.config.preamble }}
+
+          cmake -S . -B build -G Ninja
+          --install-prefix ${{ github.workspace }}/dist/${{ matrix.config.os }}${{ matrix.config.build-type }}
+          --toolchain ${{ github.workspace }}/.conan/conan_paths.cmake
+          -DCMAKE_BUILD_TYPE=${{matrix.config.build-type}}
+
+          cmake --build build
+
+          cmake --install build
+
+      - name: Get compiler information
+        id: compiler_info
+        shell: bash
+        # Search the cmake info for the compiler information, remove the
+        # env var labels, and dequote it.
+        run: |
+          cd build
+          compiler_version=$(cmake --system-information | grep -E "^CMAKE_CXX_COMPILER_VERSION " | cut -d ' ' -f2 | tr -d '"')
+          compiler_id=$(cmake --system-information | grep -E "^CMAKE_CXX_COMPILER_ID " | cut -d ' ' -f2 | tr -d '"')
+          python_version=$(python -V | sed 's/ /-/')
+          echo "compiler_version=$compiler_version" >> $GITHUB_OUTPUT
+          echo "compiler_id=$compiler_id" >> $GITHUB_OUTPUT
+          echo "python_version=$python_version" >> $GITHUB_OUTPUT
+
+      - name: Bundle and Upload Artifact
+        #Use inbuilt powershell commands because `zip` isn't on windows.
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $env:archive_name="OpenAssetIO-" + `
+          "${{ github.event.release.tag_name }}" + `
+          "-${{runner.os}}" + `
+          "-${{runner.arch}}" + `
+          "-${{matrix.config.build-type}}" + `
+          "-${{ steps.compiler_info.outputs.compiler_id }}" + `
+          "-${{ steps.compiler_info.outputs.compiler_version }}" + `
+          "-${{ steps.compiler_info.outputs.python_version }}.zip"
+          Compress-Archive -Path "${{ github.workspace }}/dist/${{ matrix.config.os }}${{ matrix.config.build-type }}" -DestinationPath ${{ github.workspace }}/dist/$env:archive_name
+          gh release upload ${{ github.event.release.tag_name }} ${{ github.workspace }}/dist/$env:archive_name --clobber

--- a/doc/contributing/PROCESS.md
+++ b/doc/contributing/PROCESS.md
@@ -145,7 +145,7 @@ To make a new OpenAssetIO release, follow this procedure.
 > **Warning**
 >
 > Upon merging to main, several actions will kickoff against your merge
-> commit. Notably among these is
+> commit. Notable among these is
 > [Build wheels](https://github.com/OpenAssetIO/OpenAssetIO/actions/workflows/build-wheels.yml),
 > which makes the python release artifacts available for upload, by the
 > [Deploy PyPI](https://github.com/OpenAssetIO/OpenAssetIO/actions/workflows/deploy-pypi.yml)
@@ -168,10 +168,13 @@ To make a new OpenAssetIO release, follow this procedure.
   - If this is an alpha or beta release, ensure `Set as a pre-release`
     checkbox is checked.
   - Click "Publish Release"
-- In response to a release being published, the
-  [Deploy PyPI](https://github.com/OpenAssetIO/OpenAssetIO/actions/workflows/deploy-pypi.yml)
-  action will be invoked. Monitor this to ensure PyPI wheels are
-  uploaded correctly.
+- In response to a release being published, two things happen.
+  - The [Deploy PyPI](https://github.com/OpenAssetIO/OpenAssetIO/actions/workflows/deploy-pypi.yml)
+    action will be invoked. Monitor this to ensure PyPI wheels are
+    uploaded correctly.
+  - The [Upload release builds](https://github.com/OpenAssetIO/OpenAssetIO/actions/workflows/upload-release-builds.yml)
+    action will be invoked, building a wider than usual matrix of of
+    openassetio artifacts, and then uploading them to the release page.
 - You're done! Take a break and relax!
 
 ## Breaking integrations


### PR DESCRIPTION
## Description
Boy that took a while ... CI iteration eh?

Adds CI steps to automatically publish release artifacts when a release is made.
Adds additional build configs (release, debug), to the existing build matrix in order to upload these, but does not allow these additional builds to be run on PR's, instead only running on main. Tripling the agents doing the build and test workflow during PR iteration seemed too heavy to me.

Closes #1201 

~~- [ ] I have updated the release notes.~~
- [x] I have updated all relevant user documentation.

You can see a test release here : https://github.com/elliotcmorris/OpenAssetIO/releases/tag/v1.0.0-test.26
and you can see on the actions page of this PR that only one configuration (RelWithDebugInfo) actually runs anything significant : https://github.com/OpenAssetIO/OpenAssetIO/actions/runs/7464239504/job/20310775805?pr=1241