### PR TITLE
Path to/from URL converter

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,12 @@ v1.0.0-beta.x.x
 
 ### New Features
 
+- Added convenience `utils.FileUrlPathConverter` utility class for
+  converting `file://` URLs to and from paths. Both POSIX and Windows
+  paths (including UNC) are supported in a platform-agnostic way (i.e.
+  Windows paths can be processed on POSIX hosts and vice versa).
+  [#1117](https://github.com/OpenAssetIO/OpenAssetIO/issues/1117)
+
 - Propagate `OpenAssetIOException`-derived Python exceptions as a
   corresponding C++ exception if a Python method implementation raises
   when transparently called from C++.

--- a/cmake/DefaultTargetProperties.cmake
+++ b/cmake/DefaultTargetProperties.cmake
@@ -194,6 +194,8 @@ function(openassetio_set_default_target_properties target_name)
 
         if (OPENASSETIO_ENABLE_SANITIZER_ADDRESS)
             list(APPEND sanitizers "address")
+            # Allow binaries to detect if they're running under ASan.
+            target_compile_definitions(${target_name} PRIVATE OPENASSETIO_ENABLE_SANITIZER_ADDRESS)
         endif ()
 
         if (OPENASSETIO_ENABLE_SANITIZER_LEAK)

--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -11,6 +11,12 @@ find_package(fmt REQUIRED)
 
 
 #-----------------------------------------------------------------------
+# URL parsing/construction
+
+find_package(ada REQUIRED)
+
+
+#-----------------------------------------------------------------------
 # Python
 
 if (OPENASSETIO_ENABLE_PYTHON)

--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -17,6 +17,15 @@ find_package(ada REQUIRED)
 
 
 #-----------------------------------------------------------------------
+# Regex
+
+if (NOT DEFINED PCRE2_USE_STATIC_LIBS)
+    set(PCRE2_USE_STATIC_LIBS ON)
+endif ()
+find_package(PCRE2 REQUIRED COMPONENTS 8BIT)
+
+
+#-----------------------------------------------------------------------
 # Python
 
 if (OPENASSETIO_ENABLE_PYTHON)

--- a/resources/build/Dockerfile
+++ b/resources/build/Dockerfile
@@ -26,6 +26,13 @@ RUN git clone --branch v2.7.4 https://github.com/ada-url/ada
 RUN cd ada && cmake -S . -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DADA_TESTING=OFF && \
      cmake --build build --parallel && cmake --install build
 
+# Pull and install pcre2
+RUN git clone --branch pcre2-10.42 https://github.com/PCRE2Project/pcre2
+RUN cd pcre2 && cmake -S . -B build \
+    -DPCRE2_STATIC_PIC=ON -DPCRE2_SUPPORT_JIT=ON -DPCRE2_BUILD_PCRE2GREP=OFF \
+    -DPCRE2_BUILD_TESTS=OFF && \
+     cmake --build build --parallel && cmake --install build
+
 # Test dependencies
 # Pull and install catch2
 RUN git clone --branch v2.13.10 https://github.com/catchorg/Catch2
@@ -53,6 +60,13 @@ COPY --from=openassetio-dependencies /usr/local/include/ada.h /usr/local/include
 COPY --from=openassetio-dependencies /usr/local/lib64/libada.a /usr/local/lib64/libada.a
 COPY --from=openassetio-dependencies /usr/local/lib64/cmake/ada /usr/local/lib64/cmake/ada
 
+# Copy pcre2
+COPY --from=openassetio-dependencies /usr/local/include/pcre2.h /usr/local/include/pcre2.h
+COPY --from=openassetio-dependencies /usr/local/include/pcre2posix.h /usr/local/include/pcre2posix.h
+COPY --from=openassetio-dependencies /usr/local/lib64/libpcre2-8.a /usr/local/lib64/libpcre2-8.a
+COPY --from=openassetio-dependencies /usr/local/lib64/libpcre2-posix.a /usr/local/lib64/libpcre2-posix.a
+COPY --from=openassetio-dependencies /usr/local/cmake/pcre2-config.cmake /usr/local/cmake/pcre2-config.cmake
+COPY --from=openassetio-dependencies /usr/local/cmake/pcre2-config-version.cmake /usr/local/cmake/pcre2-config-version.cmake
 # Copy trompeloeil
 # Trompeloeil installs itself into relevent test framework folders, so
 # some relevent parts of it for us is copied over with include/catch2

--- a/resources/build/Dockerfile
+++ b/resources/build/Dockerfile
@@ -21,6 +21,11 @@ RUN git clone --branch 9.1.0 https://github.com/fmtlib/fmt
 RUN cd fmt && cmake -S . -B build -DFMT_MASTER_PROJECT=OFF -DFMT_INSTALL=ON && \
      cmake --build build --parallel && cmake --install build
 
+# Pull and install ada
+RUN git clone --branch v2.7.4 https://github.com/ada-url/ada
+RUN cd ada && cmake -S . -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DADA_TESTING=OFF && \
+     cmake --build build --parallel && cmake --install build
+
 # Test dependencies
 # Pull and install catch2
 RUN git clone --branch v2.13.10 https://github.com/catchorg/Catch2
@@ -41,6 +46,12 @@ COPY --from=openassetio-dependencies /usr/local/lib64/cmake/Catch2 /usr/local/li
 COPY --from=openassetio-dependencies /usr/local/include/fmt /usr/local/include/fmt
 COPY --from=openassetio-dependencies /usr/local/lib64/libfmt.a /usr/local/lib64/libfmt.a
 COPY --from=openassetio-dependencies /usr/local/lib64/cmake/fmt /usr/local/lib64/cmake/fmt
+
+# Copy ada
+COPY --from=openassetio-dependencies /usr/local/include/ada /usr/local/include/ada
+COPY --from=openassetio-dependencies /usr/local/include/ada.h /usr/local/include/ada.h
+COPY --from=openassetio-dependencies /usr/local/lib64/libada.a /usr/local/lib64/libada.a
+COPY --from=openassetio-dependencies /usr/local/lib64/cmake/ada /usr/local/lib64/cmake/ada
 
 # Copy trompeloeil
 # Trompeloeil installs itself into relevent test framework folders, so

--- a/resources/build/conanfile.py
+++ b/resources/build/conanfile.py
@@ -36,6 +36,8 @@ class OpenAssetIOConan(ConanFile):
         self.requires("pybind11/2.10.1")
         # TOML library
         self.requires("tomlplusplus/3.2.0")
+        # URL processing
+        self.requires("ada/2.7.4")
         # Test framework
         self.requires("catch2/2.13.8")
         # Mocking library
@@ -47,3 +49,4 @@ class OpenAssetIOConan(ConanFile):
 
     def configure(self):
         self.options["fmt"].header_only = True
+        self.options["ada"].shared = False

--- a/resources/build/conanfile.py
+++ b/resources/build/conanfile.py
@@ -38,6 +38,8 @@ class OpenAssetIOConan(ConanFile):
         self.requires("tomlplusplus/3.2.0")
         # URL processing
         self.requires("ada/2.7.4")
+        # Regex
+        self.requires("pcre2/10.42")
         # Test framework
         self.requires("catch2/2.13.8")
         # Mocking library
@@ -50,3 +52,13 @@ class OpenAssetIOConan(ConanFile):
     def configure(self):
         self.options["fmt"].header_only = True
         self.options["ada"].shared = False
+
+        self.options["pcre2"].shared = False
+        # Unnecessary - we only do UTF-8
+        self.options["pcre2"].build_pcre2_16 = False
+        self.options["pcre2"].build_pcre2_32 = False
+        # Unnecessary - we don't need the command-line tool.
+        self.options["pcre2"].build_pcre2grep = False
+        # Enable optimising patterns with additional compile step.
+        self.options["pcre2"].support_jit = True
+

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -100,6 +100,7 @@ target_link_libraries(
     $<BUILD_INTERFACE:fmt::fmt-header-only>
     # (Static) private library dependencies
     ada::ada
+    PCRE2::8BIT
 )
 
 #-----------------------------------------------------------------------

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -98,6 +98,8 @@ target_link_libraries(
     # Header-only private dependencies:
     $<BUILD_INTERFACE:tomlplusplus::tomlplusplus>
     $<BUILD_INTERFACE:fmt::fmt-header-only>
+    # (Static) private library dependencies
+    ada::ada
 )
 
 #-----------------------------------------------------------------------

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -80,6 +80,7 @@ target_sources(
     src/managerApi/ManagerInterface.cpp
     src/managerApi/EntityReferencePagerInterface.cpp
     src/trait/TraitsData.cpp
+    src/utils/Regex.cpp
 )
 
 # Public header dependency.

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -81,6 +81,13 @@ target_sources(
     src/managerApi/EntityReferencePagerInterface.cpp
     src/trait/TraitsData.cpp
     src/utils/Regex.cpp
+    src/utils/path.cpp
+    src/utils/path/common.cpp
+    src/utils/path/windows.cpp
+    src/utils/path/windows/detail.cpp
+    src/utils/path/windows/pathTypes.cpp
+    src/utils/path/posix.cpp
+    src/utils/path/posix/detail.cpp
 )
 
 # Public header dependency.

--- a/src/openassetio-core/include/openassetio/utils/path.hpp
+++ b/src/openassetio-core/include/openassetio/utils/path.hpp
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#pragma once
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+#include <openassetio/export.h>
+#include <openassetio/typedefs.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace utils {
+
+/**
+ * Indicator of platform type associate with a path.
+ */
+enum class PathType : std::uint8_t {
+  /// Use the current system platform to determine path type.
+  kSystem = 0,
+  /// Assume a POSIX path.
+  kPOSIX,
+  /// Assume a Windows path (including UNC).
+  kWindows
+};
+
+/**
+ * Utility class for converting between file system paths and file URLs.
+ *
+ * The @ref PathType argument allows POSIX hosts to process paths/URLs
+ * for Windows systems and vice versa.
+ *
+ * Construction of this class should not be considered cheap
+ * (internally, multiple regex patterns are compiled). Once constructed,
+ * an instance can be used to process any number of URLs/paths.
+ *
+ * Conversion of Windows UNC paths to file URLs is supported, including
+ * `\\?\` device paths. However, conversion of file URLs back to Windows
+ * paths only supports drive paths or standard UNC share paths, not
+ * device paths.
+ *
+ * Some corner cases that may be technically valid are not currently
+ * supported, and will result in an exception if detected. E.g.
+ *  - Upward traversals (`..`) as path segments - these may be a
+ *    security risk.
+ *  - Non-ASCII Windows server names.
+ *  - Windows UNC non-normalised device paths (`\\?\`) that have
+ *    forward-slashes within path segments.
+ *  - Percent-encoded path separators.
+ *  - Windows drive letters of the form `C|`.
+ */
+class OPENASSETIO_CORE_EXPORT FileUrlPathConverter {
+ public:
+  FileUrlPathConverter();
+  ~FileUrlPathConverter();
+
+  /**
+   * Construct a file URL from a path.
+   *
+   * The path must be absolute and not contain any upward traversals
+   * (`..`) within it.
+   *
+   * Conversion of Windows UNC paths to file URLs is supported,
+   * including standard `\\` shares, and `\\?\` drive and `\\?\\UNC\`
+   * share device paths.
+   *
+   * Note that Windows device paths of the form `\\.\` are not
+   * supported. This may be added in a future update.
+   *
+   * @param absolutePath Path string.
+   *
+   * @param pathType Platform associated with path.
+   *
+   * @return Converted file URL.
+   *
+   * @throws InputValidationException if the path is invalid or
+   * unsupported.
+   */
+  [[nodiscard]] Str pathToUrl(std::string_view absolutePath,
+                              PathType pathType = PathType::kSystem) const;
+
+  /**
+   * Construct a path from a file URL.
+   *
+   * Note that long Windows paths may exceed the Windows MAX_PATH limit.
+   * Working around this, e.g. by transforming the path to a UNC device
+   * path (`\\?\C:\` or `\\?\UNC\host\share`), is left up to the caller.
+   *
+   * @param fileUrl URL to convert.
+   *
+   * @param pathType Platform associated with path.
+   *
+   * @return Extracted path suitable for the @p pathType platform.
+   *
+   * @throws InputValidationException if the URL or path that it decodes
+   * to is invalid or unsupported.
+   */
+  [[nodiscard]] Str pathFromUrl(std::string_view fileUrl,
+                                PathType pathType = PathType::kSystem) const;
+
+ private:
+  std::unique_ptr<struct FileUrlPathConverterImpl> impl_;
+};
+
+}  // namespace utils
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/utils/Regex.cpp
+++ b/src/openassetio-core/src/utils/Regex.cpp
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#include "Regex.hpp"
+
+#include <cassert>
+
+#include <fmt/format.h>
+
+#include <openassetio/errors/exceptions.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace utils {
+
+namespace {
+constexpr Str::size_type kErrorMessageMaxLength = 1000;
+
+Str errorCodeToMessage(int errorCode) {
+  Str errorMessage(kErrorMessageMaxLength, '\0');
+  const auto errorMessageLength = pcre2_get_error_message(
+      errorCode, reinterpret_cast<PCRE2_UCHAR8*>(errorMessage.data()), errorMessage.size());
+  errorMessage.resize(static_cast<Str::size_type>(errorMessageLength));
+  return errorMessage;
+}
+}  // namespace
+
+Regex::Regex(const std::string_view pattern) {
+  int errorCode;
+  std::size_t errorOffset;
+
+  code_ = pcre2_compile(
+      reinterpret_cast<PCRE2_SPTR8>(pattern.data()), pattern.size(),
+      PCRE2_CASELESS | PCRE2_DOLLAR_ENDONLY |
+          PCRE2_DOTALL, /* case-insensitive; `$` matches end of string; `.` matches newlines */
+      &errorCode,       /* error number */
+      &errorOffset,     /* error offset */
+      nullptr);         /* use default compile context */
+
+  if (code_ == nullptr) {
+    throw errors::InputValidationException{fmt::format(
+        "Error {} compiling regex '{}': {}", errorCode, pattern, errorCodeToMessage(errorCode))};
+  }
+
+  // Extra performance JIT compile. We don't care about partial
+  // matches.
+  errorCode = pcre2_jit_compile(code_, PCRE2_JIT_COMPLETE);
+
+  if (errorCode != 0) {
+    throw errors::InputValidationException{fmt::format(
+        "Error {} JIT compiling '{}': {}", errorCode, pattern, errorCodeToMessage(errorCode))};
+  }
+}
+
+Regex::~Regex() { pcre2_code_free(code_); }
+
+std::optional<Regex::Match> Regex::match(const std::string_view subject) const {
+  Match matchObj{code_};
+
+  const int numMatches =
+      pcre2_jit_match(code_,                                         /* regex object */
+                      reinterpret_cast<PCRE2_SPTR8>(subject.data()), /* subject */
+                      subject.size(),                                /* length of subject */
+                      0,                     /* start at offset 0 in the subject */
+                      0,                     /* default options */
+                      matchObj.data().get(), /* block for storing the result */
+                      nullptr);              /* use default match context */
+
+  if (numMatches < 0 && numMatches != PCRE2_ERROR_NOMATCH) {
+    throw errors::InputValidationException{fmt::format("Error {} matching regex to '{}': {}",
+                                                       numMatches, subject,
+                                                       errorCodeToMessage(numMatches))};
+  }
+
+  if (numMatches > 0) {
+    return matchObj;
+  }
+
+  return std::nullopt;
+}
+
+Str Regex::substituteToReduceSize(const std::string_view& subject,
+                                  const std::string_view& replacement) const {
+  if (subject.empty()) {
+    // Zero-size buffer is immediately an error in pcre, so just short-circuit.
+    return {};
+  }
+  // `+ 1` so pcre knows it has enough space for a null terminator.
+  Str result(subject.size() + 1, '\0');
+  std::size_t resultSize = result.size();
+
+  int numSubstitutions =
+      pcre2_substitute(code_,                                         /* regex object */
+                       reinterpret_cast<PCRE2_SPTR8>(subject.data()), /* subject */
+                       subject.size(),                                /* length of subject */
+                       0,                         /* start at offset 0 in the subject */
+                       PCRE2_SUBSTITUTE_GLOBAL,   /* substitute all matches */
+                       Match{code_}.data().get(), /* block for storing the result */
+                       nullptr,                   /* use default match context */
+                       reinterpret_cast<PCRE2_SPTR8>(replacement.data()), /* replacement */
+                       replacement.size(),                                /* replacement length */
+                       reinterpret_cast<PCRE2_UCHAR8*>(result.data()),    /* output buffer */
+                       &resultSize                                        /* output buffer size */
+      );
+
+  if (numSubstitutions < 0) {
+    throw errors::InputValidationException{
+        fmt::format("Error {} substituting regex matches in '{}' with '{}': {}", numSubstitutions,
+                    subject, replacement, errorCodeToMessage(numSubstitutions))};
+  }
+
+  result.resize(resultSize);
+  return result;
+}
+
+Regex::Match::Match(const pcre2_code_8* code)
+    : data_{pcre2_match_data_create_from_pattern(code, nullptr)} {
+  if (!data_) {
+    throw errors::InputValidationException{
+        fmt::format("Failed to construct regex match data buffer")};
+  }
+}
+
+std::string_view Regex::Match::group(const std::string_view subject,
+                                     const std::size_t groupNum) const {
+  // Precondition.
+  assert(groupNum < pcre2_get_ovector_count(data_.get()));
+
+  PCRE2_SIZE* matches = pcre2_get_ovector_pointer(data_.get());
+
+  const std::size_t startIdx = matches[groupNum * 2];
+  const std::size_t onePastEndIdx = matches[groupNum * 2 + 1];
+  assert(subject.size() >= onePastEndIdx);
+  return subject.substr(startIdx, onePastEndIdx - startIdx);
+}
+}  // namespace utils
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/utils/Regex.hpp
+++ b/src/openassetio-core/src/utils/Regex.hpp
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#pragma once
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string_view>
+
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+
+#include <openassetio/export.h>
+#include <openassetio/typedefs.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace utils {
+
+/**
+ * Regular expression compilation, matching and caching.
+ *
+ * Wraps PCRE2, using its JIT compilation and matching functions.
+ *
+ * Instances of this class are _not_ thread-safe. Use a separate
+ * instance per thread.
+ *
+ * As well as the regex object itself, matches are cached for subsequent
+ * querying.
+ */
+class Regex {
+ public:
+  /**
+   * Container for a regex match.
+   */
+  class Match {
+    struct MatchDataDeleter {
+      void operator()(pcre2_match_data* ptr) { pcre2_match_data_free(ptr); }
+    };
+    using Data = std::unique_ptr<pcre2_match_data, MatchDataDeleter>;
+
+   public:
+    explicit Match(const pcre2_code* code);
+
+    /**
+     * Get the string from a group in the match.
+     *
+     * Warning: no validation is performed. It is assumed the given
+     * group number exists in the match data.
+     *
+     * @param subject Subject string to extract a substring view from.
+     * Should be the same as the subject of the original `match`
+     * call, or at least a string of equal length.
+     *
+     * @param groupNum Regex capture group to extract.
+     *
+     * @return Substring view of the match in the subject string.
+     */
+    [[nodiscard]] std::string_view group(std::string_view subject, std::size_t groupNum) const;
+
+    /**
+     * Get the internal match data pointer.
+     *
+     * @return Internal PCRE2 match data.
+     */
+    [[nodiscard]] const Data& data() const { return data_; }
+
+   private:
+    Data data_;
+  };
+
+  /**
+   * Constructor.
+   *
+   * Pre-compiles the regular expression pattern.
+   *
+   * Note that:
+   * - Patterns are case-insensitive.
+   * - `$` matches end of string, not newline.
+   * - `.` matches all characters, including newlines.
+   *
+   * @param pattern Regex pattern.
+   */
+  explicit Regex(std::string_view pattern);
+
+  ~Regex();
+
+  /**
+   * Check if the regex matches a given subject string.
+   *
+   * Caches the match results for subsequent retrieval in other methods.
+   *
+   * @param subject Subject string to match the regex against.
+   *
+   * @return `true` if there is a match, `false` otherwise.
+   */
+  [[nodiscard]] std::optional<Match> match(std::string_view subject) const;
+
+  /**
+   * Get a new string with all matches of the regex substituted with the
+   * given replacement string.
+   *
+   * Resulting string must be less than or equal in size to the subject
+   * string.
+   *
+   * @param subject String to copy, with substitutions.
+   * @param replacement Replacement to substitute matches with.
+   * @return New string that is a copy of @p subject but with matches
+   * replaced with @p replacement.
+   * @throws InputValidationException On substitution error (e.g. if the
+   * resulting string would be longer than the subject string).
+   */
+  [[nodiscard]] Str substituteToReduceSize(const std::string_view& subject,
+                                           const std::string_view& replacement) const;
+
+ private:
+  pcre2_code* code_{nullptr};
+};
+}  // namespace utils
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/utils/path.cpp
+++ b/src/openassetio-core/src/utils/path.cpp
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#include <openassetio/utils/path.hpp>
+
+#include <openassetio/errors/exceptions.hpp>
+
+#include "./path/common.hpp"
+#include "./path/posix.hpp"
+#include "./path/windows.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace utils {
+/**
+ * Utility class for converting between file URLs and paths for both
+ * Windows and POSIX systems.
+ *
+ * Reusable components (each usually consisting of a couple of
+ * pre-compiled regexes and a handful of functions) are constructed and
+ * dependency-injected bottom-up, resulting in top-level Windows and
+ * POSIX handlers.
+ *
+ * We then delegate to the top-level Windows and POSIX utilities for the
+ * bulk of path/URL processing.
+ */
+struct FileUrlPathConverterImpl {
+  // Generic path/URL utilities.
+  path::GenericUrl urlHandler{};
+  path::ForwardSlashSeparatedString forwardSlashSeparatedStringHandler{};
+
+  // Common Windows path/URL utilities.
+  path::windows::detail::WindowsUrl windowsUrlHandler{};
+  path::windows::detail::UncHost uncHostHandler{};
+  path::windows::detail::DriveLetter driveLetterHandler{};
+  path::windows::detail::NormalisedPath windowsNormalisedPathHandler{};
+  path::windows::detail::UncUnnormalisedDevicePath uncUnnormalisedDevicePathHandler{};
+
+  // Windows path utilities for specific types of path.
+  path::windows::pathTypes::DrivePath drivePathHandler{driveLetterHandler,
+                                                       windowsNormalisedPathHandler};
+  path::windows::pathTypes::UncSharePath uncSharePathHandler{
+      uncHostHandler, windowsNormalisedPathHandler, windowsUrlHandler};
+  path::windows::pathTypes::UncUnnormalisedDeviceSharePath uncUnnormalisedDeviceSharePathHandler{
+      uncHostHandler, uncUnnormalisedDevicePathHandler, windowsUrlHandler};
+  path::windows::pathTypes::UncUnnormalisedDeviceDrivePath uncUnnormalisedDeviceDrivePathHandler{
+      driveLetterHandler, uncUnnormalisedDevicePathHandler};
+
+  // Entry point for converting Windows path<->URL.
+  path::windows::FileUrlPathConverter windowsFileUrlPathConverter{
+      windowsUrlHandler,
+      driveLetterHandler,
+      uncHostHandler,
+      forwardSlashSeparatedStringHandler,
+      drivePathHandler,
+      uncSharePathHandler,
+      uncUnnormalisedDeviceDrivePathHandler,
+      uncUnnormalisedDeviceSharePathHandler};
+
+  // POSIX path/URL utilities.
+  path::posix::detail::PosixPath posixPathHandler{forwardSlashSeparatedStringHandler};
+  path::posix::detail::PosixUrl posixUrlHandler{};
+
+  // Entry point for converting POSIX path<->URL.
+  path::posix::FileUrlPathConverter posixFileUrlPathConverter{posixUrlHandler, posixPathHandler};
+
+  /**
+   * Validate a path and construct a file URL from it.
+   *
+   * @param path Path string.
+   * @param pathType Platform associated with path.
+   * @return Converted file URL.
+   * @throws InputValidationException if the path is invalid or
+   * unsupported.
+   */
+  [[nodiscard]] Str pathToUrl(const std::string_view path, PathType pathType) const {
+    if (path.empty()) {
+      throw errors::InputValidationException(Str{path::kErrorEmptyPath});
+    }
+
+    if (path::GenericPath::containsNullByte(path)) {
+      throw errors::InputValidationException(Str{path::kErrorNullByte});
+    }
+
+    pathType = path::GenericPath::resolveSystemPathType(pathType);
+
+    return pathType == PathType::kWindows ? windowsFileUrlPathConverter.pathToUrl(path)
+                                          : posixFileUrlPathConverter.pathToUrl(path);
+  }
+
+  /**
+   * Convert a file URL to a path for a given platform type.
+   *
+   * @param fileUrl URL to convert.
+   * @param pathType Platform associated with path.
+   * @return Platform-specific path string.
+   * @throws InputValidationException if the URL or path that it decodes
+   * to is invalid or unsupported.
+   */
+  [[nodiscard]] Str pathFromUrl(const std::string_view fileUrl, PathType pathType) const {
+    if (!urlHandler.isFileUrl(fileUrl)) {
+      path::throwError(path::kErrorNotAFileUrl, fileUrl);
+    }
+    pathType = path::GenericPath::resolveSystemPathType(pathType);
+    return pathType == PathType::kWindows ? windowsFileUrlPathConverter.pathFromUrl(fileUrl)
+                                          : posixFileUrlPathConverter.pathFromUrl(fileUrl);
+  }
+};
+
+FileUrlPathConverter::FileUrlPathConverter()
+    : impl_{std::make_unique<FileUrlPathConverterImpl>()} {}
+
+FileUrlPathConverter::~FileUrlPathConverter() = default;
+
+Str FileUrlPathConverter::pathToUrl(std::string_view absolutePath, PathType pathType) const {
+  return impl_->pathToUrl(absolutePath, pathType);
+}
+
+Str FileUrlPathConverter::pathFromUrl(std::string_view fileUrl, PathType pathType) const {
+  return impl_->pathFromUrl(fileUrl, pathType);
+}
+}  // namespace utils
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/utils/path/common.cpp
+++ b/src/openassetio-core/src/utils/path/common.cpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#include "common.hpp"
+
+#include <fmt/format.h>
+
+#include <openassetio/errors/exceptions.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace utils::path {
+
+void throwError(const std::string_view message, const std::string_view pathOrUrl) {
+  throw errors::InputValidationException(fmt::format("{} ('{}')", message, pathOrUrl));
+}
+
+// ---------------------------------------------------------------------
+// ForwardSlashSeparatedString
+
+Str ForwardSlashSeparatedString::removeTrailingForwardSlashesInPathSegments(
+    const std::string_view& str) const {
+  return trailingForwardSlashesInSegmentRegex.substituteToReduceSize(str, "/");
+}
+
+// ---------------------------------------------------------------------
+// GenericUrl
+
+bool GenericUrl::isFileUrl(const std::string_view& url) const {
+  return fileUrlRegex.match(url).has_value();
+}
+
+void GenericUrl::setUrlPath(const Str& urlPath, ada::url& url) {
+  if (!url.set_pathname(urlPath)) {
+    // This exception is unexpected. All validation leading to this
+    // point should mean the above method always succeeds.
+    throwError(kErrorInvalidUrlPath, urlPath);
+  }
+}
+}  // namespace utils::path
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/utils/path/common.hpp
+++ b/src/openassetio-core/src/utils/path/common.hpp
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#pragma once
+#include <string_view>
+
+#include <ada.h>
+
+#include <openassetio/export.h>
+#include <openassetio/typedefs.hpp>
+#include <openassetio/utils/path.hpp>
+
+#include "../Regex.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+/**
+ * Various utility components for handling different types of path/URL
+ */
+namespace utils::path {
+
+// Non-`file://` URLs are invalid.
+constexpr std::string_view kErrorNotAFileUrl = "Not a file URL";
+// Path provided to pathToUrl is empty.
+constexpr std::string_view kErrorEmptyPath = "Path is empty";
+// E.g. empty path or no drive letter in Windows paths.
+constexpr std::string_view kErrorInvalidPath = "Path is ill-formed";
+// E.g. no leading / in path.
+constexpr std::string_view kErrorRelativePath = "Path is relative";
+// There's a `..` segment in the path.
+constexpr std::string_view kErrorUpwardsTraversal = "Path contains upwards traversal";
+// A `\0` was found in the (decoded) path.
+constexpr std::string_view kErrorNullByte = "Path contains NULL bytes";
+// Decoding a percent-encoded URL reveals an extra path separator.
+constexpr std::string_view kErrorEncodedSeparator = "Percent-encoded path separator";
+// E.g. Non-ASCII hostname in URL.
+constexpr std::string_view kErrorUnsupportedHostname = "Unsupported hostname";
+// E.g. Non-ASCII hostname in path.
+constexpr std::string_view kErrorInvalidHostname = "Path references an invalid hostname";
+// E.g. Windows device path with forward slashes - technically allowed
+// (as a literal rather than path separator) but unsupported by us.
+constexpr std::string_view kErrorUnsupportedDevicePath = "Unsupported Win32 device path";
+// E.g. `file://server/path` on posix.
+constexpr std::string_view kErrorNonLocal = "Unsupported non-local file";
+// Ada flagged an error setting the path component of a URL.
+constexpr std::string_view kErrorInvalidUrlPath = "Invalid URL path";
+// Ada failed to parse a given URL.
+constexpr std::string_view kErrorUrlParseFailure = "Invalid URL";
+
+// Constants for common character (sets) used in string processing.
+// Useful for grepability.
+constexpr char kColon = ':';
+constexpr char kPercent = '%';
+constexpr char kHyphen = '-';
+constexpr std::string_view kAnySlash = "\\/";
+constexpr char kForwardSlash = '/';
+constexpr char kBackSlash = '\\';
+constexpr std::string_view kBackSlashStr = "\\";
+constexpr std::string_view kDoubleBackSlash = R"(\\)";
+
+/**
+ * Throw an exception formatted to contain the problematic string.
+ *
+ * @param message Error message.
+ * @param pathOrUrl Problematic string to append to message.
+ */
+void throwError(std::string_view message, std::string_view pathOrUrl);
+
+/**
+ * Utility for dealing with `/`-separated strings.
+ *
+ * I.e. posix paths and URLs.
+ */
+struct ForwardSlashSeparatedString {
+  Regex trailingForwardSlashesInSegmentRegex{R"(//+)"};
+
+  /**
+   * Replace multiple `/`s between segments with a single `/`
+   *
+   * E.g. /path///file -> /path/file
+   *
+   * @param str Path or URL to process.
+   * @return New string with `/`s collapsed.
+   */
+  [[nodiscard]] Str removeTrailingForwardSlashesInPathSegments(const std::string_view& str) const;
+};
+
+/**
+ * Utility for non-platform specific paths.
+ */
+struct GenericPath {
+#ifdef _WIN32
+  static constexpr PathType kSystemPathType = PathType::kWindows;
+#else
+  static constexpr PathType kSystemPathType = PathType::kPOSIX;
+#endif
+
+  /**
+   * Transform kSystemPath to the appropriate type for the running
+   * system.
+   *
+   * @param pathType Input path type that might be kSystemPath.
+   * @return Potentially transformed path type.
+   */
+  [[nodiscard]] static constexpr PathType resolveSystemPathType(PathType pathType) {
+    return pathType == PathType::kSystem ? kSystemPathType : pathType;
+  }
+
+  /**
+   * Check if a path contains a `\0` null byte.
+   *
+   * @param path Path to check.
+   * @return true if a `\0` was found, false otherwise.
+   */
+  [[nodiscard]] static constexpr bool containsNullByte(std::string_view path) {
+    return path.find_first_of('\0') != std::string_view::npos;
+  }
+};
+
+/**
+ * Utility for dealing with non-platform specific URLs.
+ */
+struct GenericUrl {
+  Regex fileUrlRegex{R"(^file://)"};
+
+  /**
+   * Check if URL has a `file://` scheme.
+   *
+   * Regex (ab)used for case-insensitive matching.
+   *
+   * @param url URL to check.
+   * @return true if URL has file scheme, false otherwise.
+   */
+  [[nodiscard]] bool isFileUrl(const std::string_view& url) const;
+
+  /**
+   * Set the path component on a URL object.
+   *
+   * @param urlPath Path to set.
+   * @param url URL object to set path component on.
+   * @throw InputValidationException If the path is invalid, according
+   * to the Ada library.
+   */
+  static void setUrlPath(const Str& urlPath, ada::url& url);
+};
+}  // namespace utils::path
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/utils/path/posix.cpp
+++ b/src/openassetio-core/src/utils/path/posix.cpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#include "posix.hpp"
+
+#include <cassert>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace utils::path::posix {
+
+Str FileUrlPathConverter::pathToUrl(const std::string_view& posixPath) const {
+  // Precondition.
+  assert(!posixPath.empty());
+
+  if (posixPathHandler.containsUpwardsTraversal(posixPath)) {
+    throwError(kErrorUpwardsTraversal, posixPath);
+  }
+  if (!detail::PosixPath::startsWithForwardSlash(posixPath)) {
+    throwError(kErrorRelativePath, posixPath);
+  }
+
+  ada::url adaUrl;
+  adaUrl.type = ada::scheme::FILE;
+  // Must explicitly set empty host to get `file://` rather than
+  // `file:`.
+  adaUrl.set_host("");
+
+  const Str processedPath = [&] {
+    if (auto encodedPath = detail::PosixUrl::maybePercentEncode(posixPath)) {
+      return posixPathHandler.removeTrailingForwardSlashesInPathSegments(*encodedPath);
+    }
+    return posixPathHandler.removeTrailingForwardSlashesInPathSegments(posixPath);
+  }();
+
+  if (!adaUrl.set_pathname(processedPath)) {
+    throwError(kErrorInvalidUrlPath, posixPath);
+  }
+
+  return adaUrl.get_href();
+}
+
+Str FileUrlPathConverter::pathFromUrl(const std::string_view& url) const {
+  ada::result<ada::url_aggregator> adaUrl = ada::parse(url);
+  if (!adaUrl) {
+    throwError(kErrorUrlParseFailure, url);
+  }
+
+  if (!adaUrl->get_host().empty()) {
+    throwError(kErrorNonLocal, url);
+  }
+
+  const std::string_view path = adaUrl->get_pathname();
+
+  if (urlHandler.containsPercentEncodedForwardSlash(path)) {
+    throwError(kErrorEncodedSeparator, url);
+  }
+
+  const Str decodedPath = ada::unicode::percent_decode(path, path.find(kPercent));
+
+  if (GenericPath::containsNullByte(decodedPath)) {
+    throwError(kErrorNullByte, url);
+  }
+
+  return posixPathHandler.removeTrailingForwardSlashesInPathSegments(decodedPath);
+}
+}  // namespace utils::path::posix
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/utils/path/posix.hpp
+++ b/src/openassetio-core/src/utils/path/posix.hpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#pragma once
+#include <string_view>
+
+#include <openassetio/export.h>
+
+#include "./posix/detail.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+/**
+ * Utilities for POSIX-specific URLs and paths.
+ */
+namespace utils::path::posix {
+/**
+ * POSIX path<->URL handler.
+ *
+ * This is the POSIX-specific entry point for converting a POSIX path
+ * to/from a URL.
+ */
+struct FileUrlPathConverter {
+  detail::PosixUrl& urlHandler;
+  detail::PosixPath& posixPathHandler;
+
+  /**
+   * Convert a POSIX path into a file URL.
+   *
+   * @param posixPath path to convert.
+   * @return URL string.
+   * @throws InputValidationException if the path is invalid (e.g.
+   * relative) or unsupported.
+   */
+  [[nodiscard]] Str pathToUrl(const std::string_view& posixPath) const;
+
+  /**
+   * Convert a file URL to a POSIX path.
+   *
+   * @param url URL to convert.
+   * @return POSIX path.
+   * @throws InputValidationException if the URL or path that it decodes
+   * to is invalid or unsupported.
+   */
+  [[nodiscard]] Str pathFromUrl(const std::string_view& url) const;
+};
+}  // namespace utils::path::posix
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/utils/path/posix/detail.cpp
+++ b/src/openassetio-core/src/utils/path/posix/detail.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#include "detail.hpp"
+
+#include <cassert>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace utils::path::posix::detail {
+
+// ---------------------------------------------------------------------
+// PosixPath
+
+bool PosixPath::containsUpwardsTraversal(const std::string_view& str) const {
+  return upwardsTraversalRegex.match(str).has_value();
+}
+
+bool PosixPath::startsWithForwardSlash(const std::string_view& path) {
+  // Precondition
+  assert(!path.empty());
+  return path.front() == kForwardSlash;
+}
+
+Str PosixPath::removeTrailingForwardSlashesInPathSegments(const std::string_view& path) const {
+  if (path.size() <= 2) {
+    return Str{path};
+  }
+  Str normalisedPath;
+  normalisedPath.reserve(path.size());
+  // Apparently (according to swift-url code comments) two leading
+  // `/`s are implementation defined, so should be retained. Any
+  // more than two should be collapsed to one.
+  if (path[0] == kForwardSlash && path[1] == kForwardSlash && path[2] != kForwardSlash) {
+    const std::string_view pathView{path};
+    normalisedPath += pathView.substr(0, 2);
+    normalisedPath +=
+        forwardSlashSeparatedStringHandler.removeTrailingForwardSlashesInPathSegments(
+            pathView.substr(2));
+  } else {
+    normalisedPath =
+        forwardSlashSeparatedStringHandler.removeTrailingForwardSlashesInPathSegments(path);
+  }
+  return normalisedPath;
+}
+
+// ---------------------------------------------------------------------
+// PosixUrl
+
+bool PosixUrl::containsPercentEncodedForwardSlash(const std::string_view& url) const {
+  // Using regex for case-insensitivity.
+  return percentEncodedForwardSlashRegex.match(url).has_value();
+}
+
+std::optional<Str> PosixUrl::maybePercentEncode(const std::string_view& path) {
+  // Ada will automatically %-encode upon setting the URL path, but
+  // with a more limited set than we want.
+  Str encodedPath;
+  if (ada::unicode::percent_encode<false>(path, kPercentEncodeCharacterSet.data(), encodedPath)) {
+    return encodedPath;
+  }
+  return std::nullopt;
+}
+}  // namespace utils::path::posix::detail
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/utils/path/posix/detail.hpp
+++ b/src/openassetio-core/src/utils/path/posix/detail.hpp
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#pragma once
+#include <optional>
+#include <string_view>
+
+#include <ada.h>
+
+#include <openassetio/export.h>
+#include <openassetio/typedefs.hpp>
+
+#include "../../Regex.hpp"
+#include "../common.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+/**
+ * Sundry utilities for POSIX-specific URLs and paths.
+ */
+namespace utils::path::posix::detail {
+
+/**
+ * Utility for POSIX paths.
+ */
+struct PosixPath {
+  ForwardSlashSeparatedString& forwardSlashSeparatedStringHandler;
+
+  Regex upwardsTraversalRegex{R"((^|/)\.\.(/|$))"};
+
+  /**
+   * Check if a path contains `..` segment.
+   *
+   * @param path Path to check.
+   * @return true if a `..` segment was found, false otherwise.
+   */
+  [[nodiscard]] bool containsUpwardsTraversal(const std::string_view& str) const;
+
+  /**
+   * Check if a path starts with a `/`.
+   *
+   * @param path Path to check.
+   * @return true if the path starts with `/`, false otherwise.
+   */
+  [[nodiscard]] static bool startsWithForwardSlash(const std::string_view& path);
+
+  /**
+   * Remove extraneous leading `/`s in a path.
+   *
+   * If there are exactly two leading `/`s, then they are left
+   * unmodified, since the POSIX spec says:
+   *
+   * > A pathname that begins with two successive slashes may be
+   *   interpreted in an implementation-defined manner, although more
+   *   than two leading slashes shall be treated as a single slash.
+   *
+   * @param path Path to modify.
+   * @return Updated path.
+   */
+  [[nodiscard]] Str removeTrailingForwardSlashesInPathSegments(const std::string_view& path) const;
+};
+
+/**
+ * Utility for dealing with URLs pointing to POSIX paths.
+ */
+struct PosixUrl {
+  Regex percentEncodedForwardSlashRegex{R"(%2F)"};
+  /**
+   * Augment default percent encoded set for paths.
+   *
+   * From swift-url's` `POSIXPathEncodeSet` docstring:
+   *
+   * - The '%' sign itself. Filesystem paths do not contain
+   * percent-encoding, and any character sequences which look like
+   * percent-encoding are just coincidences.
+   * - Backslashes (`\`). They are allowed in POSIX paths and are not
+   * separators.
+   * - Colons (`:`) and vertical bars (`|`). These are sometimes
+   * interpreted as Windows drive letter delimiters, which POSIX paths
+   * obviously do not have.
+   */
+  static constexpr std::array kPercentEncodeCharacterSet = [] {
+    constexpr std::uint8_t kByteSize = 8;
+    constexpr std::size_t kArrSize = 32;  // 0xFF/kByteSize + 1;
+
+    constexpr std::uint8_t kPercentHex = 0x25;
+    constexpr std::uint8_t kBackSlashHex = 0x5C;
+    constexpr std::uint8_t kColonHex = 0x3A;
+    constexpr std::uint8_t kVerticalBarHex = 0x7C;
+
+    std::array<uint8_t, kArrSize> charSet{};
+    // Copy Ada's default %-encode set for URL path components.
+    for (std::size_t idx = 0; idx < charSet.size(); ++idx) {
+      charSet[idx] = ada::character_sets::PATH_PERCENT_ENCODE[idx];
+    }
+    // Augment the %-encode set with additional characters.
+    for (std::uint8_t charCode : {kPercentHex, kBackSlashHex, kColonHex, kVerticalBarHex}) {
+      charSet[charCode / kByteSize] |= static_cast<std::uint8_t>(1 << (charCode % kByteSize));
+    }
+
+    return charSet;
+  }();
+
+  /**
+   * Check if a URL contains a percent-encoded `/`.
+   *
+   * @param url URL string to check.
+   * @return true if a percent-encoded slash was found, false otherwise.
+   */
+  [[nodiscard]] bool containsPercentEncodedForwardSlash(const std::string_view& url) const;
+
+  /**
+   * Check if percent-encoding is needed for a URL path, and if so
+   * update an output string.
+   *
+   * @param path Path to potentially percent-encode.
+   * @param encodedPath String to update with result of
+   * percent-encoding. Not modified if no encoding is needed.
+   * @return true if encoding was required, false otherwise.
+   */
+  static std::optional<Str> maybePercentEncode(const std::string_view& path);
+};
+}  // namespace utils::path::posix::detail
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/utils/path/windows.cpp
+++ b/src/openassetio-core/src/utils/path/windows.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#include "windows.hpp"
+
+#include <algorithm>
+#include <cassert>
+
+#include <ada.h>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace utils::path::windows {
+
+// ---------------------------------------------------------------------
+// FileUrlPathConverter
+
+Str FileUrlPathConverter::pathToUrl(const std::string_view& windowsPath) const {
+  // Precondition.
+  assert(!windowsPath.empty());
+
+  ada::url url;
+  // Note: url.set_protocol(...) is a no-op, see https://github.com/ada-url/ada/issues/573
+  url.type = ada::scheme::FILE;
+
+  if (!uncUnnormalisedDeviceSharePathHandler.toUrl(windowsPath, url)) {
+    if (!uncUnnormalisedDeviceDrivePathHandler.toUrl(windowsPath, url)) {
+      if (!uncSharePathHandler.toUrl(windowsPath, url)) {
+        // If none of the above, assume a drive path, e.g. `C:\`
+        drivePathHandler.toUrl(windowsPath, url);
+      }
+    }
+  }
+
+  return url.get_href();
+}
+
+Str FileUrlPathConverter::pathFromUrl(const std::string_view& url) const {
+  ada::result<ada::url_aggregator> adaUrl = ada::parse(url);
+  if (!adaUrl) {
+    throwError(kErrorUrlParseFailure, url);
+  }
+
+  const std::string_view host = adaUrl->get_host();
+  const std::string_view encodedPath = adaUrl->get_pathname();
+
+  std::string_view trimmedPath = encodedPath;
+  if (host.empty() && !encodedPath.empty()) {
+    // E.g. path of `file:///C:/` is `/C:/`, so trim leading `/`.
+    trimmedPath = encodedPath.substr(1);
+  }
+
+  Str decodedPath = ada::unicode::percent_decode(trimmedPath, trimmedPath.find(kPercent));
+
+  // TODO(DF): Ordering of validation to satisfy error priority of
+  // swift-url test cases.
+
+  if (host.empty() && !driveLetterHandler.isAbsoluteDrivePath(decodedPath)) {
+    throwError(kErrorRelativePath, url);
+  }
+  if (GenericPath::containsNullByte(decodedPath)) {
+    throwError(kErrorNullByte, url);
+  }
+  if (urlHandler.containsPercentEncodedSlash(encodedPath)) {
+    throwError(kErrorEncodedSeparator, url);
+  }
+  if (!host.empty() && uncHostHandler.isInvalidHostname(host)) {
+    throwError(kErrorUnsupportedHostname, url);
+  }
+
+  Str windowsPath;
+  if (!host.empty()) {
+    windowsPath += kDoubleBackSlash;
+    if (const auto ip6Host = urlHandler.ip6ToValidHostname(host)) {
+      windowsPath += *ip6Host;
+    } else {
+      windowsPath += host;
+    }
+  }
+
+  decodedPath =
+      forwardSlashSeparatedStringHandler.removeTrailingForwardSlashesInPathSegments(decodedPath);
+  windowsPath += decodedPath;
+
+  std::replace(windowsPath.begin(), windowsPath.end(), kForwardSlash, kBackSlash);
+
+  return windowsPath;
+}
+}  // namespace utils::path::windows
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/utils/path/windows.hpp
+++ b/src/openassetio-core/src/utils/path/windows.hpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#pragma once
+#include <string_view>
+
+#include <openassetio/export.h>
+
+#include "./common.hpp"
+#include "./windows/detail.hpp"
+#include "./windows/pathTypes.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+/**
+ * Utilities for Windows-specific URLs and paths.
+ */
+namespace utils::path::windows {
+/**
+ * Windows path<->URL handler.
+ *
+ * This is the Windows-specific entry point for converting any type of
+ * Window path to/from a URL.
+ */
+struct FileUrlPathConverter {
+  detail::WindowsUrl& urlHandler;
+  detail::DriveLetter& driveLetterHandler;
+  detail::UncHost& uncHostHandler;
+  ForwardSlashSeparatedString& forwardSlashSeparatedStringHandler;
+
+  pathTypes::DrivePath& drivePathHandler;
+  pathTypes::UncSharePath& uncSharePathHandler;
+  pathTypes::UncUnnormalisedDeviceDrivePath& uncUnnormalisedDeviceDrivePathHandler;
+  pathTypes::UncUnnormalisedDeviceSharePath& uncUnnormalisedDeviceSharePathHandler;
+
+  /**
+   * Convert a Windows path into a file URL.
+   *
+   * Conversion is attempted starting at most specific path prefix
+   * (device share paths, i.e. `\\?\UNC\`) down to least specific (drive
+   * paths, i.e. `C:\`).
+   *
+   * @param windowsPath Path to convert.
+   * @return URL string.
+   * @throws InputValidationException if path is invalid or unsupported.
+   */
+  [[nodiscard]] Str pathToUrl(const std::string_view& windowsPath) const;
+
+  /**
+   * Convert a file URL to a Windows path.
+   *
+   * If the URL has a hostname it is converted to a standard UNC share
+   * path. Otherwise it is assumed to be a drive path.
+   *
+   * No attempt is made to convert (back) to a device path, e.g. to
+   * overcome the Windows MAX_PATH (260 char) limit. or to support
+   * unnormalised paths.
+   *
+   * @param url Url to convert to a path.
+   * @return `\`-separated Windows path.
+   * @throws InputValidationException if URL is invalid or decodes to an
+   * invalid path.
+   */
+  [[nodiscard]] Str pathFromUrl(const std::string_view& url) const;
+};
+}  // namespace utils::path::windows
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/utils/path/windows/detail.cpp
+++ b/src/openassetio-core/src/utils/path/windows/detail.cpp
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#include "detail.hpp"
+
+#include <algorithm>
+#include <cassert>
+
+#include "../common.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace utils::path::windows::detail {
+
+// ---------------------------------------------------------------------
+// WindowsUrl
+
+bool WindowsUrl::containsPercentEncodedSlash(const std::string_view& url) const {
+  // Using regex for case-insensitivity.
+  return percentEncodedSlashRegex.match(url).has_value();
+}
+
+std::optional<Str> WindowsUrl::ip6ToValidHostname(const std::string_view& host) const {
+  auto match = ip6HostRegex.match(host);
+  if (!match) {
+    return std::nullopt;
+  }
+  Str ip6HostName;
+  ip6HostName = match->group(host, 1);
+  ip6HostName += kIp6HostSuffix;
+  std::replace(ip6HostName.begin(), ip6HostName.end(), kColon, kHyphen);
+  return ip6HostName;
+}
+
+bool WindowsUrl::maybePercentEncodeAndAppendTo(const std::string_view& path, Str& appendTo) {
+  // Ada will automatically %-encode upon setting the URL path, but
+  // with a more limited set than we want.
+  // TODO(DF): Ideally we'd use `percent_encode<true>`, which appends
+  // to a given string if encoding is needed. However, that
+  // specialisation is not generated in ada v2.7.4 on MacOS/clang and
+  // fails to link. See https://github.com/ada-url/ada/issues/580
+  Str result;
+  if (ada::unicode::percent_encode<false>(path, kPercentEncodeCharacterSet.data(), result)) {
+    appendTo += result;
+    return true;
+  }
+  return false;
+}
+
+bool WindowsUrl::setUrlHost(const std::string_view& host, ada::url& url) const {
+  if (localHostRegex.match(host).has_value()) {
+    return url.set_host(kLocalHostIP);
+  }
+  return url.set_host(host);
+}
+
+// ---------------------------------------------------------------------
+// NormalisedPath
+
+std::string_view NormalisedPath::withoutTrailingSlashes(const std::string_view& path) const {
+  auto match = trailingSlashesRegex.match(path);
+  if (!match) {
+    return path;
+  }
+  return path.substr(0, path.size() - match->group(path, 1).size());
+}
+
+std::string_view NormalisedPath::withoutTrailingDotsAsFile(const std::string_view& path) const {
+  auto match = trailingDotsAsFileRegex.match(path);
+  if (!match) {
+    return path;
+  }
+  return path.substr(0, path.size() - match->group(path, 1).size());
+}
+
+std::string_view NormalisedPath::withoutTrailingDotsInFile(const std::string_view& path) const {
+  auto match = trailingDotsInFileRegex.match(path);
+  if (!match) {
+    return path;
+  }
+  return path.substr(0, path.size() - match->group(path, 1).size());
+}
+
+std::string_view NormalisedPath::withoutTrailingSpacesAndDots(const std::string_view& path) const {
+  auto match = trailingDotsAndSpacesRegex.match(path);
+  if (!match) {
+    return path;
+  }
+  return path.substr(0, path.size() - match->group(path, 1).size());
+}
+
+bool NormalisedPath::containsUpwardsTraversal(const std::string_view& path) const {
+  return upwardsTraversalRegex.match(path).has_value();
+}
+
+Str NormalisedPath::removeTrailingDotsInPathSegments(const std::string_view& path) const {
+  return trailingSingleDotInSegmentRegex.substituteToReduceSize(path, "");
+}
+
+Str NormalisedPath::removeTrailingSlashesInPathSegments(const std::string_view& path) const {
+  return trailingSlashesInSegmentRegex.substituteToReduceSize(path, kBackSlashStr);
+}
+
+bool NormalisedPath::startsWithSlash(const std::string_view& path) {
+  // Precondition.
+  assert(!path.empty());
+  return path.substr(0, 1).find_first_of(kAnySlash) != std::string_view::npos;
+}
+
+// ---------------------------------------------------------------------
+// DriveLetter
+
+bool DriveLetter::isDrive(const std::string_view& str) const {
+  return driveRegex.match(str).has_value();
+}
+
+bool DriveLetter::isAbsoluteDrivePath(const std::string_view& str) const {
+  return absoluteDrivePathRegex.match(str).has_value();
+}
+
+// ---------------------------------------------------------------------
+// UncHost
+
+bool UncHost::isInvalidHostname(const std::string_view& host) const {
+  return invalidHostnameRegex.match(host).has_value();
+}
+
+// ---------------------------------------------------------------------
+// UncUnnormalisedDevicePath
+
+void UncUnnormalisedDevicePath::validatePath(const std::string_view& windowsPath,
+                                             const UncDetails& uncDetails) const {
+  if (uncDetails.fullPath.empty()) {
+    // Must have something after the `\\?\` or `\\?\UNC\`
+    throwError(kErrorInvalidPath, windowsPath);
+  }
+  if (containsForwardSlash(uncDetails.fullPath)) {
+    // Don't support verbatim `/` in UNC device paths, for now.
+    throwError(kErrorUnsupportedDevicePath, windowsPath);
+  }
+  if (containsUpwardsTraversal(uncDetails.shareNameAndPath)) {
+    // Disallow `..`, except for hostnames.
+    throwError(kErrorUpwardsTraversal, windowsPath);
+  }
+}
+
+std::string_view UncUnnormalisedDevicePath::withoutTrailingSlashes(
+    const std::string_view& path) const {
+  auto match = trailingSlashesRegex.match(path);
+  if (!match) {
+    return path;
+  }
+  return path.substr(0, path.size() - match->group(path, 1).size());
+}
+
+bool UncUnnormalisedDevicePath::containsForwardSlash(const std::string_view& path) {
+  return path.find_first_of(kForwardSlash) != std::string_view::npos;
+}
+
+bool UncUnnormalisedDevicePath::containsUpwardsTraversal(const std::string_view& str) const {
+  return upwardsTraversalRegex.match(str).has_value();
+}
+
+Str UncUnnormalisedDevicePath::removeTrailingSlashesInPathSegments(
+    const std::string_view& path) const {
+  return trailingSlashesInSegmentRegex.substituteToReduceSize(path, R"(\)");
+}
+
+}  // namespace utils::path::windows::detail
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/utils/path/windows/detail.hpp
+++ b/src/openassetio-core/src/utils/path/windows/detail.hpp
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#pragma once
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+#include <ada.h>
+
+#include <openassetio/export.h>
+
+#include "../../Regex.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+/**
+ * Sundry utilities for Windows-specific URLs and paths.
+ */
+namespace utils::path::windows::detail {
+/**
+ * Utility for dealing with URLs pointing to Windows paths.
+ */
+struct WindowsUrl {
+  static constexpr std::string_view kLocalHostIP = "127.0.0.1";
+  static constexpr std::string_view kIp6HostSuffix = ".ipv6-literal.net";
+  Regex ip6HostRegex{R"(^\[([A-Z0-9:]+)\]$)"};
+  Regex localHostRegex{"^localhost$"};
+  Regex percentEncodedSlashRegex{R"(%(:?5C|2F))"};
+  /**
+   * Augment default percent encoded set for paths.
+   *
+   * From swift-url's` `WindowsPathEncodeSet` docstring:
+   *
+   * - The '%' sign itself. Filesystem paths do not contain
+   * percent-encoding, and any character sequences which look like
+   * percent-encoding are just coincidences.
+   * - Note that the colon character (`:`) is also included, so this
+   * encode-set is not appropriate for Windows drive letter components.
+   * Drive letters should not be percent-encoded.
+   */
+  static constexpr std::array kPercentEncodeCharacterSet = [] {
+    constexpr std::uint8_t kByteSize = 8;
+    constexpr std::size_t kArrSize = 32;  // 0xFF/kByteSize + 1;
+
+    constexpr std::uint8_t kPercentHex = 0x25;
+    constexpr std::uint8_t kColonHex = 0x3A;
+    constexpr std::uint8_t kVerticalBarHex = 0x7C;
+
+    std::array<uint8_t, kArrSize> charSet{};
+    // Copy Ada's default %-encode set for URL path components.
+    for (std::size_t idx = 0; idx < charSet.size(); ++idx) {
+      charSet[idx] = ada::character_sets::PATH_PERCENT_ENCODE[idx];
+    }
+    // Augment the %-encode set with additional characters.
+    for (std::uint8_t charCode : {kPercentHex, kColonHex, kVerticalBarHex}) {
+      charSet[charCode / kByteSize] |= static_cast<std::uint8_t>(1 << (charCode % kByteSize));
+    }
+
+    return charSet;
+  }();
+
+  /**
+   * Check if a URL contains a percent-encoded `\` or `/`.
+   *
+   * @param url URL string to check.
+   * @return true if a percent-encoded slash was found, false otherwise.
+   */
+  [[nodiscard]] bool containsPercentEncodedSlash(const std::string_view& url) const;
+
+  /**
+   * Detect an IP6 address, and if found convert it to a valid UNC
+   * hostname.
+   *
+   * @param host hostname that is potentially an IP6 address.
+   * @return Unset optional if hostname is not an IP6 address, otherwise
+   * a valid UNC hostname pointing to the IP6 address.
+   */
+  [[nodiscard]] std::optional<Str> ip6ToValidHostname(const std::string_view& host) const;
+
+  /**
+   * Check if percent-encoding is needed for a URL path, and if so
+   * append the encoded string to a second string.
+   *
+   * @param path Path to potentially percent-encode.
+   * @param appendTo String to append result of percent-encoding. Not
+   * modified if no encoding is needed.
+   * @return true if encoding was required, false otherwise.
+   */
+  static bool maybePercentEncodeAndAppendTo(const std::string_view& path, Str& appendTo);
+
+  /**
+   * Set the host part on a URL object.
+   *
+   * Converts localhost to 127.0.0.1, to avoid the possibility that
+   * `file://localhost/` would be auto collapsed to `file:///` during
+   * transport, which would not then be valid when converting back to a
+   * path on Windows.
+   *
+   * @param host Hostname to set on URL object.
+   * @param url URL object o modify
+   * @return true if setting host succeeded, false if the host is
+   * invalid, according to the Ada library.
+   */
+  bool setUrlHost(const std::string_view& host, ada::url& url) const;
+};
+
+/**
+ * Parsed details of a UNC (i.e. `\\`-prefixed) path.
+ */
+struct UncDetails {
+  /// Hostname or drive letter.
+  std::string_view hostOrDrive;
+  /// Host share name (blank for UNC device drive paths).
+  std::string_view shareName;
+  /// Path in share - i.e. everything after the share name.
+  std::string_view sharePath;
+  /// Combined share name and path - i.e. everything after the
+  /// host/drive.
+  std::string_view shareNameAndPath;
+  /// Complete path excluding UNC prefix - i.e. host + share name and
+  /// path
+  std::string_view fullPath;
+};
+
+/**
+ * Utility for handling Windows drive and standard UNC share paths.
+ *
+ * I.e. `C:\` and `\\` but NOT `\\?\`.
+ *
+ * These paths have various normalisation rules, e.g. treating `/` as
+ * well as `\` as a path separator, and trimming some trailing chars
+ * from path segments.
+ *
+ * See https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
+ */
+struct NormalisedPath {
+  Regex upwardsTraversalRegex{R"((^|[\\/])\.\.([\\/]|$))"};
+  Regex trailingDotsAsFileRegex{R"([\\/](\.{3,})$)"};
+  Regex trailingDotsInFileRegex{R"([^.\\/](\.+)$)"};
+  Regex trailingDotsAndSpacesRegex{R"([\\/][^\\/ ]*( [. ]*)$)"};
+  Regex trailingSlashesRegex{R"([\\/]([\\/]+)$)"};
+  Regex trailingSingleDotInSegmentRegex{R"((?<![.\\/])\.(?=[/\\]))"};
+  Regex trailingSlashesInSegmentRegex{R"([\\/][\\/]+)"};
+
+  /**
+   * Get a view of the input path with all but the last trailing slash
+   * removed.
+   *
+   * E.g. `C:\some\\\path\\\\ -> `C:\some\\\path\`
+   *
+   * @param path Path to (potentially) trim.
+   * @return Input path if no trimming was needed, otherwise a
+   * substring view with extraneous trailing slashes trimmed.
+   */
+  [[nodiscard]] std::string_view withoutTrailingSlashes(const std::string_view& path) const;
+
+  /**
+   * If the final segment of input path ends in three or more `.`s, get
+   * a view of the input path with these removed.
+   *
+   * E.g. `C:\some\path\....` -> `C:\some\path\`
+   *
+   * Does not affect single `.` or double `..`. Double dots are
+   * disallowed (see kErrorUpwardsTraversal). Single dots are collapsed
+   * for us by the Ada URL library's own normalisation.
+   *
+   * @param path Path to (potentially) trim.
+   * @return Input path if no trimming was needed, otherwise a
+   * substring view with extraneous trailing dots trimmed.
+   */
+  [[nodiscard]] std::string_view withoutTrailingDotsAsFile(const std::string_view& path) const;
+
+  /**
+   * If the final segment of the input path is a file name, and the file
+   * name ends in one or more `.`s, trim them.
+   *
+   * Also see @ref removeTrailingDotsInPathSegments.
+   *
+   * E.g. `C:\some\file...` -> `C:\some\file`
+   *
+   * @param path Path to (potentially)trim
+   * @return Input path if no trimming was needed, otherwise a
+   * substring view with extraneous trailing dots trimmed.
+   */
+  [[nodiscard]] std::string_view withoutTrailingDotsInFile(const std::string_view& path) const;
+
+  /**
+   * If the final segment of the input path ends in a space followed by
+   * any number of spaces and dots, remove them.
+   *
+   * E.g. `C:\some\file ... .. .` -> `C:\some\file`
+   *
+   * @param path Path to (potentially)trim
+   * @return Input path if no trimming was needed, otherwise a
+   * substring view with extraneous trailing dots trimmed.
+   */
+  [[nodiscard]] std::string_view withoutTrailingSpacesAndDots(const std::string_view& path) const;
+
+  /**
+   * Check if a path contains `..` segment.
+   *
+   * @param path Path to check.
+   * @return True if a `..` segment was found, false otherwise.
+   */
+  [[nodiscard]] bool containsUpwardsTraversal(const std::string_view& path) const;
+
+  /**
+   * Remove all trailing `.`s in each path segment.
+   *
+   * E.g. `C:\path...\to.\file` -> `C:\path\to\file`
+   *
+   * @param path Path to process.
+   * @return New string with any trailing dots within segments removed.
+   */
+  [[nodiscard]] Str removeTrailingDotsInPathSegments(const std::string_view& path) const;
+
+  /**
+   * Remove all trailing slashes in each path segment.
+   *
+   * E.g. `C:\path\/\/to\\file` -> `C:\path\to\file`
+   *
+   * @param path Path to process.
+   * @return New string with any trailing slashes within segments
+   * removed.
+   */
+  [[nodiscard]] Str removeTrailingSlashesInPathSegments(const std::string_view& path) const;
+
+  /**
+   * Check if given path starts with a path separator.
+   *
+   * E.g. `/some/path` or `\some/path`, but not `some/path`.
+   *
+   * @param path Path to check.
+   * @return true if the path starts with a separator, false otherwise.
+   */
+  [[nodiscard]] static bool startsWithSlash(const std::string_view& path);
+};
+
+/**
+ * Utility for handling Windows drive letters e.g. `C:\`.
+ */
+struct DriveLetter {
+  Regex driveRegex{R"(^[A-Z]:$)"};
+  Regex absoluteDrivePathRegex{R"(^[A-Z]:[/\\])"};
+  /**
+   * Check if a given string is a Windows drive letter.
+   *
+   * E.g. `C:`, but not `C:\` - i.e. just the drive letter matches.
+   *
+   * @param str String to check.
+   * @return true if string is a drive letter, false otherwise.
+   */
+  [[nodiscard]] bool isDrive(const std::string_view& str) const;
+
+  /**
+   * Check if a given string is a Windows absolute path on a drive.
+   *
+   * E.g. `C:\path` or `C:\`, but not `C:` or `hostname`.
+   *
+   * @param str String to check.
+   * @return true if string is an absolute drive path, false otherwise.
+   */
+  [[nodiscard]] bool isAbsoluteDrivePath(const std::string_view& str) const;
+};
+
+/**
+ * Utility handler for UNC path host component.
+ *
+ * I.e. the "host" in `\\host\share\path`.
+ */
+struct UncHost {
+  /**
+   * Invalid UNC hostname regex.
+   *
+   * - Unicode domains are unsupported, so ensure ASCII.
+   * - Ensure no %-encoding.
+   * - Reject "?" and "." as UNC hostnames. From swift-url code comments:
+   *   > Otherwise we might create something which looks like a Win32 file
+   *     namespace/local device path
+   * - Reject drive letters as hostnames.
+   */
+  Regex invalidHostnameRegex{R"(^[.?]$|[^[:ascii:]]|%|^[A-Z]:$)"};
+
+  /**
+   * Check if a given hostname is invalid.
+   *
+   * @param host Hostname to check.
+   * @return true if the hostname is invalid, false otherwise.
+   */
+  [[nodiscard]] bool isInvalidHostname(const std::string_view& host) const;
+};
+
+/**
+ * Utility handler for non-normalised UNC device paths, i.e. `\\?\`.
+ *
+ * These path types do not undergo normalisation and so e.g. only
+ * support `\` as a separator.
+ *
+ * The only normalisation we do is to collapse multiple `\` down to
+ * one.
+ */
+struct UncUnnormalisedDevicePath {
+  Regex upwardsTraversalRegex{R"((^|\\)\.\.(\\|$))"};
+  Regex trailingSlashesRegex{R"(\\(\\+)$)"};
+  Regex trailingSlashesInSegmentRegex{R"((\\\\+))"};
+
+  /**
+   * Validate a Windows UNC device path.
+   *
+   * @param windowsPath Path to validate.
+   * @param uncDetails UNC features of path.
+   */
+  void validatePath(const std::string_view& windowsPath, const UncDetails& uncDetails) const;
+
+  /**
+   * Trim trailing `\`s from a path.
+   *
+   * E.g. `\\?\C:\directory\\\\\` -> `\\?\C:\directory\`
+   *
+   * @param path Path to trim.,
+   * @return Input path if there was nothing to trim, otherwise a
+   * substring view of the path with extraneous `\`s removed.
+   */
+  [[nodiscard]] std::string_view withoutTrailingSlashes(const std::string_view& path) const;
+
+  /**
+   * Check if a path contains a `/` anywhere.
+   *
+   * @param path Path to check.
+   * @return true if a `/` was found, false otherwise.
+   */
+  [[nodiscard]] static bool containsForwardSlash(const std::string_view& path);
+
+  /**
+   * Check if a path contains `..` segment.
+   *
+   * @param path Path to check.
+   * @return true if a `..` segment was found, false otherwise.
+   */
+  [[nodiscard]] bool containsUpwardsTraversal(const std::string_view& str) const;
+
+  /**
+   * Remove all trailing slashes in each path segment.
+   *
+   * E.g. `\\?\C:\path\\\\to\\file` -> `\\?\C:\path\to\file`
+   *
+   * @param path Path to process.
+   * @return New string with any trailing slashes within segments
+   * removed.
+   */
+  [[nodiscard]] Str removeTrailingSlashesInPathSegments(const std::string_view& path) const;
+};
+
+}  // namespace utils::path::windows::detail
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/utils/path/windows/pathTypes.cpp
+++ b/src/openassetio-core/src/utils/path/windows/pathTypes.cpp
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#include "pathTypes.hpp"
+
+#include <algorithm>
+#include <cassert>
+
+#include "../common.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace utils::path::windows::pathTypes {
+
+// ---------------------------------------------------------------------
+// DrivePath
+
+void DrivePath::toUrl(const std::string_view& windowsPath, ada::url& url) const {
+  validatePath(windowsPath);
+  // Must explicitly set empty host to get `file://` rather than
+  // `file:`.
+  url.set_host("");
+  setUrlPath(windowsPath, url);
+}
+
+void DrivePath::validatePath(const std::string_view& windowsPath) const {
+  // TODO(DF): Kludge to match error priority of swift-url. Otherwise
+  // this would be handled by `isAbsoluteDrivePath`.
+  if (detail::NormalisedPath::startsWithSlash(windowsPath)) {
+    // Path starts with slash so is a relative path.
+    throwError(kErrorRelativePath, windowsPath);
+  }
+  if (normalisedPathHandler.containsUpwardsTraversal(windowsPath)) {
+    // Path contains a `..` segment.
+    throwError(kErrorUpwardsTraversal, windowsPath);
+  }
+  if (!driveLetterHandler.isAbsoluteDrivePath(windowsPath)) {
+    // Path either isn't a drive path, or is a relative drive path
+    // e.g. `C:` (without trailing slash).
+    throwError(kErrorRelativePath, windowsPath);
+  }
+}
+
+void DrivePath::setUrlPath(const std::string_view& windowsPath, ada::url& url) const {
+  // Precondition.
+  assert(driveLetterHandler.isAbsoluteDrivePath(windowsPath));
+
+  // TODO(DF): This trimming logic could surely be optimised.
+  const std::string_view trimmedPath = normalisedPathHandler.withoutTrailingDotsInFile(
+      normalisedPathHandler.withoutTrailingDotsAsFile(
+          normalisedPathHandler.withoutTrailingSpacesAndDots(
+              normalisedPathHandler.withoutTrailingSlashes(windowsPath))));
+
+  const Str normalisedPath = normalisedPathHandler.removeTrailingDotsInPathSegments(
+      normalisedPathHandler.removeTrailingSlashesInPathSegments(trimmedPath));
+
+  const std::string_view normalisedPathView{normalisedPath};
+  const std::string_view driveLetter = normalisedPathView.substr(0, kDriveLetterLength);
+  const std::string_view drivePath = normalisedPathView.substr(kDriveLetterLength);
+
+  if (Str encodedPath{driveLetter};
+      detail::WindowsUrl::maybePercentEncodeAndAppendTo(drivePath, encodedPath)) {
+    GenericUrl::setUrlPath(encodedPath, url);
+  } else {
+    GenericUrl::setUrlPath(normalisedPath, url);
+  }
+}
+
+// ---------------------------------------------------------------------
+// UncSharePath
+
+bool UncSharePath::toUrl(const std::string_view& windowsPath, ada::url& url) const {
+  const std::optional<detail::UncDetails> uncDetails = extractUncDetails(windowsPath);
+  if (!uncDetails) {
+    return false;
+  }
+  validatePath(windowsPath, *uncDetails);
+  if (!urlHandler.setUrlHost(uncDetails->hostOrDrive, url)) {
+    throwError(kErrorInvalidHostname, windowsPath);
+  }
+  setUrlPath(*uncDetails, url);
+  return true;
+}
+
+std::optional<detail::UncDetails> UncSharePath::extractUncDetails(
+    const std::string_view& path) const {
+  auto pathParts = pathRegex.match(path);
+  if (!pathParts) {
+    return std::nullopt;
+  }
+  const std::string_view prefix = pathParts->group(path, 1);
+  const std::string_view hostOrDrive = pathParts->group(path, 2);
+  const auto [shareName, sharePath, shareNameAndPath] =
+      extractShareNameAndPath(pathParts->group(path, 3));
+  const std::string_view fullPath =
+      path.substr(prefix.size(), hostOrDrive.size() + shareNameAndPath.size());
+  return detail::UncDetails{hostOrDrive, shareName, sharePath, shareNameAndPath, fullPath};
+}
+
+std::tuple<std::string_view, std::string_view, std::string_view>
+UncSharePath::extractShareNameAndPath(std::string_view shareNameAndPath) const {
+  shareNameAndPath = normalisedPathHandler.withoutTrailingSlashes(shareNameAndPath);
+  auto headAndTail = pathHeadAndTailRegex.match(shareNameAndPath);
+  if (!headAndTail) {
+    // Share name without path.
+    return {shareNameAndPath, {}, shareNameAndPath};
+  }
+  const std::string_view shareName = headAndTail->group(shareNameAndPath, 1);
+  const std::string_view sharePath = normalisedPathHandler.withoutTrailingDotsInFile(
+      normalisedPathHandler.withoutTrailingDotsAsFile(
+          normalisedPathHandler.withoutTrailingSpacesAndDots(
+              headAndTail->group(shareNameAndPath, 2))));
+  // In case shareNameAndPath is now shorter due to trimming trailing
+  // dots/spaces.
+  shareNameAndPath = shareNameAndPath.substr(0, shareName.size() + sharePath.size());
+  return {shareName, sharePath, shareNameAndPath};
+}
+
+void UncSharePath::validatePath(const std::string_view& windowsPath,
+                                const detail::UncDetails& uncDetails) const {
+  if (uncDetails.fullPath.empty()) {
+    // Completely empty path after UNC prefix.
+    throwError(kErrorInvalidPath, windowsPath);
+  }
+  if (normalisedPathHandler.containsUpwardsTraversal(uncDetails.shareNameAndPath)) {
+    // Disallow `..`, except for hostnames.
+    throwError(kErrorUpwardsTraversal, windowsPath);
+  }
+  if (uncHostHandler.isInvalidHostname(uncDetails.hostOrDrive)) {
+    // E.g. non-ASCII or other disallowed character in hostname.
+    throwError(kErrorInvalidHostname, windowsPath);
+  }
+}
+
+void UncSharePath::setUrlPath(const detail::UncDetails& uncDetails, ada::url& url) const {
+  Str normalisedPath;
+  normalisedPath.reserve(uncDetails.shareNameAndPath.size());
+  normalisedPath += uncDetails.shareName;
+  normalisedPath += normalisedPathHandler.removeTrailingDotsInPathSegments(uncDetails.sharePath);
+  normalisedPath = normalisedPathHandler.removeTrailingSlashesInPathSegments(normalisedPath);
+
+  if (Str encodedPath;
+      detail::WindowsUrl::maybePercentEncodeAndAppendTo(normalisedPath, encodedPath)) {
+    GenericUrl::setUrlPath(encodedPath, url);
+  } else {
+    GenericUrl::setUrlPath(normalisedPath, url);
+  }
+}
+
+// ---------------------------------------------------------------------
+// UncUnnormalisedDeviceDrivePath
+
+bool UncUnnormalisedDeviceDrivePath::toUrl(const std::string_view& windowsPath,
+                                           ada::url& url) const {
+  const std::optional<detail::UncDetails> uncDetails = extractUncDetails(windowsPath);
+  if (!uncDetails) {
+    return false;
+  }
+  validatePath(windowsPath, *uncDetails);
+  url.set_host("");
+  setUrlPath(*uncDetails, url);
+  return true;
+}
+
+std::optional<detail::UncDetails> UncUnnormalisedDeviceDrivePath::extractUncDetails(
+    const std::string_view& path) const {
+  auto pathParts = pathRegex.match(path);
+  if (!pathParts) {
+    return std::nullopt;
+  }
+  const std::string_view hostOrDrive = pathParts->group(path, 1);
+  const std::string_view shareNameAndPath =
+      uncUnnormalisedDevicePathHandler.withoutTrailingSlashes(pathParts->group(path, 2));
+  const std::string_view fullPath =
+      path.substr(kPathPrefixLength, hostOrDrive.size() + shareNameAndPath.size());
+  return detail::UncDetails{hostOrDrive, {}, {}, shareNameAndPath, fullPath};
+}
+
+void UncUnnormalisedDeviceDrivePath::validatePath(const std::string_view& windowsPath,
+                                                  const detail::UncDetails& uncDetails) const {
+  uncUnnormalisedDevicePathHandler.validatePath(windowsPath, uncDetails);
+
+  // UNC device drive path specific
+
+  if (uncDetails.hostOrDrive.empty()) {
+    // E.g. `\\?\\path` - drive letter segment is blank.
+    throwError(kErrorInvalidPath, windowsPath);
+  }
+  if (uncDetails.shareNameAndPath.empty()) {
+    // Must be followed by an absolute path e.g. `\\?\C:\`.
+    throwError(kErrorInvalidPath, windowsPath);
+  }
+  if (!driveLetterHandler.isDrive(uncDetails.hostOrDrive)) {
+    // Must be followed by a drive e.g. `\\?\C:`.
+    throwError(kErrorUnsupportedDevicePath, windowsPath);
+  }
+}
+
+void UncUnnormalisedDeviceDrivePath::setUrlPath(const detail::UncDetails& uncDetails,
+                                                ada::url& url) const {
+  // `\\?\C:\path` - `C:` part should not be %-encoded.
+  if (Str encodedPath{uncDetails.hostOrDrive}; detail::WindowsUrl::maybePercentEncodeAndAppendTo(
+          uncUnnormalisedDevicePathHandler.removeTrailingSlashesInPathSegments(
+              uncDetails.shareNameAndPath),
+          encodedPath)) {
+    GenericUrl::setUrlPath(
+        uncUnnormalisedDevicePathHandler.removeTrailingSlashesInPathSegments(encodedPath), url);
+  } else {
+    GenericUrl::setUrlPath(
+        uncUnnormalisedDevicePathHandler.removeTrailingSlashesInPathSegments(uncDetails.fullPath),
+        url);
+  }
+}
+
+// ---------------------------------------------------------------------
+// UncUnnormalisedDeviceSharePath
+
+bool UncUnnormalisedDeviceSharePath::toUrl(const std::string_view& windowsPath,
+                                           ada::url& url) const {
+  const std::optional<detail::UncDetails> uncDetails = extractUncDetails(windowsPath);
+  if (!uncDetails) {
+    return false;
+  }
+  validatePath(windowsPath, *uncDetails);
+  if (!urlHandler.setUrlHost(uncDetails->hostOrDrive, url)) {
+    throwError(kErrorInvalidHostname, windowsPath);
+  }
+  setUrlPath(*uncDetails, url);
+  return true;
+}
+
+std::optional<detail::UncDetails> UncUnnormalisedDeviceSharePath::extractUncDetails(
+    const std::string_view& path) const {
+  auto pathParts = pathRegex.match(path);
+  if (!pathParts) {
+    return std::nullopt;
+  }
+  const std::string_view hostOrDrive = pathParts->group(path, 1);
+  const auto [shareName, sharePath, shareNameAndPath] =
+      extractShareNameAndPath(pathParts->group(path, 2));
+  const std::string_view fullPath =
+      path.substr(kPrefixLength, hostOrDrive.size() + shareNameAndPath.size());
+  return detail::UncDetails{hostOrDrive, shareName, sharePath, shareNameAndPath, fullPath};
+}
+
+std::tuple<std::string_view, std::string_view, std::string_view>
+UncUnnormalisedDeviceSharePath::extractShareNameAndPath(std::string_view shareNameAndPath) const {
+  shareNameAndPath = uncUnnormalisedDevicePathHandler.withoutTrailingSlashes(shareNameAndPath);
+  auto headAndTail = pathHeadAndTailRegex.match(shareNameAndPath);
+  if (!headAndTail) {
+    return {shareNameAndPath, {}, shareNameAndPath};
+  }
+  return {headAndTail->group(shareNameAndPath, 1), headAndTail->group(shareNameAndPath, 2),
+          shareNameAndPath};
+}
+
+void UncUnnormalisedDeviceSharePath::validatePath(const std::string_view& windowsPath,
+                                                  const detail::UncDetails& uncDetails) const {
+  uncUnnormalisedDevicePathHandler.validatePath(windowsPath, uncDetails);
+
+  if (uncDetails.hostOrDrive.empty()) {
+    // E.g. `\\?\UNC\\path` - host segment is blank.
+    throwError(kErrorInvalidHostname, windowsPath);
+  }
+  if (uncHostHandler.isInvalidHostname(uncDetails.hostOrDrive)) {
+    throwError(kErrorInvalidHostname, windowsPath);
+  }
+}
+
+void UncUnnormalisedDeviceSharePath::setUrlPath(const detail::UncDetails& uncDetails,
+                                                ada::url& url) const {
+  const Str urlPath = uncUnnormalisedDevicePathHandler.removeTrailingSlashesInPathSegments(
+      uncDetails.shareNameAndPath);
+  if (Str encodedUrlPath;
+      detail::WindowsUrl::maybePercentEncodeAndAppendTo(urlPath, encodedUrlPath)) {
+    GenericUrl::setUrlPath(encodedUrlPath, url);
+  } else {
+    GenericUrl::setUrlPath(urlPath, url);
+  }
+}
+}  // namespace utils::path::windows::pathTypes
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/utils/path/windows/pathTypes.hpp
+++ b/src/openassetio-core/src/utils/path/windows/pathTypes.hpp
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#pragma once
+#include <optional>
+#include <string_view>
+#include <tuple>
+
+#include <ada.h>
+
+#include <openassetio/export.h>
+
+#include "../../Regex.hpp"
+#include "./detail.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+/**
+ * Handlers for the various top-level categories of Windows-specific
+ * paths.
+ */
+namespace utils::path::windows::pathTypes {
+/**
+ * Utility for handling Windows drive paths e.g. `C:\path`.
+ */
+struct DrivePath {
+  detail::DriveLetter& driveLetterHandler;
+  detail::NormalisedPath& normalisedPathHandler;
+
+  static constexpr std::size_t kDriveLetterLength = 2;
+
+  /**
+   * Validate and convert a Windows drive path to a file URL.
+   *
+   * @param windowsPath Windows path to convert to a URL.
+   * @param url URL object to update.
+   */
+  void toUrl(const std::string_view& windowsPath, ada::url& url) const;
+
+  /**
+   * Validate a Windows drive path.
+   *
+   * @param windowsPath Path to validate.
+   */
+  void validatePath(const std::string_view& windowsPath) const;
+
+  /**
+   * Set Windows path as path component of a file URL.
+   *
+   * The path is normalised according to Windows rules before being
+   * percent encoded and set as the path component of the given URL
+   * object.
+   *
+   * @param windowsPath Path to set as URL path component.
+   * @param url URL object to update.
+   */
+  void setUrlPath(const std::string_view& windowsPath, ada::url& url) const;
+};
+
+/**
+ * Utility for handling standard UNC share paths.
+ *
+ * I.e. `\\host\share`, but not `\\?\device\`
+ *
+ * These paths are normalised much like drive paths, e.g. `/` as well
+ * as `\` is a path separator.
+ */
+struct UncSharePath {
+  detail::UncHost& uncHostHandler;
+  detail::NormalisedPath& normalisedPathHandler;
+  detail::WindowsUrl& urlHandler;
+
+  Regex pathRegex{R"(^([\\/]{2,})([^\\/]*)(.*)$)"};
+  Regex pathHeadAndTailRegex{R"(^([\\/]+[^\\/]+)([\\/].*)$)"};
+
+  /**
+   * Validate and convert a Windows UNC share path to a file URL.
+   *
+   * No-op if the path is not a Windows UNC share path.
+   *
+   * Note that this will parse any UNC path, including device paths
+   * `\\?\`, so these must be filtered out before calling this method.
+   *
+   * @param windowsPath Windows path to convert to a URL.
+   * @param url URL object to update.
+   * @return true if the path is a UNC share path, false otherwise.
+   */
+  bool toUrl(const std::string_view& windowsPath, ada::url& url) const;
+
+  /**
+   * Check if the path is a UNC path, and if so return a structure
+   * containing useful features extracted from the path.
+   *
+   * Note that this will attempt to parse any UNC path, including `\\?\`
+   * device paths, so these must be filtered out before this method is
+   * called.
+   *
+   * @param path Path to parse.
+   * @return Empty optional if the path is not a UNC path, otherwise
+   * the results of parsing the path components.
+   */
+  [[nodiscard]] std::optional<detail::UncDetails> extractUncDetails(
+      const std::string_view& path) const;
+
+  /**
+   * Normalise and split the share name and path components from a UNC
+   * host path.
+   *
+   * Normalises the share path.
+   *
+   * @param shareNameAndPath UNC path excluding hostname prefix.
+   * @return Share name, path and joined name and path, after
+   * normalisation.
+   */
+  [[nodiscard]] std::tuple<std::string_view, std::string_view, std::string_view>
+  extractShareNameAndPath(std::string_view shareNameAndPath) const;
+
+  /**
+   * Validate a Windows UNC share path.
+   *
+   * @param windowsPath Path to validate.
+   * @param uncDetails UNC features of path.
+   */
+  void validatePath(const std::string_view& windowsPath,
+                    const detail::UncDetails& uncDetails) const;
+
+  /**
+   * Set Windows UNC path as path component of a file URL.
+   *
+   * The UNC share path is normalised according to Windows rules before
+   * being percent encoded and set as the path component of the given
+   * URL object.
+   *
+   * @param windowsPath Path to set as URL path component.
+   * @param url URL object to update.
+   */
+  void setUrlPath(const detail::UncDetails& uncDetails, ada::url& url) const;
+};
+
+/**
+ * Utility for handling Windows device drive paths, i.e. `\\?\C:\`.
+ *
+ * The only Windows "devices" we support are drives (plus the special
+ * "UNC" device that is handled by UncUnnormalisedDeviceSharePath).
+ */
+struct UncUnnormalisedDeviceDrivePath {
+  detail::DriveLetter& driveLetterHandler;
+  detail::UncUnnormalisedDevicePath& uncUnnormalisedDevicePathHandler;
+
+  static constexpr std::size_t kPathPrefixLength = std::string_view{R"(\\?\)"}.size();
+  Regex pathRegex{R"(^\\\\\?\\([^\\]*)(.*)$)"};
+
+  /**
+   * Validate and convert a Windows UNC device drive path to a file
+   * URL.
+   *
+   * Note that this will parse all device paths, i.e. paths prefixed
+   * with `\\?\`, including non-drive paths such as `\\?\UNC\`, so such
+   * paths should be filtered before calling this method.
+   *
+   * No-op if the path is not a Windows device path.
+   *
+   * @param windowsPath Windows path to convert to a URL.
+   * @param url URL object to update.
+   * @return true if the path is a Windows UNC device path, false
+   * otherwise.
+   */
+  bool toUrl(const std::string_view& windowsPath, ada::url& url) const;
+
+  /**
+   * Check if the path is a UNC device path, and if so return a
+   * structure containing useful features extracted from the path.
+   *
+   * Assumes a device drive path, i.e. does not split out a share
+   * name/path.
+   *
+   * @param path Path to parse.
+   * @return Empty optional if the path is not a UNC device path,
+   * otherwise the results of parsing the path components.
+   */
+  [[nodiscard]] std::optional<detail::UncDetails> extractUncDetails(
+      const std::string_view& path) const;
+
+  /**
+   * Validate a Windows UNC device drive path.
+   *
+   * @param windowsPath Path to validate.
+   * @param uncDetails UNC features of path.
+   */
+  void validatePath(const std::string_view& windowsPath,
+                    const detail::UncDetails& uncDetails) const;
+
+  /**
+   * Set Windows UNC drive path as path component of a file URL.
+   *
+   * The path after the drive letter is percent encoded, if necessary.
+   * Multiple trailing slashes in path segments are collapsed down to
+   * one.
+   *
+   * @param windowsPath Path to set as URL path component.
+   * @param url URL object to update.
+   */
+  void setUrlPath(const detail::UncDetails& uncDetails, ada::url& url) const;
+};
+
+/**
+ * Utility for handling Windows UNC device share paths, i.e. `\\?\UNC\`.
+ */
+struct UncUnnormalisedDeviceSharePath {
+  detail::UncHost& uncHostHandler;
+  detail::UncUnnormalisedDevicePath& uncUnnormalisedDevicePathHandler;
+  detail::WindowsUrl& urlHandler;
+
+  static constexpr std::size_t kPrefixLength = std::string_view{R"(\\?\UNC\)"}.size();
+  Regex pathRegex{R"(^\\\\\?\\UNC\\([^\\]*)(.*)$)"};
+  Regex pathHeadAndTailRegex{R"(^(\\[^\\]+)(.*)$)"};
+
+  /**
+   * Validate and convert a Windows UNC device share path to a file
+   * URL.
+   *
+   * No-op if the path is not a Windows device share path.
+   *
+   * @param windowsPath Windows path to convert to a URL.
+   * @param url URL object to update.
+   * @return true if the path is a Windows UNC device share path, false
+   * otherwise.
+   */
+  bool toUrl(const std::string_view& windowsPath, ada::url& url) const;
+
+  /**
+   * Check if the path is a UNC device share path, and if so return a
+   * structure containing useful features extracted from the path.
+   *
+   * @param path Path to parse.
+   * @return Empty optional if the path is not a UNC device share path,
+   * otherwise the results of parsing the path components.
+   */
+  [[nodiscard]] std::optional<detail::UncDetails> extractUncDetails(
+      const std::string_view& path) const;
+
+  /**
+   * Split the share name and path components from a UNC device share
+   * path.
+   *
+   * Doesn't normalise the path, other than trimming extraneous
+   * trailing `\`s.
+   *
+   * @param shareNameAndPath UNC device share path excluding hostname
+   * prefix.
+   * @return Share name, path and joined name and path, after
+   * normalisation.
+   */
+  [[nodiscard]] std::tuple<std::string_view, std::string_view, std::string_view>
+  extractShareNameAndPath(std::string_view shareNameAndPath) const;
+
+  /**
+   * Validate a Windows UNC device share path.
+   *
+   * @param windowsPath Path to validate.
+   * @param uncDetails UNC features of path.
+   */
+  void validatePath(const std::string_view& windowsPath,
+                    const detail::UncDetails& uncDetails) const;
+
+  /**
+   * Set Windows UNC device share path as path component of a file URL.
+   *
+   * Multiple trailing slashes in path segments are collapsed down to
+   * one.
+   *
+   * @param uncDetails UNC features of path.
+   * @param url URL object to update.
+   */
+  void setUrlPath(const detail::UncDetails& uncDetails, ada::url& url) const;
+};
+
+}  // namespace utils::path::windows::pathTypes
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/tests/CMakeLists.txt
+++ b/src/openassetio-core/tests/CMakeLists.txt
@@ -57,3 +57,68 @@ openassetio_add_test_fixture_dependencies(
     openassetio.internal.core-cpp-test
     openassetio.internal.install
 )
+
+#-----------------------------------------------------------------------
+# Internal utils test target
+#
+# Target bundling and testing hidden private utils from the core
+# library.
+
+add_executable(openassetio-core-cpp-internal-test-exe)
+openassetio_set_default_target_properties(openassetio-core-cpp-internal-test-exe)
+
+# Add to the set of installable targets.
+install(
+    TARGETS openassetio-core-cpp-internal-test-exe
+    EXPORT ${PROJECT_NAME}_EXPORTED_TARGETS
+)
+
+
+#-----------------------------------------------------------------------
+# Target dependencies
+
+target_sources(openassetio-core-cpp-internal-test-exe
+    PRIVATE
+    # Implementation dependencies.
+    ${PROJECT_SOURCE_DIR}/src/openassetio-core/src/utils/Regex.cpp
+
+    # Tests.
+    main.cpp
+    utils/RegexTest.cpp
+)
+
+target_include_directories(
+    openassetio-core-cpp-internal-test-exe
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/openassetio-core/src
+)
+
+target_link_libraries(
+    openassetio-core-cpp-internal-test-exe
+    PRIVATE
+    openassetio-core
+    # Implementation dependencies.
+    fmt::fmt-header-only
+    PCRE2::8BIT
+
+    # Test dependencies.
+    Catch2::Catch2
+)
+
+
+#-----------------------------------------------------------------------
+# Create CTest target
+
+# Requires: openassetio.internal.install
+add_custom_target(
+    openassetio.internal.core-cpp-internal-test
+    COMMAND
+    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/\
+$<TARGET_FILE_NAME:openassetio-core-cpp-internal-test-exe>"
+)
+
+openassetio_add_test_target(openassetio.internal.core-cpp-internal-test)
+openassetio_add_test_fixture_dependencies(
+    openassetio.internal.core-cpp-internal-test
+    openassetio.internal.install
+)

--- a/src/openassetio-core/tests/utils/RegexTest.cpp
+++ b/src/openassetio-core/tests/utils/RegexTest.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#include <fmt/format.h>
+#include <catch2/catch.hpp>
+
+#include <openassetio/errors/exceptions.hpp>
+
+#include <utils/Regex.hpp>
+
+// Note pathTo/FromUrl tests will fully exercise usage, here we're just
+// mainly testing error cases.
+
+using Catch::Matchers::Exception::ExceptionMessageMatcher;
+using openassetio::errors::InputValidationException;
+using openassetio::utils::Regex;
+
+TEST_CASE("Happy path") {
+  Regex regex{"a(.)c"};
+  openassetio::Str text{"abcde"};
+
+  auto match = regex.match(text);
+
+  REQUIRE(match.has_value());
+  CHECK(match->group(text, 1) == "b");
+  CHECK(regex.substituteToReduceSize(text, "f") == "fde");
+}
+
+TEST_CASE("Invalid pattern exception") {
+  CHECK_THROWS_MATCHES(
+      Regex{"("}, InputValidationException,
+      ExceptionMessageMatcher{"Error 114 compiling regex '(': missing closing parenthesis"});
+}
+
+// Disable the following test if ASan is enabled, since PCRE2 has a leak
+// in this particular error case.
+#ifndef OPENASSETIO_ENABLE_SANITIZER_ADDRESS
+TEST_CASE("Invalid JIT pattern exception") {
+  // From PCRE2 docs:
+  // > There is a limit to the size of pattern that JIT supports,
+  //   imposed by the size of machine stack that it uses. The exact
+  //   rules are not documented because they may change at any time
+  constexpr std::size_t kMaxSingleDotPatterns = 2727;  // Experimentally determined.
+  std::string longPattern;
+  for (std::size_t patternIdx = 0; patternIdx < kMaxSingleDotPatterns + 1; patternIdx++) {
+    longPattern += "(.)";
+  }
+  CHECK_THROWS_MATCHES(Regex{longPattern}, InputValidationException,
+                       ExceptionMessageMatcher{fmt::format(
+                           "Error -48 JIT compiling '{}': no more memory", longPattern)});
+}
+#endif
+
+TEST_CASE("Invalid match exception") {
+  Regex regex{"(*LIMIT_MATCH=1)((a+)b)+"};
+  CHECK_THROWS_MATCHES(
+      regex.match("abab"), InputValidationException,
+      ExceptionMessageMatcher{"Error -47 matching regex to 'abab': match limit exceeded"});
+}
+
+TEST_CASE("Invalid substitution exception") {
+  Regex regex{"a"};
+  CHECK_THROWS_MATCHES(
+      regex.substituteToReduceSize("a", "aa"), InputValidationException,
+      ExceptionMessageMatcher{
+          "Error -48 substituting regex matches in 'a' with 'aa': no more memory"});
+}

--- a/src/openassetio-python/cmodule/CMakeLists.txt
+++ b/src/openassetio-python/cmodule/CMakeLists.txt
@@ -63,6 +63,7 @@ target_sources(
     src/managerApi/ManagerInterfaceBinding.cpp
     src/managerApi/ManagerStateBaseBinding.cpp
     src/trait/TraitsDataBinding.cpp
+    src/utilsBinding.cpp
 )
 
 target_link_libraries(openassetio-python-module

--- a/src/openassetio-python/cmodule/src/_openassetio.cpp
+++ b/src/openassetio-python/cmodule/src/_openassetio.cpp
@@ -19,6 +19,7 @@ PYBIND11_MODULE(_openassetio, mod) {
   const py::module constants = mod.def_submodule("constants");
   const py::module errors = mod.def_submodule("errors");
   const py::module trait = mod.def_submodule("trait");
+  py::module utils = mod.def_submodule("utils");
 
   registerVersion(mod);
   registerAccess(access);
@@ -41,4 +42,5 @@ PYBIND11_MODULE(_openassetio, mod) {
   registerManagerImplementationFactoryInterface(hostApi);
   registerManager(hostApi);
   registerManagerFactory(hostApi);
+  registerUtils(utils);
 }

--- a/src/openassetio-python/cmodule/src/_openassetio.hpp
+++ b/src/openassetio-python/cmodule/src/_openassetio.hpp
@@ -105,3 +105,6 @@ void registerEntityReferencePager(const py::module& mod);
 
 /// Register the EntityReferencePagerInterface class with Python.
 void registerEntityReferencePagerInterface(const py::module& mod);
+
+/// Register the utils namespace with Python.
+void registerUtils(py::module& mod);

--- a/src/openassetio-python/cmodule/src/utilsBinding.cpp
+++ b/src/openassetio-python/cmodule/src/utilsBinding.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#include <pybind11/pybind11.h>
+
+#include <openassetio/utils/path.hpp>
+
+#include "_openassetio.hpp"
+
+void registerUtils(py::module_ &mod) {
+  namespace utils = openassetio::utils;
+
+  py::enum_<utils::PathType>{mod, "PathType"}
+      .value("kSystem", utils::PathType::kSystem)
+      .value("kPOSIX", utils::PathType::kPOSIX)
+      .value("kWindows", utils::PathType::kWindows);
+
+  py::class_<utils::FileUrlPathConverter>(mod, "FileUrlPathConverter")
+      .def(py::init())
+      .def("pathToUrl", &utils::FileUrlPathConverter::pathToUrl, py::arg("absolutePath"),
+           py::arg("pathType") = utils::PathType::kSystem)
+      .def("pathFromUrl", &utils::FileUrlPathConverter::pathFromUrl, py::arg("fileUrl"),
+           py::arg("pathType") = utils::PathType::kSystem);
+}

--- a/src/openassetio-python/package/openassetio/utils.py
+++ b/src/openassetio-python/package/openassetio/utils.py
@@ -1,0 +1,26 @@
+#
+#   Copyright 2023 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+@namespace openassetio.utils
+Provides assorted utility functions to aid library use.
+"""
+
+from openassetio import _openassetio  # pylint: disable=no-name-in-module
+
+
+PathType = _openassetio.utils.PathType
+
+FileUrlPathConverter = _openassetio.utils.FileUrlPathConverter

--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -137,7 +137,7 @@ line-length = 99
 target-version = ["py39"]
 
 [tool.cibuildwheel]
-test-requires = ["pytest"]
+test-requires = ["pytest==7.4.4", "pytest-subtests==0.11.0"]
 test-command = "pytest {package}/tests/package"
 
 [tool.cibuildwheel.linux]

--- a/src/openassetio-python/tests/package/test_imports.py
+++ b/src/openassetio-python/tests/package/test_imports.py
@@ -58,6 +58,9 @@ class Test_package_imports:
     def test_importing_log_succeeds(self):
         from openassetio import log
 
+    def test_importing_utils_succeeds(self):
+        from openassetio import utils
+
 
 class Test_core_imports:
     def test_importing_audit_succeeds(self):

--- a/src/openassetio-python/tests/package/utils/resources/file_url_path_tests.json
+++ b/src/openassetio-python/tests/package/utils/resources/file_url_path_tests.json
@@ -1,0 +1,4188 @@
+{
+    "license": "SPDX-License-Identifier: Apache-2.0",
+    "copyright": [
+      "The swift-url Contributors",
+      "The Foundry Visionmongers Ltd"
+    ],
+    "adapted_from": "https://github.com/karwa/swift-url",
+    "file_path_to_url":
+    [
+
+        { "__section__": "------------------------------ Various kinds of 'root' paths ------------------------------" },
+
+
+
+        {
+            "comment": "Empty path",
+            "file_path": "",
+            "URL_posix": { "failure-reason": "empty-input" },
+            "URL_windows": { "failure-reason": "empty-input" }
+        },
+        {
+            "comment": "POSIX root path",
+            "file_path": "/",
+            "URL_posix": "file:///",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "POSIX root path (backslash)",
+            "file_path": "\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive [no leading, no trailing]. Windows path APIs consider this a relative path.",
+            "file_path": "C:",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive (lowercase) [no leading, no trailing]",
+            "file_path": "c:",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive [no leading, with trailing]",
+            "file_path": "C:\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/"
+        },
+        {
+            "comment": "Windows drive (lowercase) [no leading, with trailing]",
+            "file_path": "c:\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///c:/"
+        },
+        {
+            "comment": "Windows drive [no leading, with trailing (alt)]",
+            "file_path": "C:/",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/"
+        },
+        {
+            "comment": "Windows drive (lowercase) [no leading, with trailing (alt)]",
+            "file_path": "c:/",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///c:/"
+        },
+        {
+            "comment": "Windows drive [with leading, no trailing]",
+            "file_path": "\\C:",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive (lowercase) [with leading, no trailing]",
+            "file_path": "\\c:",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive [with leading (alt), no trailing]",
+            "file_path": "/C:",
+            "URL_posix": "file:///C%3A",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive (lowercase) [with leading(alt), no trailing]",
+            "file_path": "/c:",
+            "URL_posix": "file:///c%3A",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive [with leading, with trailing]",
+            "file_path": "\\C:\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive [with leading (alt), with trailing (alt)]",
+            "file_path": "/C:/",
+            "URL_posix": "file:///C%3A/",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive (alt) [no leading, no trailing]. Windows path APIs do not consider this to be a drive letter.",
+            "file_path": "C|",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive (alt)(lowercase) [no leading, no trailing]",
+            "file_path": "c|",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive (alt) [no leading, with trailing]",
+            "file_path": "C|\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive (alt)(lowercase) [no leading, with trailing]",
+            "file_path": "c|\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive (alt) [with leading, no trailing]",
+            "file_path": "\\C|",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive (alt)(lowercase) [with leading, no trailing]",
+            "file_path": "\\c|",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive (alt) [with leading (alt), with trailing (alt)]",
+            "file_path": "/C|/",
+            "URL_posix": "file:///C%7C/",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive (alt)(lowercase) [with leading (alt), with trailing (alt)]",
+            "file_path": "/c|/",
+            "URL_posix": "file:///c%7C/",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Namespaced Windows path prefix",
+            "file_path": "\\\\?\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced Windows path prefix [forward slash]",
+            "file_path": "//?/",
+            "URL_posix": "file:////%3F/",
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced Windows drive [no trailing]. The Windows 'dir' command also rejects this.",
+            "file_path": "\\\\?\\C:",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced Windows drive (lowercase) [no trailing]",
+            "file_path": "\\\\?\\c:",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced Windows drive [with trailing]",
+            "file_path": "\\\\?\\C:\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/"
+        },
+        {
+            "comment": "Namespaced Windows drive (lowercase) [with trailing]",
+            "file_path": "\\\\?\\c:\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///c:/"
+        },
+        {
+            "comment": "Namespaced Windows drive [forward slash, with trailing]",
+            "file_path": "//?/C:\\",
+            "URL_posix": "file:////%3F/C%3A%5C",
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced Windows drive (lowercase) [forward slash, with trailing]",
+            "file_path": "//?/c:\\",
+            "URL_posix": "file:////%3F/c%3A%5C",
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced Windows drive [with trailing (alt)]",
+            "file_path": "\\\\?\\C:/",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced Windows drive (lowercase) [with trailing (alt)]",
+            "file_path": "\\\\?\\c:/",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced Windows drive (alt) [no trailing]",
+            "file_path": "\\\\?\\C|",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced Windows drive (alt)(lowercase) [no trailing]",
+            "file_path": "\\\\?\\c|",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced Windows drive (alt) [with trailing]",
+            "file_path": "\\\\?\\C|\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced Windows drive (alt)(lowercase) [with trailing]",
+            "file_path": "\\\\?\\c|\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "UNC server root [no trailing]",
+            "file_path": "\\\\mypc",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/"
+        },
+        {
+            "comment": "UNC server root, mixed separators [no trailing]",
+            "file_path": "/\\mypc",
+            "URL_posix": "file:///%5Cmypc",
+            "URL_windows": "file://mypc/"
+        },
+        {
+            "comment": "UNC server root [with trailing]",
+            "file_path": "\\\\mypc\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/"
+        },
+        {
+            "comment": "UNC server root, mixed separators [with trailing]",
+            "file_path": "/\\mypc\\",
+            "URL_posix": "file:///%5Cmypc%5C",
+            "URL_windows": "file://mypc/"
+        },
+        {
+            "comment": "UNC share root [no trailing]",
+            "file_path": "\\\\mypc\\share",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share"
+        },
+        {
+            "comment": "UNC share root, mixed separators [no trailing]",
+            "file_path": "/\\mypc/share",
+            "URL_posix": "file:///%5Cmypc/share",
+            "URL_windows": "file://mypc/share"
+        },
+        {
+            "comment": "UNC share root [with trailing]",
+            "file_path": "\\\\mypc\\share\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share/"
+        },
+        {
+            "comment": "UNC share root, mixed separators [with trailing]",
+            "file_path": "/\\mypc\\share/",
+            "URL_posix": "file:///%5Cmypc%5Cshare/",
+            "URL_windows": "file://mypc/share/"
+        },
+        {
+            "comment": "Namespaced UNC path prefix [no trailing]",
+            "file_path": "\\\\?\\UNC",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced UNC (lowercase) path prefix [no trailing]. Windows also accepts lowercase 'UNC'.",
+            "file_path": "\\\\?\\unc",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced UNC path prefix",
+            "file_path": "\\\\?\\UNC\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced UNC (lowercase) path prefix",
+            "file_path": "\\\\?\\unc\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced UNC path prefix [forward slash]",
+            "file_path": "//?/UNC/",
+            "URL_posix": "file:////%3F/UNC/",
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced UNC (lowercase) path prefix [forward slash]",
+            "file_path": "//?/unc/",
+            "URL_posix": "file:////%3F/unc/",
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced UNC server root [no trailing]",
+            "file_path": "\\\\?\\UNC\\mypc",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/"
+        },
+        {
+            "comment": "Namespaced UNC (lowercase) server root [no trailing]",
+            "file_path": "\\\\?\\unc\\mypc",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/"
+        },
+        {
+            "comment": "Namespaced UNC server root [with trailing]",
+            "file_path": "\\\\?\\UNC\\mypc\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/"
+        },
+        {
+            "comment": "Namespaced UNC (lowercase) server root [with trailing]",
+            "file_path": "\\\\?\\unc\\mypc\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/"
+        },
+        {
+            "comment": "Namespaced UNC server root [with trailing (alt)]",
+            "file_path": "\\\\?\\UNC\\mypc/",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced UNC (lowercase) server root [with trailing (alt)]",
+            "file_path": "\\\\?\\unc\\mypc/",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced UNC share root [no trailing]",
+            "file_path": "\\\\?\\UNC\\mypc\\share",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share"
+        },
+        {
+            "comment": "Namespaced UNC (lowercase) share root [no trailing]",
+            "file_path": "\\\\?\\unc\\mypc\\share",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share"
+        },
+        {
+            "comment": "Namespaced UNC share root [with trailing]",
+            "file_path": "\\\\?\\UNC\\mypc\\share\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share/"
+        },
+        {
+            "comment": "Namespaced UNC (lowercase) share root [with trailing]",
+            "file_path": "\\\\?\\unc\\mypc\\share\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share/"
+        },
+        {
+            "comment": "Namespaced UNC share root [mixed separators]",
+            "file_path": "\\\\?\\UNC\\mypc/share\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced UNC (lowercase) share root [mixed separators]",
+            "file_path": "\\\\?\\unc\\mypc/share\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced UNC share root [forward slash prefix]",
+            "file_path": "//?/UNC/mypc\\share\\",
+            "URL_posix": "file:////%3F/UNC/mypc%5Cshare%5C",
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced UNC (lowercase) share root [forward slash prefix]",
+            "file_path": "//?/unc/mypc\\share\\",
+            "URL_posix": "file:////%3F/unc/mypc%5Cshare%5C",
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+
+
+
+        { "__section__": "------------------------------ Basic directory paths ------------------------------" },
+
+
+
+        {
+            "comment": "Directory path [no drive, no leading]",
+            "file_path": "foo/BAR/baZ/",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Directory path [no drive, with leading]",
+            "file_path": "/foo/BAR/baZ/",
+            "URL_posix": "file:///foo/BAR/baZ/",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Directory path [with drive, no leading]",
+            "file_path": "C:/foo/BAR/baZ/",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/BAR/baZ/"
+        },
+        {
+            "comment": "Directory path [with drive, with leading]",
+            "file_path": "/C:/foo/BAR/baZ/",
+            "URL_posix": "file:///C%3A/foo/BAR/baZ/",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Directory path [with drive (alt), no leading]. Windows path APIs do not consider these to have drive letters.",
+            "file_path": "C|/foo/BAR/baZ/",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Directory path [with drive (alt), with leading]",
+            "file_path": "/C|/foo/BAR/baZ/",
+            "URL_posix": "file:///C%7C/foo/BAR/baZ/",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Directory path, mixed separators [no drive, with leading]",
+            "file_path": "/foo\\BAR/baZ\\",
+            "URL_posix": "file:///foo%5CBAR/baZ%5C",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Directory path, mixed separators [with drive, no leading]",
+            "file_path": "C:\\foo/BAR\\baZ/",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/BAR/baZ/"
+        },
+        {
+            "comment": "Namespaced directory path [no drive]",
+            "file_path": "\\\\?\\foo\\BAR\\baZ\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced directory path [with drive]",
+            "file_path": "\\\\?\\C:\\foo\\BAR\\baZ\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/BAR/baZ/"
+        },
+        {
+            "comment": "Namespaced directory path [with drive (lowercase)]",
+            "file_path": "\\\\?\\c:\\foo\\BAR\\baZ\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///c:/foo/BAR/baZ/"
+        },
+        {
+            "comment": "Namespaced directory path [with drive (alt)]",
+            "file_path": "\\\\?\\C|\\foo\\BAR\\baZ\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced directory path, mixed separators [with drive]",
+            "file_path": "\\\\?\\C:\\foo/BAR\\baZ/",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "UNC directory path",
+            "file_path": "\\\\my_pc\\foo\\BAR\\baZ\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/foo/BAR/baZ/"
+        },
+        {
+            "comment": "UNC directory path, mixed separators",
+            "file_path": "/\\my_pc/foo\\BAR/baZ\\",
+            "URL_posix": "file:///%5Cmy_pc/foo%5CBAR/baZ%5C",
+            "URL_windows": "file://my_pc/foo/BAR/baZ/"
+        },
+        {
+            "comment": "UNC directory path, forward slashes",
+            "file_path": "//my_pc/foo/BAR/baZ/",
+            "URL_posix": "file:////my_pc/foo/BAR/baZ/",
+            "URL_windows": "file://my_pc/foo/BAR/baZ/"
+        },
+        {
+            "comment": "Namespaced UNC directory path",
+            "file_path": "\\\\?\\UNC\\my_pc\\foo\\BAR\\baZ\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/foo/BAR/baZ/"
+        },
+        {
+            "comment": "Namespaced UNC (lowercase) directory path",
+            "file_path": "\\\\?\\unc\\my_pc\\foo\\BAR\\baZ\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/foo/BAR/baZ/"
+        },
+        {
+            "comment": "Namespaced UNC directory path, mixed separators",
+            "file_path": "\\\\?\\UNC\\my_pc/foo\\BAR/baZ\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+
+
+
+        { "__section__": "------------------------------ Basic file paths ------------------------------" },
+
+
+
+        {
+            "comment": "File path [no drive, no leading]",
+            "file_path": "foo/BAR/baZ.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "File path [no drive, with leading]",
+            "file_path": "/foo/BAR/baZ.txt",
+            "URL_posix": "file:///foo/BAR/baZ.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "File path [with drive, no leading]",
+            "file_path": "C:/foo/BAR/baZ.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/BAR/baZ.txt"
+        },
+        {
+            "comment": "File path [with drive (lowercase), no leading]",
+            "file_path": "c:/foo/BAR/baZ.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///c:/foo/BAR/baZ.txt"
+        },
+        {
+            "comment": "File path [with drive, with leading]",
+            "file_path": "/C:/foo/BAR/baZ.txt",
+            "URL_posix": "file:///C%3A/foo/BAR/baZ.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "File path [with drive (alt), no leading]. Windows path APIs do not consider these to have drive letters.",
+            "file_path": "C|/foo/BAR/baZ.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "File path [with drive (alt), with leading]",
+            "file_path": "/C|/foo/BAR/baZ.txt",
+            "URL_posix": "file:///C%7C/foo/BAR/baZ.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "File path, mixed separators [with drive, no leading]",
+            "file_path": "C:\\foo/BAR\\baZ.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/BAR/baZ.txt"
+        },
+        {
+            "comment": "File path, mixed separators [no drive, with leading]",
+            "file_path": "/foo\\BAR/baZ.txt",
+            "URL_posix": "file:///foo%5CBAR/baZ.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Namespaced file path [no drive]",
+            "file_path": "\\\\?\\foo\\BAR\\baZ.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced file path [with drive]",
+            "file_path": "\\\\?\\C:\\foo\\BAR\\baZ.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/BAR/baZ.txt"
+        },
+        {
+            "comment": "Namespaced file path [with drive (lowercase)]",
+            "file_path": "\\\\?\\c:\\foo\\BAR\\baZ.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///c:/foo/BAR/baZ.txt"
+        },
+        {
+            "comment": "Namespaced file path [with drive (alt)]",
+            "file_path": "\\\\?\\C|\\foo\\BAR\\baZ.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced file path, mixed separators [with drive]",
+            "file_path": "\\\\?\\C:\\foo/BAR\\baZ.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "UNC file path",
+            "file_path": "\\\\my_pc\\foo\\BAR\\baZ.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/foo/BAR/baZ.txt"
+        },
+        {
+            "comment": "UNC file path, mixed separators",
+            "file_path": "/\\my_pc/foo\\BAR/baZ.txt",
+            "URL_posix": "file:///%5Cmy_pc/foo%5CBAR/baZ.txt",
+            "URL_windows": "file://my_pc/foo/BAR/baZ.txt"
+        },
+        {
+            "comment": "UNC file path, forward slashes",
+            "file_path": "//my_pc/foo/BAR/baZ.txt",
+            "URL_posix": "file:////my_pc/foo/BAR/baZ.txt",
+            "URL_windows": "file://my_pc/foo/BAR/baZ.txt"
+        },
+        {
+            "comment": "Namespaced UNC file path",
+            "file_path": "\\\\?\\UNC\\my_pc\\foo\\BAR\\baZ.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/foo/BAR/baZ.txt"
+        },
+        {
+            "comment": "Namespaced UNC (lowecase) file path",
+            "file_path": "\\\\?\\unc\\my_pc\\foo\\BAR\\baZ.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/foo/BAR/baZ.txt"
+        },
+        {
+            "comment": "Namespaced UNC file path, mixed separators",
+            "file_path": "\\\\?\\UNC\\my_pc/foo\\BAR/baZ.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+
+
+
+        { "__section__": "------------------------------ Hostnames (UNC) ------------------------------" },
+
+
+
+        {
+            "comment": "UNC path with uppercase server name",
+            "file_path": "\\\\MY_PC\\Foo\\bAr.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/Foo/bAr.txt"
+        },
+        {
+            "comment": "UNC path with uppercase server name [forward slash]",
+            "file_path": "//MY_PC/Foo/bAr.txt",
+            "URL_posix": "file:////MY_PC/Foo/bAr.txt",
+            "URL_windows": "file://my_pc/Foo/bAr.txt"
+        },
+        {
+            "comment": "UNC path with uppercase server name [mixed separators]",
+            "file_path": "/\\MY_PC/Foo\\bAr.txt",
+            "URL_posix": "file:///%5CMY_PC/Foo%5CbAr.txt",
+            "URL_windows": "file://my_pc/Foo/bAr.txt"
+        },
+        {
+            "comment": "Namespaced UNC path with uppercase server name",
+            "file_path": "\\\\?\\UNC\\MY_PC\\Foo\\bAr.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/Foo/bAr.txt"
+        },
+        {
+            "comment": "Namespaced UNC (lowercase) path with uppercase server name",
+            "file_path": "\\\\?\\unc\\MY_PC\\Foo\\bAr.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/Foo/bAr.txt"
+        },
+        {
+            "comment": "UNC path with uppercase server name [mixed separators]",
+            "file_path": "\\\\?\\UNC\\MY_PC/foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "UNC path with spaces in server name. Chrome allows this, but it isn't a valid hostname and cannot be escaped. https://github.com/whatwg/url/issues/599 ",
+            "file_path": "\\\\some computer\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced UNC path with spaces in server name",
+            "file_path": "\\\\?\\UNC\\some computer\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path with percent-encoded server name",
+            "file_path": "\\\\%61%62%63\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced UNC path with percent-encoded server name",
+            "file_path": "\\\\?\\UNC\\%61%62%63\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path with percent-encoded '?' server name",
+            "file_path": "\\\\%3F\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced UNC path with percent-encoded '?' server name",
+            "file_path": "\\\\?\\UNC\\%3F\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path with percent-encoded '.' server name",
+            "file_path": "\\\\%2E\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced UNC path with percent-encoded '.' server name",
+            "file_path": "\\\\?\\UNC\\%2E\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path with invalid unicode in server name. U+FDD0 is disallowed.",
+            "file_path": "\\\\\ufdd0zyx\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced UNC path with invalid unicode in server name",
+            "file_path": "\\\\?\\UNC\\\ufdd0zyx\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path to localhost. Unfortunately, we need to do some fudging with this to preserve the hostname. '\\\\localhost\\someshare' is a valid UNC path, and Chrome, Edge, IE, etc are all able to locate it using 'file://localhost/someshare'. We need the hostname to be able to resolve the path '/someshare'; nothing on Windows seems able to resolve the host-less 'file:///someshare'. The most compatible option appears to be to use the IPv4 loopback address; '\\\\.\\UNC\\localhost\\someshare' (i.e. file://./UNC/localhost/someshare) would also be an option, but IE/Explorer can't handle those.",
+            "file_path": "\\\\localhost\\SomeShare\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://127.0.0.1/SomeShare/Windows/System32/notepad.exe"
+        },
+        {
+            "comment": "Namespaced UNC path to localhost. Unfortunately, we need to do some fudging to maintain that this is a UNC path.",
+            "file_path": "\\\\?\\UNC\\localhost\\SomeShare\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://127.0.0.1/SomeShare/Windows/System32/notepad.exe"
+        },
+        {
+            "comment": "UNC path to localhost (mixed case). See above for the reason behind this unfortunate hack.",
+            "file_path": "\\\\LoCaLhOsT\\SomeShare\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://127.0.0.1/SomeShare/Windows/System32/notepad.exe"
+        },
+        {
+            "comment": "Namespaced UNC path to localhost (mixed case)",
+            "file_path": "\\\\?\\UNC\\LoCaLhOsT\\SomeShare\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://127.0.0.1/SomeShare/Windows/System32/notepad.exe"
+        },
+        {
+            "comment": "UNC path to localhost (percent-encoded)",
+            "file_path": "\\\\Lo%63aLhOsT\\SomeShare\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced UNC path to localhost (percent-encoded)",
+            "file_path": "\\\\?\\UNC\\Lo%63aLhOsT\\SomeShare\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path with IPv4 server address",
+            "file_path": "\\\\192.168.178.1\\c$\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://192.168.178.1/c$/Windows/System32/notepad.exe"
+        },
+        {
+            "comment": "Namespaced UNC path with IPv4 server address",
+            "file_path": "\\\\?\\UNC\\192.168.178.1\\c$\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://192.168.178.1/c$/Windows/System32/notepad.exe"
+        },
+        {
+            "comment": "UNC path with weird IPv4 server address",
+            "file_path": "\\\\0xBaDf00d\\c$\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://11.173.240.13/c$/Windows/System32/notepad.exe"
+        },
+        {
+            "comment": "Namespaced UNC path with weird IPv4 server address",
+            "file_path": "\\\\?\\UNC\\0xBaDf00d\\c$\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://11.173.240.13/c$/Windows/System32/notepad.exe"
+        },
+        {
+            "comment": "UNC path with weird IPv4 server address [forward slash]",
+            "file_path": "//0xBaDf00d/c$/Windows/System32/notepad.exe",
+            "URL_posix": "file:////0xBaDf00d/c$/Windows/System32/notepad.exe",
+            "URL_windows": "file://11.173.240.13/c$/Windows/System32/notepad.exe"
+        },
+        {
+            "comment": "UNC path with URL-style IPv6 server address. Supposedly, this is not valid UNC, but Chrome/Edge support these paths anyway. IE/Windows Explorer don't.",
+            "file_path": "\\\\[2001:db8::]\\WebURL\\foo",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://[2001:db8::]/WebURL/foo"
+        },
+        {
+            "comment": "Namespaced UNC path with URL-style IPv6 server address",
+            "file_path": "\\\\?\\UNC\\[2001:db8::]\\WebURL\\foo",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://[2001:db8::]/WebURL/foo"
+        },
+        {
+            "comment": "UNC path with undelimited IPv6 server address",
+            "file_path": "\\\\0:0:0::1\\c$\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced UNC path with undelimited IPv6 server address",
+            "file_path": "\\\\?\\UNC\\0:0:0::1\\c$\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path with transcribed IPv6 server address",
+            "file_path": "\\\\2001-db8--.ipv6-literal.net\\WebURL\\foo",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://2001-db8--.ipv6-literal.net/WebURL/foo"
+        },
+        {
+            "comment": "Namespaced UNC path with transcribed IPv6 server address",
+            "file_path": "\\\\?\\UNC\\2001-db8--.ipv6-literal.net\\WebURL\\foo",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://2001-db8--.ipv6-literal.net/WebURL/foo"
+        },
+        {
+            "comment": "UNC path with '.' server address. This is used for DOS device paths.",
+            "file_path": "\\\\.\\SomeDevice\\SomePath\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path with '.' server address [forward slash]. This is technically not a DOS device path, but we have no way of encoding the difference. It is not a valid domain, anyway.",
+            "file_path": "//./SomeDevice/SomePath/",
+            "URL_posix": "file:////SomeDevice/SomePath/",
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced UNC path with '.' server address. This is technically not a DOS device path, but we have no way of encoding the difference. It is not a valid domain, anyway.",
+            "file_path": "\\\\?\\UNC\\.\\C:\\Windows\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced UNC path with '.' server address [forward slash]",
+            "file_path": "\\\\?\\UNC\\./COM1",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "UNC path with '..' server address",
+            "file_path": "\\\\..\\share\\WebURL\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://../share/WebURL/"
+        },
+        {
+            "comment": "Namespaced UNC path with '..' server address",
+            "file_path": "\\\\?\\UNC\\..\\share\\WebURL\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://../share/WebURL/"
+        },
+        {
+            "comment": "UNC path with '...' server address",
+            "file_path": "\\\\...\\share\\WebURL\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://.../share/WebURL/"
+        },
+        {
+            "comment": "Namespaced UNC path with '...' server address",
+            "file_path": "\\\\?\\UNC\\...\\share\\WebURL\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://.../share/WebURL/"
+        },
+        {
+            "comment": "UNC path with drive letter server address",
+            "file_path": "\\\\C:\\bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path with drive letter (lowercase) server address",
+            "file_path": "\\\\c:\\bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced UNC path with drive letter server address",
+            "file_path": "\\\\?\\UNC\\C:\\bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced UNC path with drive letter (lowercase) server address",
+            "file_path": "\\\\?\\UNC\\c:\\bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path with drive letter server address [forward slash]",
+            "file_path": "//C:/bar",
+            "URL_posix": "file:////C%3A/bar",
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path with drive letter (alt) server address",
+            "file_path": "\\\\C|\\bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced UNC path with drive letter (alt) server address",
+            "file_path": "\\\\?\\UNC\\C|\\bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path with drive letter (alt) server address [forward slash]",
+            "file_path": "//C|/bar",
+            "URL_posix": "file:////C%7C/bar",
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path with drive letter server address, 3 leading slashes [forward slash]",
+            "file_path": "///C:/bar",
+            "URL_posix": "file:///C%3A/bar",
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path with drive letter (alt) server address, 3 leading slashes [forward slash]",
+            "file_path": "///C|/bar",
+            "URL_posix": "file:///C%7C/bar",
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path with drive letter server address, 4 leading slashes [forward slash]",
+            "file_path": "////C:/bar",
+            "URL_posix": "file:///C%3A/bar",
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path with drive letter (alt) server address, 4 leading slashes [forward slash]",
+            "file_path": "////C|/bar",
+            "URL_posix": "file:///C%7C/bar",
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+
+
+
+        { "__section__": "------------------------------ UNC special share names ------------------------------" },
+
+
+
+        {
+            "comment": "UNC path, share looks like a drive letter. UNC paths do not have drive letters, so this should be escaped to avoid special handling by URL-level operations.",
+            "file_path": "\\\\my_pc\\c:\\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/c%3A/dir"
+        },
+        {
+            "comment": "Namespaced UNC path, share looks like a drive letter",
+            "file_path": "\\\\?\\UNC\\my_pc\\c:\\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/c%3A/dir"
+        },
+        {
+            "comment": "UNC path, share looks like a drive letter (alt)",
+            "file_path": "\\\\my_pc\\c|\\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/c%7C/dir"
+        },
+        {
+            "comment": "Namespaced UNC path, share looks like a drive letter (alt)",
+            "file_path": "\\\\?\\UNC\\my_pc\\c|\\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/c%7C/dir"
+        },
+        {
+            "comment": "UNC path, share looks like a drive letter. Extra slashes before share name.",
+            "file_path": "\\\\my_pc\\\\\\c:\\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/c%3A/dir"
+        },
+        {
+            "comment": "Namespaced UNC path, share looks like a drive letter. Extra slashes before share name.",
+            "file_path": "\\\\?\\UNC\\my_pc\\\\\\c:\\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/c%3A/dir"
+        },
+        {
+            "comment": "UNC path, share looks like a drive letter (alt). Extra slashes before share name.",
+            "file_path": "\\\\my_pc\\\\\\c|\\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/c%7C/dir"
+        },
+        {
+            "comment": "UNC path, share uses $ notation for drive letter",
+            "file_path": "\\\\localhost\\c$\\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://127.0.0.1/c$/dir"
+        },
+        {
+            "comment": "Namespaced UNC path, share uses $ notation for drive letter",
+            "file_path": "\\\\?\\UNC\\localhost\\c$\\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://127.0.0.1/c$/dir"
+        },
+        {
+            "comment": "UNC path, share uses $ notation for drive letter. Extra slashes before share name.",
+            "file_path": "\\\\my_pc\\\\\\c$\\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/c$/dir"
+        },
+        {
+            "comment": "Namespaced UNC path, share uses $ notation for drive letter. Extra slashes before share name.",
+            "file_path": "\\\\?\\UNC\\my_pc\\\\\\c$\\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/c$/dir"
+        },
+        {
+            "comment": "UNC path with single dot share name        -------------------------------------------- TODO: Should this be banned?",
+            "file_path": "\\\\mypc\\.\\foo\\bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/foo/bar"
+        },
+        {
+            "comment": "Namespaced UNC path with single dot share name",
+            "file_path": "\\\\?\\UNC\\mypc\\.\\foo\\bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/foo/bar"
+        },
+        {
+            "comment": "UNC path with '..' share name. The share name is part of the path and '..' components cannot be escaped, so we can't prevent the URL parser from interpreting and simplifying this.",
+            "file_path": "\\\\mypc\\..\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "Namespaced UNC path with '..' share name",
+            "file_path": "\\\\?\\UNC\\mypc\\..\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "UNC path with '...' share name",
+            "file_path": "\\\\mypc\\...\\foo\\bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/.../foo/bar"
+        },
+        {
+            "comment": "Namespaced UNC path with '...' share name",
+            "file_path": "\\\\?\\UNC\\mypc\\...\\foo\\bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/.../foo/bar"
+        },
+
+
+
+        { "__section__": "------------------------------ Paths containing symbols ------------------------------" },
+
+
+
+        {
+            "comment": "File path with symbols, including space, tilde, '?' and '#' [no drive, no leading]",
+            "file_path": "~/foo/bar?/baz#.txt/Name;with%some symbols*#",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "File path with symbols, including space, tilde, '?' and '#' [no drive, with leading]",
+            "file_path": "/~/foo/bar?/baz#.txt/Name;with%some symbols*#",
+            "URL_posix": "file:///~/foo/bar%3F/baz%23.txt/Name;with%25some%20symbols*%23",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "File path with symbols, including space, tilde, '?' and '#' [with drive, no leading]",
+            "file_path": "C:\\~/foo\\bar?/baz#.txt\\Name;with%some symbols*#",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/~/foo/bar%3F/baz%23.txt/Name;with%25some%20symbols*%23"
+        },
+        {
+            "comment": "File path with symbols, including space, tilde, '?' and '#' [with drive, with leading]",
+            "file_path": "/C:/~/foo/bar?\\baz#.txt/Name;with%some symbols*#",
+            "URL_posix": "file:///C%3A/~/foo/bar%3F%5Cbaz%23.txt/Name;with%25some%20symbols*%23",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "File path with symbols, including space, tilde, '?' and '#' [with drive (lowercase), no leading]",
+            "file_path": "c:\\~/foo\\bar?/baz#.txt\\Name;with%some symbols*#",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///c:/~/foo/bar%3F/baz%23.txt/Name;with%25some%20symbols*%23"
+        },
+        {
+            "comment": "Namespaced file path with symbols, including space, tilde, '?' and '#' [with drive]",
+            "file_path": "\\\\?\\C:\\~\\foo\\bar?\\baz#.txt\\Name;with%some symbols*#",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/~/foo/bar%3F/baz%23.txt/Name;with%25some%20symbols*%23"
+        },
+        {
+            "comment": "Namespaced file path with symbols, including space, tilde, '?' and '#' [with drive (lowercase)]",
+            "file_path": "\\\\?\\c:\\~\\foo\\bar?\\baz#.txt\\Name;with%some symbols*#",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///c:/~/foo/bar%3F/baz%23.txt/Name;with%25some%20symbols*%23"
+        },
+        {
+            "comment": "UNC path, share name contains symbols",
+            "file_path": "\\\\my_pc\\c$?#;%some symbols*#\\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/c$%3F%23;%25some%20symbols*%23/dir"
+        },
+        {
+            "comment": "Namespaced UNC path, share name contains symbols",
+            "file_path": "\\\\?\\UNC\\my_pc\\c$?#;%some symbols*#\\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/c$%3F%23;%25some%20symbols*%23/dir"
+        },
+        {
+            "comment": "Namespaced UNC (lowercase) path, share name contains symbols",
+            "file_path": "\\\\?\\unc\\my_pc\\c$?#;%some symbols*#\\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/c$%3F%23;%25some%20symbols*%23/dir"
+        },
+        {
+            "comment": "UNC path with symbols in path section, including space, tilde, '?' and '#'",
+            "file_path": "\\\\my_pc\\share\\~\\foo\\bar?\\baz#.txt\\Name;with%some symbols*#",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share/~/foo/bar%3F/baz%23.txt/Name;with%25some%20symbols*%23"
+        },
+        {
+            "comment": "Namespaced UNC path with symbols in path section, including space, tilde, '?' and '#'",
+            "file_path": "\\\\?\\UNC\\my_pc\\share\\~\\foo\\bar?\\baz#.txt\\Name;with%some symbols*#",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share/~/foo/bar%3F/baz%23.txt/Name;with%25some%20symbols*%23"
+        },
+        {
+            "comment": "Namespaced UNC (lowercase) path with symbols in path section, including space, tilde, '?' and '#'",
+            "file_path": "\\\\?\\unc\\my_pc\\share\\~\\foo\\bar?\\baz#.txt\\Name;with%some symbols*#",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share/~/foo/bar%3F/baz%23.txt/Name;with%25some%20symbols*%23"
+        },
+        {
+            "comment": "UNC path with symbols in path section, including space, tilde, '?' and '#' [forward slash]",
+            "file_path": "//my_pc/share/~/foo/bar?/baz#.txt/Name;with%some symbols*#",
+            "URL_posix": "file:////my_pc/share/~/foo/bar%3F/baz%23.txt/Name;with%25some%20symbols*%23",
+            "URL_windows": "file://my_pc/share/~/foo/bar%3F/baz%23.txt/Name;with%25some%20symbols*%23"
+        },
+        {
+            "comment": "UNC path with symbols in path section, including space, tilde, '?' and '#' [mixed separators]",
+            "file_path": "/\\my_pc/share\\~/foo\\bar?/baz#.txt\\Name;with%some symbols*#",
+            "URL_posix": "file:///%5Cmy_pc/share%5C~/foo%5Cbar%3F/baz%23.txt%5CName;with%25some%20symbols*%23",
+            "URL_windows": "file://my_pc/share/~/foo/bar%3F/baz%23.txt/Name;with%25some%20symbols*%23"
+        },
+        {
+            "comment": "Path with C0, trailing space [no drive, with leading, no trailing]",
+            "file_path": "/foo /\u0007\u0009bar\u000A ",
+            "URL_posix": "file:///foo%20/%07%09bar%0A%20",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with C0, trailing space [no drive, with leading, with trailing]",
+            "file_path": "/foo /\u0007\u0009bar\u000A /",
+            "URL_posix": "file:///foo%20/%07%09bar%0A%20/",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with C0, trailing space [with drive, no leading, no trailing]",
+            "file_path": "C:/foo /\u0007\u0009bar\u000A ",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo%20/%07%09bar%0A"
+        },
+        {
+            "comment": "Path with C0, trailing space [with drive, no leading, with trailing]",
+            "file_path": "C:/foo /\u0007\u0009bar\u000A /",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo%20/%07%09bar%0A%20/"
+        },
+        {
+            "comment": "Namespaced path with C0, trailing space [with drive, no trailing]",
+            "file_path": "\\\\?\\C:\\foo \\\u0007\u0009bar\u000A ",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo%20/%07%09bar%0A%20"
+        },
+        {
+            "comment": "Namespaced Path with C0, trailing space [with drive, with trailing]",
+            "file_path": "\\\\?\\C:\\foo \\\u0007\u0009bar\u000A \\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo%20/%07%09bar%0A%20/"
+        },
+        {
+            "comment": "UNC path, share contains C0, trailing space [no trailing]",
+            "file_path": "\\\\my_pc\\foo \u0007\u0009bar\u000A ",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/foo%20%07%09bar%0A%20"
+        },
+        {
+            "comment": "UNC path, share contains C0, trailing space [with trailing]",
+            "file_path": "\\\\my_pc\\foo \u0007\u0009bar\u000A \\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/foo%20%07%09bar%0A%20/dir"
+        },
+        {
+            "comment": "Namespaced UNC path, share contains C0, trailing space [no trailing]",
+            "file_path": "\\\\?\\UNC\\my_pc\\foo \u0007\u0009bar\u000A ",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/foo%20%07%09bar%0A%20"
+        },
+        {
+            "comment": "Namespaced UNC path, share contains C0, trailing space [with trailing]",
+            "file_path": "\\\\?\\UNC\\my_pc\\foo \u0007\u0009bar\u000A \\dir",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/foo%20%07%09bar%0A%20/dir"
+        },
+        {
+            "comment": "UNC path, path with C0, trailing space [no trailing]",
+            "file_path": "\\\\my_pc\\share.\\foo \\\u0007\u0009bar\u000A ",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share./foo%20/%07%09bar%0A"
+        },
+        {
+            "comment": "UNC path, path with C0, trailing space [with trailing]",
+            "file_path": "\\\\my_pc\\share.\\foo \\\u0007\u0009bar\u000A \\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share./foo%20/%07%09bar%0A%20/"
+        },
+        {
+            "comment": "Namespaced UNC path, path with C0, trailing space [no trailing]",
+            "file_path": "\\\\?\\UNC\\my_pc\\share.\\foo \\\u0007\u0009bar\u000A ",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share./foo%20/%07%09bar%0A%20"
+        },
+        {
+            "comment": "Namespaced UNC path, path with C0, trailing space [with trailing]",
+            "file_path": "\\\\?\\UNC\\my_pc\\share.\\foo \\\u0007\u0009bar\u000A \\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share./foo%20/%07%09bar%0A%20/"
+        },
+        {
+            "comment": "Path with percent-encoding [no drive, with leading]",
+            "file_path": "/foo/bar%23.txt",
+            "URL_posix": "file:///foo/bar%2523.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with percent-encoding [with drive, no leading]",
+            "file_path": "C:/foo/bar%23.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar%2523.txt"
+        },
+        {
+            "comment": "Namespaced path with percent-encoding",
+            "file_path": "\\\\?\\C:\\foo\\bar%23.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar%2523.txt"
+        },
+        {
+            "comment": "UNC path, share contains with percent-encoding",
+            "file_path": "\\\\mypc\\foo%23.\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/foo%2523./"
+        },
+        {
+            "comment": "Namespaced UNC path, share contains with percent-encoding",
+            "file_path": "\\\\?\\UNC\\mypc\\foo%23.\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/foo%2523./"
+        },
+        {
+            "comment": "UNC path, path with percent-encoding",
+            "file_path": "\\\\mypc\\foo.\\bar%23.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/foo./bar%2523.txt"
+        },
+        {
+            "comment": "Namespaced UNC path, path with percent-encoding",
+            "file_path": "\\\\?\\UNC\\mypc\\foo.\\bar%23.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/foo./bar%2523.txt"
+        },
+        {
+            "comment": "Path with percent-encoded slash [no drive, with leading]",
+            "file_path": "/foo/%2Fbar.txt",
+            "URL_posix": "file:///foo/%252Fbar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with percent-encoded slash [with drive, no leading]",
+            "file_path": "C:/foo/%2Fbar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/%252Fbar.txt"
+        },
+        {
+            "comment": "Namespaced path with percent-encoded slash",
+            "file_path": "\\\\?\\C:\\foo\\%2Fbar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/%252Fbar.txt"
+        },
+        {
+            "comment": "UNC path, share contains with percent-encoded slash",
+            "file_path": "\\\\mypc\\%2Ffoo.\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/%252Ffoo./"
+        },
+        {
+            "comment": "Namespaced UNC path, share contains with percent-encoded slash",
+            "file_path": "\\\\?\\UNC\\mypc\\%2Ffoo.\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/%252Ffoo./"
+        },
+        {
+            "comment": "UNC path, path with percent-encoded slash",
+            "file_path": "\\\\mypc\\foo.\\%2Fbar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/foo./%252Fbar.txt"
+        },
+        {
+            "comment": "Namespaced UNC path, path with percent-encoded slash",
+            "file_path": "\\\\?\\UNC\\mypc\\foo.\\%2Fbar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/foo./%252Fbar.txt"
+        },
+        {
+            "comment": "Path with percent-encoded backslash [no drive, with leading]",
+            "file_path": "/foo/%5Cbar.txt",
+            "URL_posix": "file:///foo/%255Cbar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with percent-encoded backslash [with drive, no leading]",
+            "file_path": "C:/foo/%5Cbar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/%255Cbar.txt"
+        },
+        {
+            "comment": "Namespaced path contains percent-encoded backslash",
+            "file_path": "\\\\?\\C:\\foo\\%5Cbar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/%255Cbar.txt"
+        },
+        {
+            "comment": "UNC path, share contains percent-encoded backslash",
+            "file_path": "\\\\mypc\\%5Cfoo.\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/%255Cfoo./"
+        },
+        {
+            "comment": "Namespaced UNC path, share contains percent-encoded backslash",
+            "file_path": "\\\\?\\UNC\\mypc\\%5Cfoo.\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/%255Cfoo./"
+        },
+        {
+            "comment": "UNC path, path contains percent-encoded backslash",
+            "file_path": "\\\\mypc\\foo.\\%5Cbar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/foo./%255Cbar.txt"
+        },
+        {
+            "comment": "Namespaced UNC path, path contains percent-encoded backslash",
+            "file_path": "\\\\?\\UNC\\mypc\\foo.\\%5Cbar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/foo./%255Cbar.txt"
+        },
+        {
+            "comment": "Path with unicode [no drive, with leading]",
+            "file_path": "/foo/\u2001/Lock 🔒/🦆.txt",
+            "URL_posix": "file:///foo/%E2%80%81/Lock%20%F0%9F%94%92/%F0%9F%A6%86.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with unicode [with drive, no leading]",
+            "file_path": "C:/foo/\u2001/Lock 🔒/🦆.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/%E2%80%81/Lock%20%F0%9F%94%92/%F0%9F%A6%86.txt"
+        },
+        {
+            "comment": "Namespaced path with unicode [with drive, no leading]",
+            "file_path": "\\\\?\\C:\\foo\\\u2001\\Lock 🔒\\🦆.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/%E2%80%81/Lock%20%F0%9F%94%92/%F0%9F%A6%86.txt"
+        },
+        {
+            "comment": "UNC path with unicode share name",
+            "file_path": "\\\\my_pc\\🦆\\pond.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/%F0%9F%A6%86/pond.txt"
+        },
+        {
+            "comment": "Namespaced UNC path with unicode share name",
+            "file_path": "\\\\?\\UNC\\my_pc\\🦆\\pond.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/%F0%9F%A6%86/pond.txt"
+        },
+        {
+            "comment": "UNC path with unicode in path section",
+            "file_path": "\\\\my_pc\\share.\\foo\\\u2001\\Lock 🔒\\🦆.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share./foo/%E2%80%81/Lock%20%F0%9F%94%92/%F0%9F%A6%86.txt"
+        },
+        {
+            "comment": "Namespaced UNC path with unicode in path section",
+            "file_path": "\\\\?\\UNC\\my_pc\\share.\\foo\\\u2001\\Lock 🔒\\🦆.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share./foo/%E2%80%81/Lock%20%F0%9F%94%92/%F0%9F%A6%86.txt"
+        },
+        {
+            "comment": "Path with leading NULL byte [no drive, with leading]",
+            "file_path": "\u0000/foo/bar.txt",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "Path with leading NULL byte [with drive, no leading]",
+            "file_path": "\u0000C:/foo/bar.txt",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "Path with NULL byte in the middle [no drive, with leading]",
+            "file_path": "/foo/\u0000/bar.txt",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "Path with NULL byte in the middle [with drive, no leading]",
+            "file_path": "C:/foo/\u0000/bar.txt",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "Path with trailing NULL byte [no drive, with leading]",
+            "file_path": "/foo/bar/\u0000",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "Path with trailing NULL byte [with drive, no leading]",
+            "file_path": "C:/foo/bar.txt\u0000",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "Namespaced path with leading NULL byte",
+            "file_path": "\u0000\\\\?\\C:\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "Namespaced path with NULL byte in the middle",
+            "file_path": "\\\\?\\C:\\foo\\\u0000\\bar.txt",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "Namespaced path with trailing NULL byte",
+            "file_path": "\\\\?\\C:\\foo\\bar.txt\u0000",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "UNC path with leading NULL byte",
+            "file_path": "\u0000\\\\my_pc\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "UNC path with NULL byte in hostname",
+            "file_path": "\\\\my\u0000pc\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "UNC path with NULL byte in share name",
+            "file_path": "\\\\my_pc\\foo\u0000bar\\baz.txt",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "UNC path with NULL byte in path section",
+            "file_path": "\\\\my_pc\\share.\\foo\\bar\u0000.txt",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "UNC path with trailing NULL byte",
+            "file_path": "\\\\my_pc\\foo\\bar.txt\u0000",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "Namespaced UNC path with leading NULL byte",
+            "file_path": "\u0000\\\\?\\UNC\\my_pc\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "Namespaced UNC path with NULL byte in hostname",
+            "file_path": "\\\\?\\UNC\\my\u0000pc\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "Namespaced UNC path with NULL byte in share name",
+            "file_path": "\\\\?\\UNC\\my_pc\\foo\u0000bar\\baz.txt",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "Namespaced UNC path with NULL byte in path section",
+            "file_path": "\\\\?\\UNC\\my_pc\\share.\\foo\\bar\u0000.txt",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "Namespaced UNC path with trailing NULL byte",
+            "file_path": "\\\\?\\UNC\\my_pc\\foo\\bar.txt\u0000",
+            "URL_posix": { "failure-reason": "null-byte" },
+            "URL_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "Path with drive letter elsewhere in the path [no drive, with leading]",
+            "file_path": "/foo/D:/bar.txt",
+            "URL_posix": "file:///foo/D%3A/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with URL-form drive letter elsewhere in the path [no drive, with leading]",
+            "file_path": "/foo/D|/bar.txt",
+            "URL_posix": "file:///foo/D%7C/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with drive letter elsewhere in the path [with drive, no leading]",
+            "file_path": "C:/foo/D:/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/D%3A/bar.txt"
+        },
+        {
+            "comment": "Path with URL-form drive letter elsewhere in the path [with drive, no leading]",
+            "file_path": "C:/foo/D|/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/D%7C/bar.txt"
+        },
+        {
+            "comment": "Path with drive letter (lowercase) elsewhere in the path [with drive, no leading]",
+            "file_path": "C:/foo/d:/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/d%3A/bar.txt"
+        },
+        {
+            "comment": "Path with URL-form drive letter (lowercase) elsewhere in the path [with drive, no leading]",
+            "file_path": "C:/foo/d|/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/d%7C/bar.txt"
+        },
+        {
+            "comment": "Namespaced path with drive letter elsewhere in the path",
+            "file_path": "\\\\?\\C:\\foo\\D:\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/D%3A/bar.txt"
+        },
+        {
+            "comment": "Namespaced path with URL-form drive letter elsewhere in the path",
+            "file_path": "\\\\?\\C:\\foo\\D|\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/D%7C/bar.txt"
+        },
+        {
+            "comment": "Namespaced path with drive letter (lowercase) elsewhere in the path",
+            "file_path": "\\\\?\\C:\\foo\\d:\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/d%3A/bar.txt"
+        },
+        {
+            "comment": "Namespaced path with URL-form drive letter (lowercase) elsewhere in the path",
+            "file_path": "\\\\?\\C:\\foo\\d|\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/d%7C/bar.txt"
+        },
+
+
+
+        { "__section__": "------------------------------ Paths containing single-dot components ------------------------------" },
+
+
+
+        {
+            "comment": "Path with leading '.' component [no drive, no leading]",
+            "file_path": "./foo/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with leading '.' component [no drive, with leading]. This is *not* a UNC path (as '//foo/bar...' would be).",
+            "file_path": "/./foo/bar.txt",
+            "URL_posix": "file:///foo/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with leading '.' component [with drive, no leading]",
+            "file_path": "./C:/foo/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with leading '.' component [with drive, with leading]",
+            "file_path": "/./C:/foo/bar.txt",
+            "URL_posix": "file:///C%3A/foo/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with leading '.' component [with drive(alt), with leading]",
+            "file_path": "/./C|/foo/bar.txt",
+            "URL_posix": "file:///C%7C/foo/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Namespaced path with leading '.' component",
+            "file_path": "\\\\?\\.\\C:\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Path with leading percent-encoded '.' component [no drive, no leading]",
+            "file_path": "%2E/foo/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with leading percent-encoded '.' component [with drive, with leading]",
+            "file_path": "/%2E/C:/foo/bar.txt",
+            "URL_posix": "file:///%252E/C%3A/foo/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Namespaced path with leading percent-encoded '.' component",
+            "file_path": "\\\\?\\%2E\\C:\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Path with many leading '.' components [no drive, no leading]",
+            "file_path": "././././foo/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with many leading '.' components [no drive, with leading]",
+            "file_path": "/././././foo/bar.txt",
+            "URL_posix": "file:///foo/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with many leading '.' components [with drive, no leading]",
+            "file_path": "././././C:/foo/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with many leading '.' components [with drive, with leading]",
+            "file_path": "/././././C:/foo/bar.txt",
+            "URL_posix": "file:///C%3A/foo/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with many leading '.' components [with drive(alt), with leading]",
+            "file_path": "/././././C|/foo/bar.txt",
+            "URL_posix": "file:///C%7C/foo/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Namespaced path with many leading '.' components",
+            "file_path": "\\\\?\\.\\.\\.\\.\\C:\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Path with '.' component in the middle [no drive, no leading]",
+            "file_path": "foo/./bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with '.' component in the middle [no drive, with leading]",
+            "file_path": "/foo/./bar.txt",
+            "URL_posix": "file:///foo/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with '.' component in the middle [with drive, no leading]",
+            "file_path": "C:/foo/./bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar.txt"
+        },
+        {
+            "comment": "Path with '.' component in the middle [with drive, with leading]",
+            "file_path": "/C:/foo/./bar.txt",
+            "URL_posix": "file:///C%3A/foo/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Namespaced path with '.' component in the middle",
+            "file_path": "\\\\?\\C:\\foo\\.\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar.txt"
+        },
+        {
+            "comment": "Path with percent-encoded '.' component in the middle [no drive, with leading]",
+            "file_path": "/foo/%2E/bar.txt",
+            "URL_posix": "file:///foo/%252E/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with percent-encoded '.' component in the middle [with drive, no leading]",
+            "file_path": "C:/foo/%2E/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/%252E/bar.txt"
+        },
+        {
+            "comment": "Namespaced path with percent-encoded '.' component in the middle",
+            "file_path": "\\\\?\\C:\\foo\\%2E\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/%252E/bar.txt"
+        },
+        {
+            "comment": "Path with trailing '.' component [no drive, no leading]",
+            "file_path": "foo/bar/.",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with trailing '.' component [no drive, with leading]",
+            "file_path": "/foo/bar/.",
+            "URL_posix": "file:///foo/bar/",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with trailing '.' component [with drive, no leading]",
+            "file_path": "C:/foo/bar/.",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar/"
+        },
+        {
+            "comment": "Path with trailing '.' component [with drive, with leading]",
+            "file_path": "/C:/foo/bar/.",
+            "URL_posix": "file:///C%3A/foo/bar/",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Namespaced path with trailing '.' component",
+            "file_path": "\\\\?\\C:\\foo\\bar\\.",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar/"
+        },
+        {
+            "comment": "Path with trailing percent-encoded '.' component [no drive, with leading]",
+            "file_path": "/foo/bar/%2E",
+            "URL_posix": "file:///foo/bar/%252E",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with trailing percent-encoded '.' component [with drive, no leading]",
+            "file_path": "C:/foo/bar/%2E",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar/%252E"
+        },
+        {
+            "comment": "Namespaced path with trailing percent-encoded '.' component",
+            "file_path": "\\\\?\\C:\\foo\\bar\\%2E",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar/%252E"
+        },
+        {
+            "comment": "UNC path with '.' component between share name and path",
+            "file_path": "\\\\mypc\\share\\.\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share/bar.txt"
+        },
+        {
+            "comment": "UNC path with '.' component between share name and path [forward slash]",
+            "file_path": "//mypc/share/./bar.txt",
+            "URL_posix": "file:////mypc/share/bar.txt",
+            "URL_windows": "file://mypc/share/bar.txt"
+        },
+        {
+            "comment": "UNC path with '.' component between share name and path [mixed separators]",
+            "file_path": "/\\mypc/share\\./bar.txt",
+            "URL_posix": "file:///%5Cmypc/share%5C./bar.txt",
+            "URL_windows": "file://mypc/share/bar.txt"
+        },
+        {
+            "comment": "Namespaced UNC path with '.' component between share name and path",
+            "file_path": "\\\\?\\UNC\\mypc\\share\\.\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share/bar.txt"
+        },
+        {
+            "comment": "UNC path with percent-encoded '.' component between share name and path",
+            "file_path": "\\\\mypc\\share\\%2E\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share/%252E/bar.txt"
+        },
+        {
+            "comment": "Namespaced UNC path with percent-encoded '.' component between share name and path",
+            "file_path": "\\\\?\\UNC\\mypc\\share\\%2E\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share/%252E/bar.txt"
+        },
+        {
+            "comment": "UNC path with single dot path",
+            "file_path": "\\\\mypc\\share\\.",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share/"
+        },
+        {
+            "comment": "UNC path with single dot path. [forward slash]",
+            "file_path": "//mypc/share/.",
+            "URL_posix": "file:////mypc/share/",
+            "URL_windows": "file://mypc/share/"
+        },
+        {
+            "comment": "UNC path with single dot path [percent-encoded]",
+            "file_path": "\\\\mypc\\share\\%2E",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share/%252E"
+        },
+        {
+            "comment": "Namespaced UNC path with single dot path",
+            "file_path": "\\\\?\\UNC\\mypc\\share\\.",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share/"
+        },
+
+
+
+        { "__section__": "------------------------------ Paths containing double-dot components ------------------------------" },
+
+
+
+        {
+            "comment": "Path with leading '..' component [no drive, no leading]",
+            "file_path": "../foo/bar.txt",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "Path with leading '..' component [no drive, with leading]",
+            "file_path": "/../foo/bar.txt",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with leading '..' component [with drive, no leading]",
+            "file_path": "../C:/foo/bar.txt",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "Path with leading '..' component [with drive, with leading]",
+            "file_path": "/../C:/foo/bar.txt",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Namespaced path with leading '..' component",
+            "file_path": "\\\\?\\..\\C:\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Path with leading percent-encoded '..' component [no drive, no leading]",
+            "file_path": "%2E%2E/foo/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with leading percent-encoded '..' component [with drive, with leading]",
+            "file_path": "/%2E%2E/C:/foo/bar.txt",
+            "URL_posix": "file:///%252E%252E/C%3A/foo/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with '..' component in the middle [no drive, no leading]",
+            "file_path": "foo/../bar.txt",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "Path with '..' component in the middle [no drive, with leading]",
+            "file_path": "/foo/../bar.txt",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with '..' component in the middle [with drive, no leading]",
+            "file_path": "C:/foo/../bar.txt",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "Path with '..' component in the middle [with drive, with leading]",
+            "file_path": "/C:/foo/../bar.txt",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Namespaced path with '..' component in the middle",
+            "file_path": "\\\\?\\C:\\foo\\..\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "Namespaced path with '..' component in the middle [forward slash]",
+            "file_path": "\\\\?\\C:\\foo/..\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Path with percent-encoded '..' component in the middle [no drive, with leading]",
+            "file_path": "/foo/%2E%2E/bar.txt",
+            "URL_posix": "file:///foo/%252E%252E/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with percent-encoded '..' component in the middle [with drive, no leading]",
+            "file_path": "C:/foo/%2E%2E/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/%252E%252E/bar.txt"
+        },
+        {
+            "comment": "Namespaced path with percent-encoded '..' component in the middle",
+            "file_path": "\\\\?\\C:\\foo\\%2E%2E\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/%252E%252E/bar.txt"
+        },
+        {
+            "comment": "Namespaced path with percent-encoded '..' component in the middle [forward slash]",
+            "file_path": "\\\\?\\C:\\foo/%2E%2E\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Path with trailing '..' component [no drive, no leading]",
+            "file_path": "foo/bar/..",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "Path with trailing '..' component [no drive, with leading]",
+            "file_path": "/foo/bar/..",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with trailing '..' component [with drive, no leading]",
+            "file_path": "C:/foo/bar/..",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "Path with trailing '..' component [with drive, with leading]",
+            "file_path": "/C:/foo/bar/..",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Namespaced path with trailing '..' component",
+            "file_path": "\\\\?\\C:\\foo\\bar\\..",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "Namespaced path with trailing '..' component [forward slash]",
+            "file_path": "\\\\?\\C:\\foo\\bar/..",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Path with trailing percent-encoded '..' component [no drive, with leading]",
+            "file_path": "/foo/bar/%2E%2E",
+            "URL_posix": "file:///foo/bar/%252E%252E",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with trailing percent-encoded '..' component [with drive, no leading]",
+            "file_path": "C:/foo/bar/%2E%2E",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar/%252E%252E"
+        },
+        {
+            "comment": "Namespaced path with trailing percent-encoded '..' component",
+            "file_path": "\\\\?\\C:\\foo\\bar\\%2E%2E",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar/%252E%252E"
+        },
+        {
+            "comment": "Path with '..' component delimited by leading backslash. Is not considered a full component on POSIX [no drive, with leading]",
+            "file_path": "/foo\\../bar",
+            "URL_posix": "file:///foo%5C../bar",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with '..' component delimited by leading backslash. Is not considered a full component on POSIX [with drive, no leading]",
+            "file_path": "C:/foo\\../bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "Path with '..' component delimited by trailing backslash. Is not considered a full component on POSIX [no drive, with leading]",
+            "file_path": "/foo/..\\bar",
+            "URL_posix": "file:///foo/..%5Cbar",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with '..' component delimited by trailing backslash. Is not considered a full component on POSIX [with drive, no leading]",
+            "file_path": "C:/foo/..\\bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "UNC path with '..' component between share name and path",
+            "file_path": "\\\\mypc\\share\\..\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "UNC path with '..' component between share name and path [forward slash]",
+            "file_path": "//mypc/share/../bar.txt",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "UNC path with '..' component between share name and path [mixed separators]",
+            "file_path": "/\\mypc/share\\../bar.txt",
+            "URL_posix": "file:///%5Cmypc/share%5C../bar.txt",
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "Namespaced UNC path with '..' component between share name and path",
+            "file_path": "\\\\?\\UNC\\mypc\\share\\..\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "Namespaced UNC path with '..' component between share name and path [mixed separators]",
+            "file_path": "\\\\?\\UNC\\mypc/share\\../bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "UNC path with percent-encoded '..' component between share name and path",
+            "file_path": "\\\\mypc\\share\\%2E%2E\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share/%252E%252E/bar.txt"
+        },
+        {
+            "comment": "Namespaced UNC path with percent-encoded '..' component between share name and path",
+            "file_path": "\\\\?\\UNC\\mypc\\share\\%2E%2E\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share/%252E%252E/bar.txt"
+        },
+        {
+            "comment": "UNC path with trailing '..' component",
+            "file_path": "\\\\mypc\\foo/bar/..",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "Namespaced UNC path with trailing '..' component",
+            "file_path": "\\\\?\\UNC\\mypc\\foo\\bar\\..",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "Namespaced UNC path with trailing '..' component [forward slash]",
+            "file_path": "\\\\?\\UNC\\mypc\\foo\\bar/..",
+            "URL_posix": { "failure-reason": "upwards-traversal" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+
+
+
+        { "__section__": "------------------------------ Paths containing triple-dot components ------------------------------" },
+
+
+
+        {
+            "comment": "Path with leading '...' component [no drive, no leading]",
+            "file_path": ".../foo/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with leading '...' component [no drive, with leading]",
+            "file_path": "/.../foo/bar.txt",
+            "URL_posix": "file:///.../foo/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with leading '...' component [with drive, no leading]",
+            "file_path": ".../C:/foo/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with leading '...' component [with drive, with leading]",
+            "file_path": "/.../C:/foo/bar.txt",
+            "URL_posix": "file:///.../C%3A/foo/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Namespaced path with leading '...' component",
+            "file_path": "\\\\?\\...\\C:\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Path with '...' component in the middle [no drive, no leading]",
+            "file_path": "foo/.../bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with '...' component in the middle [no drive, with leading]",
+            "file_path": "/foo/.../bar.txt",
+            "URL_posix": "file:///foo/.../bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with '...' component in the middle [with drive, no leading]",
+            "file_path": "C:/foo/.../bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/.../bar.txt"
+        },
+        {
+            "comment": "Path with '..' component in the middle [with drive, with leading]",
+            "file_path": "/C:/foo/.../bar.txt",
+            "URL_posix": "file:///C%3A/foo/.../bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Namespaced path with '...' component in the middle",
+            "file_path": "\\\\?\\C:\\foo\\...\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/.../bar.txt"
+        },
+        {
+            "comment": "Path with trailing '...' component [no drive, no leading]",
+            "file_path": "foo/bar/...",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with trailing '...' component [no drive, with leading]",
+            "file_path": "/foo/bar/...",
+            "URL_posix": "file:///foo/bar/...",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with trailing '...' component [with drive, no leading]",
+            "file_path": "C:/foo/bar/...",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar/"
+        },
+        {
+            "comment": "Path with trailing '...' component [with drive, with leading]",
+            "file_path": "/C:/foo/bar/...",
+            "URL_posix": "file:///C%3A/foo/bar/...",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Namespaced path with trailing '...' component",
+            "file_path": "\\\\?\\C:\\foo\\bar\\...",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar/..."
+        },
+        {
+            "comment": "UNC path with '...' component between share name and path",
+            "file_path": "\\\\mypc\\share\\...\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share/.../bar.txt"
+        },
+        {
+            "comment": "UNC path with '...' component between share name and path [forward slash]",
+            "file_path": "//mypc/share/.../bar.txt",
+            "URL_posix": "file:////mypc/share/.../bar.txt",
+            "URL_windows": "file://mypc/share/.../bar.txt"
+        },
+        {
+            "comment": "UNC path with '...' component between share name and path [mixed separators]",
+            "file_path": "/\\mypc/share\\.../bar.txt",
+            "URL_posix": "file:///%5Cmypc/share%5C.../bar.txt",
+            "URL_windows": "file://mypc/share/.../bar.txt"
+        },
+        {
+            "comment": "Namespaced UNC path with '...' component between share name and path",
+            "file_path": "\\\\?\\UNC\\mypc\\share\\...\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share/.../bar.txt"
+        },
+        {
+            "comment": "UNC path with trailing '...' component",
+            "file_path": "\\\\mypc\\foo/bar/...",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/foo/bar/"
+        },
+        {
+            "comment": "Namespaced UNC path with trailing '...' component",
+            "file_path": "\\\\?\\UNC\\mypc\\foo\\bar\\...",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/foo/bar/..."
+        },
+
+
+
+        { "__section__": "------------------------------ Windows path normalization (trimming) ------------------------------" },
+
+
+
+        {
+            "comment": "Path components with trailing dots and spaces [no drive, no trailing]",
+            "file_path": "/foo/bar. /bar2 ./baz./qux../qux2.. /.../file.txt.. ",
+            "URL_posix": "file:///foo/bar.%20/bar2%20./baz./qux../qux2..%20/.../file.txt..%20",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path components with trailing dots and spaces [with drive, no trailing]",
+            "file_path": "C:/foo/bar. /bar2 ./baz./qux../qux2.. /.../file.txt.. ",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar.%20/bar2%20/baz/qux../qux2..%20/.../file.txt"
+        },
+        {
+            "comment": "Namespaced path components with trailing dots and spaces [no trailing]",
+            "file_path": "\\\\?\\C:\\foo\\bar. \\bar2 .\\baz.\\qux..\\qux2.. \\...\\file.txt.. ",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar.%20/bar2%20./baz./qux../qux2..%20/.../file.txt..%20"
+        },
+        {
+            "comment": "Path components with trailing dots and spaces [no drive, with trailing]",
+            "file_path": "/foo/bar. /bar2 ./baz./qux../qux2.. /.../file.txt.. /",
+            "URL_posix": "file:///foo/bar.%20/bar2%20./baz./qux../qux2..%20/.../file.txt..%20/",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path components with trailing dots and spaces [with drive, with trailing]",
+            "file_path": "C:/foo/bar. /bar2 ./baz./qux../qux2.. /.../file.txt.. /",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar.%20/bar2%20/baz/qux../qux2..%20/.../file.txt..%20/"
+        },
+        {
+            "comment": "Namespaced path components with trailing dots and spaces [with trailing]",
+            "file_path": "\\\\?\\C:\\foo\\bar. \\bar2 .\\baz.\\qux..\\qux2.. \\...\\file.txt.. \\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/bar.%20/bar2%20./baz./qux../qux2..%20/.../file.txt..%20/"
+        },
+        {
+            "comment": "Path where final component is only dots and spaces [no drive, no trailing]",
+            "file_path": "/foo/. . . . .",
+            "URL_posix": "file:///foo/.%20.%20.%20.%20.",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path where final component is only dots and spaces [with drive, no trailing]. The Windows API 'GetFullPathName' trims it all away.",
+            "file_path": "C:/foo/. . . . .",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/"
+        },
+        {
+            "comment": "Namespaced Path where final component is only dots and spaces [no trailing]",
+            "file_path": "\\\\?\\C:\\foo\\. . . . .",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/.%20.%20.%20.%20."
+        },
+        {
+            "comment": "Path where final component is only dots and spaces [no drive, with trailing]",
+            "file_path": "/foo/. . . . ./",
+            "URL_posix": "file:///foo/.%20.%20.%20.%20./",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path where final component is only dots and spaces [with drive, with trailing]",
+            "file_path": "C:/foo/. . . . ./",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/.%20.%20.%20.%20/"
+        },
+        {
+            "comment": "Namespaced Path where final component is only dots and spaces [with trailing]",
+            "file_path": "\\\\?\\C:\\foo\\. . . . .\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/foo/.%20.%20.%20.%20./"
+        },
+        {
+            "comment": "UNC path with trailing dot in share name (should not be trimmed)",
+            "file_path": "\\\\vboxsvr\\WebURL.\\Parser.\\Parser.swift..",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://vboxsvr/WebURL./Parser/Parser.swift"
+        },
+        {
+            "comment": "UNC path with trailing dot in share name (should not be trimmed)[forward slash]",
+            "file_path": "\\\\vboxsvr/WebURL./Parser.\\Parser.swift..",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://vboxsvr/WebURL./Parser/Parser.swift"
+        },
+        {
+            "comment": "Namespaced UNC path with trailing dot in share name",
+            "file_path": "\\\\?\\UNC\\vboxsvr\\WebURL.\\Parser.\\Parser.swift..",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://vboxsvr/WebURL./Parser./Parser.swift.."
+        },
+        {
+            "comment": "UNC path with trailing space in share name (should not be trimmed)",
+            "file_path": "\\\\vboxsvr\\WebURL \\Parser.\\Parser.swift..",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://vboxsvr/WebURL%20/Parser/Parser.swift"
+        },
+        {
+            "comment": "UNC path with trailing dot in share name (should not be trimmed)[forward slash]",
+            "file_path": "\\\\vboxsvr/WebURL /Parser.\\Parser.swift..",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://vboxsvr/WebURL%20/Parser/Parser.swift"
+        },
+        {
+            "comment": "Namespaced UNC path with trailing space in share name",
+            "file_path": "\\\\?\\UNC\\vboxsvr\\WebURL \\Parser.\\Parser.swift..",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://vboxsvr/WebURL%20/Parser./Parser.swift.."
+        },
+        {
+            "comment": "UNC path whose share name is only dots and spaces (should not be trimmed)",
+            "file_path": "\\\\vboxsvr\\. . . .\\Parser.\\Parser.swift..",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://vboxsvr/.%20.%20.%20./Parser/Parser.swift"
+        },
+        {
+            "comment": "Namespaced UNC path whose share name is only dots and spaces",
+            "file_path": "\\\\?\\UNC\\vboxsvr\\. . . .\\Parser.\\Parser.swift..",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://vboxsvr/.%20.%20.%20./Parser./Parser.swift.."
+        },
+        {
+            "comment": "UNC path whose share name is only dots and spaces (should not be trimmed)[no trailing]",
+            "file_path": "\\\\vboxsvr/. . . .",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://vboxsvr/.%20.%20.%20."
+        },
+        {
+            "comment": "Namespaced UNC path whose share name is only dots and spaces [no trailing]",
+            "file_path": "\\\\?\\UNC\\vboxsvr\\. . . .",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://vboxsvr/.%20.%20.%20."
+        },
+        {
+            "comment": "UNC Path, path components with trailing dots and spaces [no trailing]",
+            "file_path": "\\\\my_pc\\share.\\foo\\bar. \\bar2 .\\baz.\\qux..\\qux2.. \\...\\file.txt.. ",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share./foo/bar.%20/bar2%20/baz/qux../qux2..%20/.../file.txt"
+        },
+        {
+            "comment": "Namespaced UNC Path, path components with trailing dots and spaces [no trailing]",
+            "file_path": "\\\\?\\UNC\\my_pc\\share.\\foo\\bar. \\bar2 .\\baz.\\qux..\\qux2.. \\...\\file.txt.. ",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share./foo/bar.%20/bar2%20./baz./qux../qux2..%20/.../file.txt..%20"
+        },
+        {
+            "comment": "UNC Path, path components with trailing dots and spaces [with trailing]",
+            "file_path": "\\\\my_pc\\share.\\foo\\bar. \\bar2 .\\baz.\\qux..\\qux2.. \\...\\file.txt.. \\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share./foo/bar.%20/bar2%20/baz/qux../qux2..%20/.../file.txt..%20/"
+        },
+        {
+            "comment": "Namespaced UNC Path, path components with trailing dots and spaces [with trailing]",
+            "file_path": "\\\\?\\UNC\\my_pc\\share.\\foo\\bar. \\bar2 .\\baz.\\qux..\\qux2.. \\...\\file.txt.. \\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share./foo/bar.%20/bar2%20./baz./qux../qux2..%20/.../file.txt..%20/"
+        },
+        {
+            "comment": "UNC path whose final (non share) path component is only dots and spaces [no trailing]",
+            "file_path": "\\\\vboxsvr\\share.\\. . . .",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://vboxsvr/share./"
+        },
+        {
+            "comment": "Namespaced UNC path whose final (non share) path component is only dots and spaces [no trailing]",
+            "file_path": "\\\\?\\UNC\\vboxsvr\\share.\\. . . .",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://vboxsvr/share./.%20.%20.%20."
+        },
+        {
+            "comment": "UNC path whose final (non share) path component is only dots and spaces [with trailing]",
+            "file_path": "\\\\vboxsvr\\share.\\. . . .\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://vboxsvr/share./.%20.%20.%20/"
+        },
+        {
+            "comment": "Namespaced UNC path whose final (non share) path component is only dots and spaces [with trailing]",
+            "file_path": "\\\\?\\UNC\\vboxsvr\\share.\\. . . .\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://vboxsvr/share./.%20.%20.%20./"
+        },
+
+
+
+        { "__section__": "------------------------------ Path normalization: leading separators ------------------------------" },
+
+
+
+        {
+            "comment": "Path with 2 leading slashes. Posix: should not be trimmed. Windows: UNC.",
+            "file_path": "//foo/bAr/BaZ/qux.txt",
+            "URL_posix": "file:////foo/bAr/BaZ/qux.txt",
+            "URL_windows": "file://foo/bAr/BaZ/qux.txt"
+        },
+        {
+            "comment": "Path with 2 leading backslashes. Posix: relative path. Windows: UNC.",
+            "file_path": "\\\\foo/bAr/BaZ\\qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://foo/bAr/BaZ/qux.txt"
+        },
+        {
+            "comment": "Path with 2 leading slashes. Mixed separators. Posix: percent-encoded. Windows: UNC.",
+            "file_path": "/\\foo\\bAr/BaZ\\qux.txt",
+            "URL_posix": "file:///%5Cfoo%5CbAr/BaZ%5Cqux.txt",
+            "URL_windows": "file://foo/bAr/BaZ/qux.txt"
+        },
+        {
+            "comment": "Path with 3 leading slashes. Posix: should be trimmed. Windows: UNC. Some Windows APIs treat this as an empty hostname, but we trim them.",
+            "file_path": "///foo/bAr/BaZ/qux.txt",
+            "URL_posix": "file:///foo/bAr/BaZ/qux.txt",
+            "URL_windows": "file://foo/bAr/BaZ/qux.txt"
+        },
+        {
+            "comment": "Path with 3 leading backslashes. Posix: relative path. Windows: UNC. Some Windows APIs treat this as an empty hostname, but we trim them.",
+            "file_path": "\\\\\\foo/bAr/BaZ/qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://foo/bAr/BaZ/qux.txt"
+        },
+        {
+            "comment": "Path with 3 leading slashes. Mixed separators. Posix: percent-encoded. Windows: UNC. Some Windows APIs treat this as an empty hostname, but we trim them.",
+            "file_path": "/\\\\foo/bAr/BaZ/qux.txt",
+            "URL_posix": "file:///%5C%5Cfoo/bAr/BaZ/qux.txt",
+            "URL_windows": "file://foo/bAr/BaZ/qux.txt"
+        },
+        {
+            "comment": "Path with 4 leading slashes. Posix: should be trimmed. Windows: UNC.",
+            "file_path": "////foo/bAr/BaZ/qux.txt",
+            "URL_posix": "file:///foo/bAr/BaZ/qux.txt",
+            "URL_windows": "file://foo/bAr/BaZ/qux.txt"
+        },
+        {
+            "comment": "Path with 4 leading backslashes. Posix: relative path. Windows: UNC.",
+            "file_path": "\\\\\\\\foo/bAr/BaZ/qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://foo/bAr/BaZ/qux.txt"
+        },
+        {
+            "comment": "Path with 4 leading slashes. Mixed separators. Posix: percent-encoded. Windows: UNC.",
+            "file_path": "///\\foo/bAr/BaZ/qux.txt",
+            "URL_posix": "file:///%5Cfoo/bAr/BaZ/qux.txt",
+            "URL_windows": "file://foo/bAr/BaZ/qux.txt"
+        },
+        {
+            "comment": "Path with 5 leading slashes. Posix: should be normalized to a single slash. Windows: UNC.",
+            "file_path": "/////foo/bAr/BaZ/qux.txt",
+            "URL_posix": "file:///foo/bAr/BaZ/qux.txt",
+            "URL_windows": "file://foo/bAr/BaZ/qux.txt"
+        },
+        {
+            "comment": "Path with 5 leading backslashes. Posix: relative path. Windows: UNC.",
+            "file_path": "\\\\\\\\\\foo/bAr/BaZ/qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://foo/bAr/BaZ/qux.txt"
+        },
+        {
+            "comment": "Namespaced path with 2 leading slashes",
+            "file_path": "\\\\?\\\\C:\\bAr\\BaZ\\qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced path with 2 leading slashes. Mixed separators.",
+            "file_path": "\\\\?\\/C:\\bAr\\BaZ\\qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced UNC path with 2 leading slashes",
+            "file_path": "\\\\?\\UNC\\\\C:\\bAr\\BaZ\\qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced path with 3 leading slashes",
+            "file_path": "\\\\?\\\\\\C:\\bAr\\BaZ\\qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced path with 3 leading slashes. Mixed separators.",
+            "file_path": "\\\\?\\/\\C:\\bAr\\BaZ\\qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced UNC path with 3 leading slashes",
+            "file_path": "\\\\?\\UNC\\\\\\C:\\bAr\\BaZ\\qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced path with 4 leading slashes",
+            "file_path": "\\\\?\\\\\\\\C:\\bAr\\BaZ\\qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced path with 4 leading slashes. Mixed separators.",
+            "file_path": "\\\\?\\/\\/C:\\bAr\\BaZ\\qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced UNC path with 4 leading slashes",
+            "file_path": "\\\\?\\UNC\\\\\\\\C:\\bAr\\BaZ\\qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Namespaced path with 5 leading slashes",
+            "file_path": "\\\\?\\\\\\\\\\C:\\bAr\\BaZ\\qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced path with 5 leading slashes. Mixed separators.",
+            "file_path": "\\\\?\\/\\/\\C:\\bAr\\BaZ\\qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Namespaced UNC path with 5 leading slashes",
+            "file_path": "\\\\?\\UNC\\\\\\\\\\C:\\bAr\\BaZ\\qux.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "UNC path, share root, extra slashes before share",
+            "file_path": "\\\\my_pc\\\\\\\\share.",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share."
+        },
+        {
+            "comment": "UNC path, share root, extra slashes before share [forward slash]",
+            "file_path": "//my_pc//////share.",
+            "URL_posix": "file:////my_pc/share.",
+            "URL_windows": "file://my_pc/share."
+        },
+        {
+            "comment": "UNC path, share root, extra slashes before share [mixed separators]",
+            "file_path": "/\\my_pc/\\/\\/\\share.",
+            "URL_posix": "file:///%5Cmy_pc/%5C/%5C/%5Cshare.",
+            "URL_windows": "file://my_pc/share."
+        },
+        {
+            "comment": "Namespaced UNC path, share root, extra slashes before share",
+            "file_path": "\\\\?\\UNC\\my_pc\\\\\\\\share.",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share."
+        },
+        {
+            "comment": "Namespaced UNC path, share root, extra slashes before share [mixed separators]",
+            "file_path": "\\\\?\\UNC\\my_pc/\\/\\/\\share.",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "UNC path, extra slashes before share",
+            "file_path": "\\\\my_pc\\\\\\\\share.\\dir.\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share./dir/"
+        },
+        {
+            "comment": "UNC path, extra slashes before share [forward slash]",
+            "file_path": "//my_pc//////share./dir./",
+            "URL_posix": "file:////my_pc/share./dir./",
+            "URL_windows": "file://my_pc/share./dir/"
+        },
+        {
+            "comment": "UNC path, extra slashes before share [mixed separators]",
+            "file_path": "/\\my_pc/\\/\\/\\share./dir./",
+            "URL_posix": "file:///%5Cmy_pc/%5C/%5C/%5Cshare./dir./",
+            "URL_windows": "file://my_pc/share./dir/"
+        },
+        {
+            "comment": "Namespaced UNC path, extra slashes before share",
+            "file_path": "\\\\?\\UNC\\my_pc\\\\\\\\share.\\dir.\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://my_pc/share./dir./"
+        },
+        {
+            "comment": "Namespaced UNC path, extra slashes before share [mixed separators]",
+            "file_path": "\\\\?\\UNC\\my_pc/\\/\\share.\\dir.\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "UNC path with extra slashes between share/path",
+            "file_path": "\\\\mypc\\share.\\\\\\\\dir.\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share./dir/"
+        },
+        {
+            "comment": "UNC path with extra slashes between share/path [forward slash]",
+            "file_path": "//mypc/share.////dir./",
+            "URL_posix": "file:////mypc/share./dir./",
+            "URL_windows": "file://mypc/share./dir/"
+        },
+        {
+            "comment": "UNC path with extra slashes between share/path [mixed separators]",
+            "file_path": "/\\mypc/share.\\/\\/dir.\\",
+            "URL_posix": "file:///%5Cmypc/share.%5C/%5C/dir.%5C",
+            "URL_windows": "file://mypc/share./dir/"
+        },
+        {
+            "comment": "Namespaced UNC path with extra slashes between share/path",
+            "file_path": "\\\\?\\UNC\\mypc\\share.\\\\\\\\dir.\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share./dir./"
+        },
+        {
+            "comment": "Namespaced UNC path with extra slashes between share/path [mixed separators]",
+            "file_path": "\\\\?\\UNC\\mypc\\share./\\/\\dir.\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+
+
+
+        { "__section__": "------------------------------ Path normalization: more collapsing separators ------------------------------" },
+
+
+
+        {
+            "comment": "Path with extra slashes after drive",
+            "file_path": "D:\\\\\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///D:/foo/bar.txt"
+        },
+        {
+            "comment": "Path with extra slashes after drive [forward slash]",
+            "file_path": "D:///foo/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///D:/foo/bar.txt"
+        },
+        {
+            "comment": "Namespaced path with extra slashes after drive",
+            "file_path": "\\\\?\\D:\\\\\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///D:/foo/bar.txt"
+        },
+        {
+            "comment": "Namespaced path with extra slashes after drive [forward slash]",
+            "file_path": "\\\\?\\D:///foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Path with extra slashes in the middle [no drive, no leading]",
+            "file_path": "abc////foo/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with extra slashes in the middle [no drive, with leading]",
+            "file_path": "/abc////foo/bar.txt",
+            "URL_posix": "file:///abc/foo/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with extra slashes in the middle [with drive, no leading]",
+            "file_path": "C:/abc////foo/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/abc/foo/bar.txt"
+        },
+        {
+            "comment": "Path with extra slashes in the middle [with drive, with leading]",
+            "file_path": "/C:/abc////foo/bar.txt",
+            "URL_posix": "file:///C%3A/abc/foo/bar.txt",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with extra slashes in the middle [with drive, no leading][mixed separators]",
+            "file_path": "C:\\abc/\\/\\foo/bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/abc/foo/bar.txt"
+        },
+        {
+            "comment": "Namespaced path with extra slashes in the middle [with drive, no leading]",
+            "file_path": "\\\\?\\C:\\abc\\\\\\\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/abc/foo/bar.txt"
+        },
+        {
+            "comment": "Namespaced path with extra slashes in the middle [with drive, no leading][mixed separators]",
+            "file_path": "\\\\?\\C:\\abc/\\/\\foo\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "UNC path with extra slashes in the middle, in path section",
+            "file_path": "\\\\mypc\\share.\\foo.\\\\\\\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share./foo/bar.txt"
+        },
+        {
+            "comment": "UNC path with extra slashes in the middle, in path section [forward slash]",
+            "file_path": "//mypc/share./foo.////bar.txt",
+            "URL_posix": "file:////mypc/share./foo./bar.txt",
+            "URL_windows": "file://mypc/share./foo/bar.txt"
+        },
+        {
+            "comment": "UNC path with extra slashes in the middle, in path section [mixed separators]",
+            "file_path": "/\\mypc/share.\\foo./\\/\\bar.txt",
+            "URL_posix": "file:///%5Cmypc/share.%5Cfoo./%5C/%5Cbar.txt",
+            "URL_windows": "file://mypc/share./foo/bar.txt"
+        },
+        {
+            "comment": "Namespaced UNC path with extra slashes in the middle, in path section",
+            "file_path": "\\\\?\\UNC\\mypc\\share.\\foo.\\\\\\\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share./foo./bar.txt"
+        },
+        {
+            "comment": "Namespaced UNC path with extra slashes in the middle, in path section [mixed separators]",
+            "file_path": "\\\\?\\UNC\\mypc\\share.\\foo./\\/\\bar.txt",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Path with extra trailing slashes [no drive, no leading]",
+            "file_path": "abc/foo/bar///",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with extra trailing slashes [no drive, with leading]",
+            "file_path": "/abc/foo/bar///",
+            "URL_posix": "file:///abc/foo/bar/",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with extra trailing slashes [with drive, no leading]",
+            "file_path": "C:/abc/foo/bar///",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/abc/foo/bar/"
+        },
+        {
+            "comment": "Path with extra trailing slashes [with drive, with leading]",
+            "file_path": "/C:/abc/foo/bar///",
+            "URL_posix": "file:///C%3A/abc/foo/bar/",
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Path with extra trailing slashes [with drive, no leading][mixed separators]",
+            "file_path": "C:\\abc/foo\\bar/\\/\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/abc/foo/bar/"
+        },
+        {
+            "comment": "Namespaced path with extra trailing slashes",
+            "file_path": "\\\\?\\C:\\abc\\foo\\bar\\\\\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file:///C:/abc/foo/bar/"
+        },
+        {
+            "comment": "Namespaced path with extra trailing slashes [mixed separators]",
+            "file_path": "\\\\?\\C:\\abc\\foo\\bar/\\/",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "UNC path with extra trailing slashes in path section",
+            "file_path": "\\\\mypc\\share.\\dir.\\\\\\\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share./dir/"
+        },
+        {
+            "comment": "UNC path with extra trailing slashes in path section [forward slash]",
+            "file_path": "//mypc/share./dir.////",
+            "URL_posix": "file:////mypc/share./dir./",
+            "URL_windows": "file://mypc/share./dir/"
+        },
+        {
+            "comment": "UNC path with extra trailing slashes in path section [mixed separators]",
+            "file_path": "/\\mypc/share.\\dir./\\/\\",
+            "URL_posix": "file:///%5Cmypc/share.%5Cdir./%5C/%5C",
+            "URL_windows": "file://mypc/share./dir/"
+        },
+        {
+            "comment": "Namespaced UNC path with extra trailing slashes in path section",
+            "file_path": "\\\\?\\UNC\\mypc\\share.\\dir.\\\\\\\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": "file://mypc/share./dir./"
+        },
+        {
+            "comment": "Namespaced UNC path with extra trailing slashes in path section [mixed separators]",
+            "file_path": "\\\\?\\UNC\\mypc\\share.\\dir./\\/\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+
+
+
+        { "__section__": "------------------------------ Special Windows Paths ------------------------------" },
+
+
+        {
+            "comment": "Windows drive-relative path",
+            "file_path": "C:foo\\bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "Windows drive-relative path with '..' component",
+            "file_path": "C:foo\\../bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "upwards-traversal" }
+        },
+        {
+            "comment": "Windows drive-relative path in Win32 file path format",
+            "file_path": "\\\\?\\C:foo\\bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Windows drive-relative path in Win32 file path format (lowercase)",
+            "file_path": "\\\\?\\c:foo\\bar",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Win32 non-drive file path.",
+            "file_path": "\\\\?\\HarddiskVolume2\\Users\\Alice\\Desktop\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Win32 non-drive file path (2).",
+            "file_path": "\\\\?\\BootPartition\\Users\\Alice\\Desktop\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Win32 non-drive file path (3).",
+            "file_path": "\\\\?\\Volume{26a21bda-a627-11d7-9931-806e6f6e6963}\\Users\\Alice\\Desktop\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "unsupported-namespaced-path" }
+        },
+        {
+            "comment": "Win32 device path",
+            "file_path": "\\\\.\\COM1",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Win32 device path (2)",
+            "file_path": "\\\\.\\UNC\\VBOXSVR\\WebURL\\",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Win32 device path (Drive letter)",
+            "file_path": "\\\\.\\C:\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Win32 device path (Drive letter, lowercase)",
+            "file_path": "\\\\.\\c:\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Win32 device path (Drive letter, alt)",
+            "file_path": "\\\\.\\C|\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Win32 device path (BootPartition).",
+            "file_path": "\\\\.\\BootPartition\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+        {
+            "comment": "Win32 device path (Volume GUID).",
+            "file_path": "\\\\.\\Volume{b289d78f-d491-4f6b-a437-5c51a88fa48f}\\Windows\\System32\\notepad.exe",
+            "URL_posix": { "failure-reason": "relative-path" },
+            "URL_windows": { "failure-reason": "invalid-hostname" }
+        },
+
+
+
+        { "__section__": "------------------------------ The End ------------------------------" }
+    ],
+
+    "url_to_file_path": [
+
+        { "__section__": "------------------------------ Non-file URLs ------------------------------" },
+
+
+
+        {
+            "comment": "Non-file URL, special scheme.",
+            "URL": "http://example.com/foo/bar/",
+            "file_path_posix": { "failure-reason": "not-a-file-url" },
+            "file_path_windows": { "failure-reason": "not-a-file-url" }
+        },
+        {
+            "comment": "Non-file URL, non-special scheme.",
+            "URL": "foo://example.com/foo/bar/",
+            "file_path_posix": { "failure-reason": "not-a-file-url" },
+            "file_path_windows": { "failure-reason": "not-a-file-url" }
+        },
+
+
+
+        { "__section__": "------------------------------ Hostnames ------------------------------" },
+
+
+
+        {
+            "comment": "URL with hostname.",
+            "URL": "file://mypc/foo/bar",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\foo\\bar"
+        },
+        {
+            "comment": "URL with domain.",
+            "URL": "file://mypc.example.com/foo/bar",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc.example.com\\foo\\bar"
+        },
+        {
+            "comment": "URL with domain, trailing '.'.",
+            "URL": "file://mypc.example.com./foo/bar",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc.example.com.\\foo\\bar"
+        },
+        {
+            "comment": "URL with '.' hostname (UNC). Should *not* become a local device path.",
+            "URL": "file://./UNC/VBOXSVR/WebURL/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "unsupported-hostname" }
+        },
+        {
+            "comment": "URL with '.' hostname (Drive).",
+            "URL": "file://./C:/foo/BAR/baZ/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "unsupported-hostname"  }
+        },
+        {
+            "comment": "URL with '.' hostname (BootPartition).",
+            "URL": "file://./BootPartition/Windows/System32/notepad.exe",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "unsupported-hostname"  }
+        },
+        {
+            "comment": "URL with '.' hostname (Volume GUID).",
+            "URL": "file://./Volume%7Bb289d78f-d491-4f6b-a437-5c51a88fa48f%7D/Windows/System32/notepad.exe",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "unsupported-hostname"  }
+        },
+        {
+            "comment": "URL with '..' hostname.",
+            "URL": "file://../UNC/VBOXSVR/WebURL/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\..\\UNC\\VBOXSVR\\WebURL\\"
+        },
+        {
+            "comment": "URL with '...' hostname.",
+            "URL": "file://.../UNC/VBOXSVR/WebURL/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\...\\UNC\\VBOXSVR\\WebURL\\"
+        },
+        {
+            "comment": "URL with IPv4 hostname.",
+            "URL": "file://192.168.178.1/c$/Windows/System32/notepad.exe",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\192.168.178.1\\c$\\Windows\\System32\\notepad.exe"
+        },
+        {
+            "comment": "URL with IPv6 hostname.",
+            "URL": "file://[2001:db8::]/WebURL/foo",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\2001-db8--.ipv6-literal.net\\WebURL\\foo"
+        },
+        {
+            "comment": "URL with transcribed IPv6 hostname.",
+            "URL": "file://2001-db8--.ipv6-literal.net/WebURL/foo",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\2001-db8--.ipv6-literal.net\\WebURL\\foo"
+        },
+        {
+            "comment": "URL with IPv4 localhost hostname.",
+            "URL": "file://127.0.0.1/SomeShare/Windows/System32/notepad.exe",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\127.0.0.1\\SomeShare\\Windows\\System32\\notepad.exe"
+        },
+        {
+            "comment": "URL with IPv6 localhost hostname.",
+            "URL": "file://[::1]/SomeShare/Windows/System32/notepad.exe",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\--1.ipv6-literal.net\\SomeShare\\Windows\\System32\\notepad.exe"
+        },
+        {
+            "comment": "URL with transcribed IPv6 localhost hostname.",
+            "URL": "file://--1.ipv6-literal.net/SomeShare/Windows/System32/notepad.exe",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\--1.ipv6-literal.net\\SomeShare\\Windows\\System32\\notepad.exe"
+        },
+
+
+
+        { "__section__": "------------------------------ Basic Paths ------------------------------" },
+
+
+
+        {
+            "comment": "URL with root path [no hostname].",
+            "URL": "file:///",
+            "file_path_posix": "/",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL with root path [with hostname].",
+            "URL": "file://mypc/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\"
+        },
+        {
+            "comment": "URL with directory path [no drive, no hostname].",
+            "URL": "file:///foo/BAR/baZ/",
+            "file_path_posix": "/foo/BAR/baZ/",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL with directory path [with drive, no hostname].",
+            "URL": "file:///C:/foo/BAR/baZ/",
+            "file_path_posix": "/C:/foo/BAR/baZ/",
+            "file_path_windows": "C:\\foo\\BAR\\baZ\\"
+        },
+        {
+            "comment": "URL with directory path [no drive, with hostname].",
+            "URL": "file://my_pc/foo/BAR/baZ/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\foo\\BAR\\baZ\\"
+        },
+        {
+            "comment": "URL with directory path [with drive, with hostname]. UNC paths do not have drive letters, but this still shouldn't fail.",
+            "URL": "file://my_pc/C:/foo/BAR/baZ/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\C:\\foo\\BAR\\baZ\\"
+        },
+        {
+            "comment": "URL with file path [no drive, no hostname].",
+            "URL": "file:///foo/BAR/baZ.txt",
+            "file_path_posix": "/foo/BAR/baZ.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL with file path [with drive, no hostname].",
+            "URL": "file:///C:/foo/BAR/baZ.txt",
+            "file_path_posix": "/C:/foo/BAR/baZ.txt",
+            "file_path_windows": "C:\\foo\\BAR\\baZ.txt"
+        },
+        {
+            "comment": "URL with file path [no drive, with hostname].",
+            "URL": "file://my_pc/foo/BAR/baZ.txt",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\foo\\BAR\\baZ.txt"
+        },
+        {
+            "comment": "URL with file path [with drive, with hostname]. UNC paths do not have drive letters, but this still shouldn't fail.",
+            "URL": "file://my_pc/C:/foo/BAR/baZ.txt",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\C:\\foo\\BAR\\baZ.txt"
+        },
+        {
+            "comment": "URL path with percent-encoded symbols, including space, tilde, '?' and '#' [no drive, no hostname]",
+            "URL": "file:///~/foo/bar%3F/baz%23.txt/Name;with%25some%20symbols*%23",
+            "file_path_posix": "/~/foo/bar?/baz#.txt/Name;with%some symbols*#",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with percent-encoded symbols, including space, tilde, '?' and '#' [with drive, no hostname]",
+            "URL": "file:///C:/~/foo/bar%3F/baz%23.txt/Name;with%25some%20symbols*%23",
+            "file_path_posix": "/C:/~/foo/bar?/baz#.txt/Name;with%some symbols*#",
+            "file_path_windows": "C:\\~\\foo\\bar?\\baz#.txt\\Name;with%some symbols*#"
+        },
+        {
+            "comment": "URL path with percent-encoded symbols, decodes to UNC with symbols in share name",
+            "URL": "file://my_pc/c$%3F%23;%25some%20symbols*%23/dir",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\c$?#;%some symbols*#\\dir"
+        },
+        {
+            "comment": "URL path with percent-encoded symbols, decodes to UNC with symbols in path",
+            "URL": "file://my_pc/share/~/foo/bar%3F/baz%23.txt/Name;with%25some%20symbols*%23",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\share\\~\\foo\\bar?\\baz#.txt\\Name;with%some symbols*#"
+        },
+
+
+
+        { "__section__": "------------------------------ Encoded path separators ------------------------------" },
+
+
+
+        {
+            "comment": "URL path with percent-encoded '/' [no drive, no hostname].",
+            "URL": "file:///foo/bar%2Fbaz",
+            "file_path_posix": { "failure-reason": "encoded-separator" },
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with percent-encoded '/' [with drive, no hostname].",
+            "URL": "file:///C:/foo/bar%2Fbaz",
+            "file_path_posix": { "failure-reason": "encoded-separator" },
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with percent-encoded '/' [no drive, with hostname].",
+            "URL": "file://mypc/foo/bar%2Fbaz",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with percent-encoded '/' [with drive, with hostname].",
+            "URL": "file://mypc/C:/foo/bar%2Fbaz",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with percent-encoded '/' (lowercase) [with drive, no hostname].",
+            "URL": "file:///C:/foo/bar%2fbaz",
+            "file_path_posix": { "failure-reason": "encoded-separator" },
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with percent-encoded '/' in UNC share name [no drive, with hostname].",
+            "URL": "file://mypc/foo%2Fbar/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with percent-encoded '/.'",
+            "URL": "file:///C:/foo/bar%2F./baz",
+            "file_path_posix": { "failure-reason": "encoded-separator" },
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with percent-encoded '/..'",
+            "URL": "file:///C:/foo/bar%2F../baz",
+            "file_path_posix": { "failure-reason": "encoded-separator" },
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with percent-encoded '\\' [no drive, no hostname].",
+            "URL": "file:///foo/bar%5Cbaz",
+            "file_path_posix": "/foo/bar\\baz",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with percent-encoded '\\' [with drive, no hostname].",
+            "URL": "file:///C:/foo/bar%5Cbaz",
+            "file_path_posix": "/C:/foo/bar\\baz",
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with percent-encoded '\\' [no drive, with hostname].",
+            "URL": "file://mypc/foo/bar%5Cbaz",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with percent-encoded '\\' [with drive, with hostname].",
+            "URL": "file://./C:/foo/bar%5Cbaz",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with percent-encoded '\\' (lowercase) [with drive, no hostname].",
+            "URL": "file:///C:/foo/bar%5cbaz",
+            "file_path_posix": "/C:/foo/bar\\baz",
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with percent-encoded '\\' in UNC share name [no drive, with hostname].",
+            "URL": "file://mypc/foo%5Cbar/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with percent-encoded '\\' (lowercase) in UNC share name [no drive, with hostname].",
+            "URL": "file://mypc/foo%5cbar/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with percent-encoded '\\.'",
+            "URL": "file:///C:/foo/bar%5C./baz",
+            "file_path_posix": "/C:/foo/bar\\./baz",
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with percent-encoded '\\..'",
+            "URL": "file:///C:/foo/bar%5C../baz",
+            "file_path_posix": "/C:/foo/bar\\../baz",
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with leading percent-encoded '/' (should not be decoded/trimmed) [no drive, no hostname].",
+            "URL": "file:///%2Ffoo/bAr/BaZ/qux.txt",
+            "file_path_posix": { "failure-reason": "encoded-separator" },
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with leading percent-encoded '\\' (should not be decoded/trimmed) [with drive, no hostname].",
+            "URL": "file:///%5CC:/bAr/BaZ/qux.txt",
+            "file_path_posix": "/\\C:/bAr/BaZ/qux.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 2 leading percent-encoded '\\' (alternate UNC encoding, should not be decoded/trimmed) [no drive, no hostname].",
+            "URL": "file:///%5C%5Cfoo/bAr/BaZ/qux.txt",
+            "file_path_posix": "/\\\\foo/bAr/BaZ/qux.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 3 leading percent-encoded '\\' (alternate UNC encoding, should not be decoded/trimmed) [no drive, no hostname].",
+            "URL": "file:///%5C%5C%5Cfoo/bAr/BaZ/qux.txt",
+            "file_path_posix": "/\\\\\\foo/bAr/BaZ/qux.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with double-percent-encoded slash [no drive, no hostname]",
+            "URL": "file:///foo/%252Fbar.txt",
+            "file_path_posix": "/foo/%2Fbar.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with double-percent-encoded slash [with drive, no hostname]",
+            "URL": "file:///C:/foo/%252Fbar.txt",
+            "file_path_posix": "/C:/foo/%2Fbar.txt",
+            "file_path_windows": "C:\\foo\\%2Fbar.txt"
+        },
+        {
+            "comment": "URL with UNC path, share contains with double-percent-encoded slash",
+            "URL": "file://mypc/%252Ffoo./",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\%2Ffoo.\\"
+        },
+        {
+            "comment": "URL with UNC path, path with double-percent-encoded slash",
+            "URL": "file://mypc/foo./%252Fbar.txt",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\foo.\\%2Fbar.txt"
+        },
+        {
+            "comment": "URL path with double-percent-encoded backslash [no drive, no hostname]",
+            "URL": "file:///foo/%255Cbar.txt",
+            "file_path_posix": "/foo/%5Cbar.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with double-percent-encoded backslash [with drive, no hostname]",
+            "URL": "file:///C:/foo/%255Cbar.txt",
+            "file_path_posix": "/C:/foo/%5Cbar.txt",
+            "file_path_windows": "C:\\foo\\%5Cbar.txt"
+        },
+        {
+            "comment": "UNC path, share contains with double-percent-encoded backslash",
+            "URL": "file://mypc/%255Cfoo./",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\%5Cfoo.\\"
+        },
+        {
+            "comment": "UNC path, path with double-percent-encoded backslash",
+            "URL": "file://mypc/foo./%255Cbar.txt",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\foo.\\%5Cbar.txt"
+        },
+
+
+
+        { "__section__": "------------------------------ Percent-encoded C0, trailing spaces ------------------------------" },
+
+
+
+        {
+            "comment": "URL path with percent-encoded C0, trailing space [no drive, no hostname, no trailing]",
+            "URL": "file:///foo%20/%07%09bar%0A%20",
+            "file_path_posix": "/foo /\u0007\u0009bar\u000A ",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with percent-encoded C0, trailing space [no drive, no hostname, with trailing]",
+            "URL": "file:///foo%20/%07%09bar%0A%20/",
+            "file_path_posix": "/foo /\u0007\u0009bar\u000A /",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with percent-encoded C0, trailing space [with drive, no hostname, no trailing]",
+            "URL": "file:///C:/foo%20/%07%09bar%0A%20",
+            "file_path_posix": "/C:/foo /\u0007\u0009bar\u000A ",
+            "file_path_windows": "C:\\foo \\\u0007\u0009bar\u000A "
+        },
+        {
+            "comment": "URL path with percent-encoded C0, trailing space [with drive, no hostname, with trailing]",
+            "URL": "file:///C:/foo%20/%07%09bar%0A%20/",
+            "file_path_posix": "/C:/foo /\u0007\u0009bar\u000A /",
+            "file_path_windows": "C:\\foo \\\u0007\u0009bar\u000A \\"
+        },
+        {
+            "comment": "URL path with percent-encoded C0, trailing space in UNC share name [with hostname, no trailing].",
+            "URL": "file://my_pc/foo%20%07%09bar%0A%20",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\foo \u0007\u0009bar\u000A "
+        },
+        {
+            "comment": "URL path with percent-encoded C0, trailing space in UNC share name [with hostname, with trailing].",
+            "URL": "file://my_pc/foo%20%07%09bar%0A%20/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\foo \u0007\u0009bar\u000A \\"
+        },
+        {
+            "comment": "URL path with percent-encoded C0, trailing space [with hostname, no trailing]",
+            "URL": "file://my_pc/share./foo%20/%07%09bar%0A%20",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\share.\\foo \\\u0007\u0009bar\u000A "
+        },
+        {
+            "comment": "URL path with percent-encoded C0, trailing space [with hostname, with trailing]",
+            "URL": "file://my_pc/share./foo%20/%07%09bar%0A%20/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\share.\\foo \\\u0007\u0009bar\u000A \\"
+        },
+
+
+
+        { "__section__": "------------------------------ Paths: Other, non-drive encoded components ------------------------------" },
+
+
+
+        {
+            "comment": "URL path with percent-encoded file name [no drive, no hostname].",
+            "URL": "file:///foo/bar%2523.txt",
+            "file_path_posix": "/foo/bar%23.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with percent-encoded file name [with drive, no hostname].",
+            "URL": "file:///C:/foo/bar%2523.txt",
+            "file_path_posix": "/C:/foo/bar%23.txt",
+            "file_path_windows": "C:\\foo\\bar%23.txt"
+        },
+        {
+            "comment": "URL path with percent-encoded UNC share name [with hostname, no trailing].",
+            "URL": "file://mypc/foo%2523",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\foo%23"
+        },
+        {
+            "comment": "URL path with percent-encoded UNC share name [with hostname, with trailing].",
+            "URL": "file://mypc/foo%2523/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\foo%23\\"
+        },
+        {
+            "comment": "URL path with percent-encoded file name [no drive, with hostname].",
+            "URL": "file://mypc/foo/bar%2523.txt",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\foo\\bar%23.txt"
+        },
+        {
+            "comment": "URL path with percent-encoded file name [with drive, with hostname].",
+            "URL": "file://mypc/C:/foo/bar%2523.txt",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\C:\\foo\\bar%23.txt"
+        },
+        {
+            "comment": "URL path with unicode [no drive, no hostname].",
+            "URL": "file:///foo/%E2%80%81/Lock%20%F0%9F%94%92/%F0%9F%A6%86.txt",
+            "file_path_posix": "/foo/\u2001/Lock 🔒/🦆.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with unicode [with drive, no hostname].",
+            "URL": "file:///C:/foo/%E2%80%81/Lock%20%F0%9F%94%92/%F0%9F%A6%86.txt",
+            "file_path_posix": "/C:/foo/\u2001/Lock 🔒/🦆.txt",
+            "file_path_windows": "C:\\foo\\\u2001\\Lock 🔒\\🦆.txt"
+        },
+        {
+            "comment": "URL path, decodes to UNC with unicode share name.",
+            "URL": "file://my_pc/%F0%9F%A6%86/pond.txt",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\🦆\\pond.txt"
+        },
+        {
+            "comment": "URL path, decodes to UNC with unicode in path.",
+            "URL": "file://my_pc/share./foo/%E2%80%81/Lock%20%F0%9F%94%92/%F0%9F%A6%86.txt",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\share.\\foo\\\u2001\\Lock 🔒\\🦆.txt"
+        },
+        {
+            "comment": "URL path with leading percent-encoded NULL byte [no hostname]",
+            "URL": "file:///%00foo/bar/",
+            "file_path_posix": { "failure-reason": "null-byte" },
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with percent-encoded NULL byte [no drive, no hostname]",
+            "URL": "file:///foo/bar%00.txt",
+            "file_path_posix": { "failure-reason": "null-byte" },
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with percent-encoded NULL byte [with drive, no hostname]",
+            "URL": "file:///C:/foo/bar%00.txt",
+            "file_path_posix": { "failure-reason": "null-byte" },
+            "file_path_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "URL path with trailing percent-encoded NULL byte [no drive, no hostname]",
+            "URL": "file:///foo%00",
+            "file_path_posix": { "failure-reason": "null-byte" },
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with trailing percent-encoded NULL byte [with drive, no hostname]",
+            "URL": "file:///C:/foo%00",
+            "file_path_posix": { "failure-reason": "null-byte" },
+            "file_path_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "URL path, UNC share has leading percent-encoded NULL byte [with hostname]",
+            "URL": "file://my_pc/%00share./foo/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "URL path, UNC with percent-encoded NULL byte [with hostname]",
+            "URL": "file://my_pc/share./foo%00.txt",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "null-byte" }
+        },
+        {
+            "comment": "URL path, UNC with trailing percent-encoded NULL byte [with hostname]",
+            "URL": "file://my_pc/share./foo%00",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "null-byte" }
+        },
+
+
+
+        { "__section__": "------------------------------ Windows drive letters ------------------------------" },
+
+
+
+        {
+            "comment": "URL path with a Windows drive-letter [no hostname, no trailing]. Windows treats this as a relative path without the trailing slash.",
+            "URL": "file:///C:",
+            "file_path_posix": "/C:",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with a Windows drive-letter [no hostname, no trailing] (lowercase)",
+            "URL": "file:///c:",
+            "file_path_posix": "/c:",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with a Windows drive-letter [no hostname, with trailing].",
+            "URL": "file:///C:/",
+            "file_path_posix": "/C:/",
+            "file_path_windows": "C:\\"
+        },
+        {
+            "comment": "URL path with a Windows drive-letter [no hostname, with trailing] (lowercase)",
+            "URL": "file:///c:/",
+            "file_path_posix": "/c:/",
+            "file_path_windows": "c:\\"
+        },
+        {
+            "comment": "URL path with a Windows drive-letter [with hostname, no trailing]. UNC paths are always fully-qualified, and don't really have 'drive letters' as such, so the trailing slash isn't required.",
+            "URL": "file://mypc/C:",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\C:"
+        },
+        {
+            "comment": "URL path with a Windows drive-letter [with hostname, no trailing] (lowercase)",
+            "URL": "file://mypc/c:",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\c:"
+        },
+        {
+            "comment": "URL path with a Windows drive-letter [with hostname, with trailing].",
+            "URL": "file://mypc/C:/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\C:\\"
+        },
+        {
+            "comment": "URL path with a Windows drive-letter [with hostname, with trailing] (lowercase)",
+            "URL": "file://mypc/c:/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\c:\\"
+        },
+        {
+            "comment": "URL path with a Windows drive-letter in $ notation [no hostname, with trailing]",
+            "URL": "file:///C$/",
+            "file_path_posix": "/C$/",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with a Windows drive-letter in $ notation [with hostname, with trailing]",
+            "URL": "file://mypc/C$/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\C$\\"
+        },
+        {
+            "comment": "URL path with a Windows drive-letter in $ notation [with hostname, with trailing] (lowercase)",
+            "URL": "file://mypc/c$/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\c$\\"
+        },
+        {
+            "comment": "URL path with a Windows drive-relative path [no hostname, no trailing].",
+            "URL": "file:///C:foo",
+            "file_path_posix": "/C:foo",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with a Windows drive-relative path [no hostname, no trailing] (lowercase)",
+            "URL": "file:///c:foo",
+            "file_path_posix": "/c:foo",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with a Windows drive-relative path [no hostname, with trailing].",
+            "URL": "file:///C:foo/bar/",
+            "file_path_posix": "/C:foo/bar/",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with a Windows drive-relative path [no hostname, with trailing] (lowercase)",
+            "URL": "file:///c:foo/bar/",
+            "file_path_posix": "/c:foo/bar/",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+
+
+
+        { "__section__": "------------------------------ Percent-encoded Windows drive letters ------------------------------" },
+
+
+
+        {
+            "comment": "URL path with an escaped drive-letter [no hostname, no trailing]",
+            "URL": "file:///c%3A",
+            "file_path_posix": "/c:",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with an escaped drive-letter [no hostname, with trailing]",
+            "URL": "file:///c%3A/",
+            "file_path_posix": "/c:/",
+            "file_path_windows": "c:\\"
+        },
+        {
+            "comment": "URL with an escaped drive letter [no hostname] (2)",
+            "URL": "file:///C%3A/foo/BAR/baZ.txt",
+            "file_path_posix": "/C:/foo/BAR/baZ.txt",
+            "file_path_windows": "C:\\foo\\BAR\\baZ.txt"
+        },
+        {
+            "comment": "URL path with a percent-encoded Windows drive-relative path [no hostname, no trailing].",
+            "URL": "file:///c%3Afoo",
+            "file_path_posix": "/c:foo",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with a Windows drive-relative path [no hostname, with trailing].",
+            "URL": "file:///c%3Afoo/bar/",
+            "file_path_posix": "/c:foo/bar/",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with an escaped drive-letter [with hostname, no trailing]",
+            "URL": "file://mypc/c%3A",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\c:"
+        },
+        {
+            "comment": "URL path with an escaped drive-letter [with hostname, with trailing]",
+            "URL": "file://mypc/c%3A/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\c:\\"
+        },
+        {
+            "comment": "URL path with an escaped drive-letter [no hostname, no trailing] (alt)",
+            "URL": "file:///c%7C",
+            "file_path_posix": "/c|",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with an escaped drive-letter [no hostname, with trailing] (alt)",
+            "URL": "file:///c%7C/",
+            "file_path_posix": "/c|/",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL with an escaped drive letter [no hostname] (alt)(2)",
+            "URL": "file:///C%7C/foo/BAR/baZ.txt",
+            "file_path_posix": "/C|/foo/BAR/baZ.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with an escaped drive-letter [with hostname, no trailing] (alt)",
+            "URL": "file://mypc/c%7C",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\c|"
+        },
+        {
+            "comment": "URL path with an escaped drive-letter [with hostname, with trailing] (alt)",
+            "URL": "file://mypc/c%7C/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\c|\\"
+        },
+        {
+            "comment": "URL encoding DOS device path. See above notes about drive letters in UNC paths",
+            "URL": "file://./C%3A/Windows/System32/notepad.exe",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "unsupported-hostname" }
+        },
+        {
+            "comment": "URL encoding DOS device path (alt)",
+            "URL": "file://./C%7C/Windows/System32/notepad.exe",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "unsupported-hostname" }
+        },
+        {
+            "comment": "URL encoding UNC path. Share name is an encoded a drive letter. Extra slashes before share name.",
+            "URL": "file://my_pc//////c%3A/dir",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\c:\\dir"
+        },
+        {
+            "comment": "UNC path, share looks like a drive letter (alt). Extra slashes before share name.",
+            "URL": "file://my_pc//////c%7C/dir",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\c|\\dir"
+        },
+
+
+
+        { "__section__": "------------------------------ Windows path normalization (trimming) ------------------------------" },
+
+
+
+        {
+            "comment": "URL path components with trailing dots [no hostname, no drive, no trailing]",
+            "URL": "file:///foo/bar.%20/bar2%20./baz./qux../qux2..%20/.../file.txt..%20",
+            "file_path_posix": "/foo/bar. /bar2 ./baz./qux../qux2.. /.../file.txt.. ",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path components with trailing dots [no hostname, with drive, no trailing]",
+            "URL": "file:///C:/foo/bar.%20/bar2%20./baz./qux../qux2..%20/.../file.txt..%20",
+            "file_path_posix": "/C:/foo/bar. /bar2 ./baz./qux../qux2.. /.../file.txt.. ",
+            "file_path_windows": "C:\\foo\\bar. \\bar2 .\\baz.\\qux..\\qux2.. \\...\\file.txt.. "
+        },
+        {
+            "comment": "URL path components with trailing dots [no hostname, no drive, with trailing]",
+            "URL": "file:///foo/bar.%20/bar2%20./baz./qux../qux2..%20/.../file.txt..%20/",
+            "file_path_posix": "/foo/bar. /bar2 ./baz./qux../qux2.. /.../file.txt.. /",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path components with trailing dots [no hostname, with drive, with trailing]",
+            "URL": "file:///C:/foo/bar.%20/bar2%20./baz./qux../qux2..%20/.../file.txt..%20/",
+            "file_path_posix": "/C:/foo/bar. /bar2 ./baz./qux../qux2.. /.../file.txt.. /",
+            "file_path_windows": "C:\\foo\\bar. \\bar2 .\\baz.\\qux..\\qux2.. \\...\\file.txt.. \\"
+        },
+        {
+            "comment": "URL path with trailing dot in UNC share name. Share names are never trimmed.",
+            "URL": "file://vboxsvr/WebURL./Parser/Parser.swift",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\vboxsvr\\WebURL.\\Parser\\Parser.swift"
+        },
+        {
+            "comment": "URL path with trailing space in UNC share name",
+            "URL": "file://vboxsvr/WebURL%20/Parser/Parser.swift",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\vboxsvr\\WebURL \\Parser\\Parser.swift"
+        },
+        {
+            "comment": "URL path with extra slashes before UNC share name",
+            "URL": "file://my_pc//////share./dir/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\share.\\dir\\"
+        },
+        {
+            "comment": "URL path components with trailing dots [with hostname, no trailing]",
+            "URL": "file://my_pc/share./foo/bar.%20/bar2%20./baz./qux../qux2..%20/.../file.txt..%20",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\share.\\foo\\bar. \\bar2 .\\baz.\\qux..\\qux2.. \\...\\file.txt.. "
+        },
+        {
+            "comment": "UNC Path, path components with trailing dots [with hostname, with trailing]",
+            "URL": "file://my_pc/share./foo/bar.%20/bar2%20./baz./qux../qux2..%20/.../file.txt..%20/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\share.\\foo\\bar. \\bar2 .\\baz.\\qux..\\qux2.. \\...\\file.txt.. \\"
+        },
+        {
+            "comment": "URL with UNC share root [no trailing]",
+            "URL": "file://mypc/share.",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\share."
+        },
+        {
+            "comment": "URL with UNC share root [with trailing]",
+            "URL": "file://mypc/share./",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\share.\\"
+        },
+        {
+            "comment": "URL path where final component is only dots and spaces [no drive, no trailing]",
+            "URL": "file:///foo/.%20.%20.%20.%20.",
+            "file_path_posix": "/foo/. . . . .",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path where final component is only dots and spaces [with drive, no trailing]. The Windows API 'GetFullPathName' trims it all away.",
+            "URL": "file:///C:/foo/.%20.%20.%20.%20.",
+            "file_path_posix": "/C:/foo/. . . . .",
+            "file_path_windows": "C:\\foo\\. . . . ."
+        },
+        {
+            "comment": "URL path where final component is only dots and spaces [no drive, with trailing]",
+            "URL": "file:///foo/.%20.%20.%20.%20./",
+            "file_path_posix": "/foo/. . . . ./",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path where final component is only dots and spaces [with drive, with trailing]",
+            "URL": "file:///C:/foo/.%20.%20.%20.%20./",
+            "file_path_posix": "/C:/foo/. . . . ./",
+            "file_path_windows": "C:\\foo\\. . . . .\\"
+        },
+        {
+            "comment": "URL with UNC path whose share name is only dots and spaces",
+            "URL": "file://vboxsvr/.%20.%20.%20./Parser/Parser.swift",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\vboxsvr\\. . . .\\Parser\\Parser.swift"
+        },
+        {
+            "comment": "URL with UNC path whose share name is only dots and spaces [no trailing]",
+            "URL": "file://vboxsvr/.%20.%20.%20.",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\vboxsvr\\. . . ."
+        },
+        {
+            "comment": "URL with UNC path whose final (non share) path component is only dots and spaces [no trailing]",
+            "URL": "file://vboxsvr/share./.%20.%20.%20.",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\vboxsvr\\share.\\. . . ."
+        },
+        {
+            "comment": "URL with UNC path whose final (non share) path component is only dots and spaces [with trailing]",
+            "URL": "file://vboxsvr/share./.%20.%20.%20./",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\vboxsvr\\share.\\. . . .\\"
+        },
+        {
+            "comment": "URL path with trailing '...' component [no drive, no trailing]",
+            "URL": "file:///foo/...",
+            "file_path_posix": "/foo/...",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with trailing '...' component [with drive, no trailing]. The Windows API 'GetFullPathName' trims it all away.",
+            "URL": "file:///C:/foo/...",
+            "file_path_posix": "/C:/foo/...",
+            "file_path_windows": "C:\\foo\\..."
+        },
+        {
+            "comment": "URL path with trailing '...' component [no drive, with trailing]",
+            "URL": "file:///foo/.../",
+            "file_path_posix": "/foo/.../",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with trailing '...' component [with drive, with trailing]",
+            "URL": "file:///C:/foo/.../",
+            "file_path_posix": "/C:/foo/.../",
+            "file_path_windows": "C:\\foo\\...\\"
+        },
+        {
+            "comment": "URL with UNC path with '...' share name",
+            "URL": "file://vboxsvr/.../Parser/Parser.swift",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\vboxsvr\\...\\Parser\\Parser.swift"
+        },
+        {
+            "comment": "URL with UNC path with '...' share name [no trailing]",
+            "URL": "file://vboxsvr/...",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\vboxsvr\\..."
+        },
+        {
+            "comment": "URL with UNC path whose final (non share) path component is a '...' component [no trailing]",
+            "URL": "file://vboxsvr/share./...",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\vboxsvr\\share.\\..."
+        },
+        {
+            "comment": "URL with UNC path whose final (non share) path component is a '...' component [with trailing]",
+            "URL": "file://vboxsvr/share./.../",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\vboxsvr\\share.\\...\\"
+        },
+
+
+
+        { "__section__": "------------------------------ Path normalization: leading separators ------------------------------" },
+
+
+
+        {
+            "comment": "URL path with 2 leading slashes [no hostname, no drive]. Posix: double slashes should be preserved in file path. Windows: unclear; some applications encode UNC paths this way (e.g. Java). For now it is rejected as a relative path on Windows.",
+            "URL": "file:////foo/bAr/BaZ/qux.txt",
+            "file_path_posix": "//foo/bAr/BaZ/qux.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 2 leading slashes [no hostname, with drive]. Posix: double slashes should be preserved in file path. Windows: invalid; 'GetFullPathName' never treats this as a local path, and 'C:' is not a valid hostname.",
+            "URL": "file:////C:/bar",
+            "file_path_posix": "//C:/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 2 leading slashes [no hostname, with drive(escaped)].",
+            "URL": "file:////C%3A/bar",
+            "file_path_posix": "//C:/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 2 leading slashes [no hostname, with drive(alt)].",
+            "URL": "file:////C|/bar",
+            "file_path_posix": "//C|/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 2 leading slashes [no hostname, with drive(alt, escaped)].",
+            "URL": "file:////C%7C/bar",
+            "file_path_posix": "//C|/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 2 leading slashes, between UNC host and share [with hostname]. 'GetFullPathName' on Windows trims slashes before the share name, but also trims the share name (probable bug).",
+            "URL": "file://my_pc//share./vol/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\share.\\vol\\"
+        },
+        {
+            "comment": "URL path with 2 leading slashes, between UNC host and share [with hostname]. One is a percent-encoded backslash, which should be rejected rather than trimmed away.",
+            "URL": "file://my_pc/%5Cshare./vol/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with 3 leading slashes [no hostname, no drive]. Should be collapsed to single slash.",
+            "URL": "file://///foo/bAr/BaZ/qux.txt",
+            "file_path_posix": "/foo/bAr/BaZ/qux.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 3 leading slashes [no hostname, no drive]. One is percent-encoded, which should be rejected rather than trimmed away.",
+            "URL": "file:////%2Ffoo/bAr/BaZ/qux.txt",
+            "file_path_posix": { "failure-reason": "encoded-separator" },
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 3 leading slashes [no hostname, no drive]. One is a percent-encoded backslash, which is allowed on POSIX but rejected on Windows.",
+            "URL": "file:///%5C/a/b/c/d.txt",
+            "file_path_posix": "/\\/a/b/c/d.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 3 leading slashes [no hostname, with drive]. Should be collapsed to single slash.",
+            "URL": "file://///C:/bar",
+            "file_path_posix": "/C:/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 3 leading slashes [no hostname, with drive(escaped)].",
+            "URL": "file://///C%3A/bar",
+            "file_path_posix": "/C:/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 3 leading slashes [no hostname, with drive(alt)].",
+            "URL": "file://///C|/bar",
+            "file_path_posix": "/C|/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 3 leading slashes [no hostname, with drive(alt, escaped)].",
+            "URL": "file://///C%7C/bar",
+            "file_path_posix": "/C|/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 3 leading slashes, between UNC host and share. 'GetFullPathName' on Windows trims slashes before the share name.",
+            "URL": "file://my_pc///share./vol/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\share.\\vol\\"
+        },
+        {
+            "comment": "URL path with 3 leading slashes, between UNC host and share. One is a percent-encoded backslash, which should be rejected rather than trimmed away.",
+            "URL": "file://my_pc//%5Cshare./vol/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with 4 leading slashes [no hostname, no drive]. Should be collapsed to single slash.",
+            "URL": "file://////foo/bAr/BaZ/qux.txt",
+            "file_path_posix": "/foo/bAr/BaZ/qux.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 4 leading slashes [no hostname, no drive]. One is percent-encoded, which should be rejected rather than trimmed away.",
+            "URL": "file://///%2Ffoo/bAr/BaZ/qux.txt",
+            "file_path_posix": { "failure-reason": "encoded-separator" },
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 4 leading slashes [no hostname, no drive]. Some are percent-encoded backslashes, which are allowed on POSIX but rejected on Windows.",
+            "URL": "file:///%5C/%5Ca/b/c/d.txt",
+            "file_path_posix": "/\\/\\a/b/c/d.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 4 leading slashes [no hostname, with drive]. Should be collapsed to single slash.",
+            "URL": "file://////C:/bar",
+            "file_path_posix": "/C:/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 4 leading slashes [no hostname, with drive(escaped)].",
+            "URL": "file://////C%3A/bar",
+            "file_path_posix": "/C:/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 4 leading slashes [no hostname, with drive(alt)].",
+            "URL": "file://////C|/bar",
+            "file_path_posix": "/C|/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 4 leading slashes [no hostname, with drive(alt, escaped)].",
+            "URL": "file://////C%7C/bar",
+            "file_path_posix": "/C|/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 4 leading slashes, between UNC host and share. 'GetFullPathName' on Windows trims slashes before the share name.",
+            "URL": "file://my_pc////share./vol/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\share.\\vol\\"
+        },
+        {
+            "comment": "URL path with 4 leading slashes, between UNC host and share. One is a percent-encoded backslash, which should be rejected rather than trimmed away.",
+            "URL": "file://my_pc///%5Cshare./vol/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with 5 leading slashes [no hostname, no drive]. Should be collapsed to single slash.",
+            "URL": "file:///////foo/bAr/BaZ/qux.txt",
+            "file_path_posix": "/foo/bAr/BaZ/qux.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 5 leading slashes [no hostname, no drive]. One is percent-encoded, which should be rejected rather than trimmed away.",
+            "URL": "file://///%2F/foo/bAr/BaZ/qux.txt",
+            "file_path_posix": { "failure-reason": "encoded-separator" },
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 5 leading slashes [no hostname, no drive]. Some are percent-encoded backslashes, which are allowed on POSIX but rejected on Windows.",
+            "URL": "file:///%5C/%5C/a/b/c/d.txt",
+            "file_path_posix": "/\\/\\/a/b/c/d.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 5 leading slashes [no hostname, with drive]. Should be collapsed to single slash.",
+            "URL": "file:///////C:/bar",
+            "file_path_posix": "/C:/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 5 leading slashes [no hostname, with drive(escaped)].",
+            "URL": "file:///////C%3A/bar",
+            "file_path_posix": "/C:/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 5 leading slashes [no hostname, with drive(alt)].",
+            "URL": "file:///////C|/bar",
+            "file_path_posix": "/C|/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 5 leading slashes [no hostname, with drive(alt, escaped)].",
+            "URL": "file:///////C%7C/bar",
+            "file_path_posix": "/C|/bar",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with 5 leading slashes, between UNC host and share. 'GetFullPathName' on Windows trims slashes before the share name.",
+            "URL": "file://my_pc/////share./vol/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\my_pc\\share.\\vol\\"
+        },
+        {
+            "comment": "URL path with 5 leading slashes, between UNC host and share. One is a percent-encoded backslash, which should be rejected rather than trimmed away.",
+            "URL": "file://my_pc///%5C/share./vol/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+
+
+
+        { "__section__": "------------------------------ Path normalization: more collapsing separators ------------------------------" },
+
+
+
+        {
+            "comment": "URL path with extra slashes in the middle. Should be normalized to a single slash. [no drive, no hostname]",
+            "URL": "file:///abc////foo/bar.txt",
+            "file_path_posix": "/abc/foo/bar.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with extra slashes in the middle. Should be normalized to a single slash. [with drive, no hostname]",
+            "URL": "file:///C:/abc////foo/bar.txt",
+            "file_path_posix": "/C:/abc/foo/bar.txt",
+            "file_path_windows": "C:\\abc\\foo\\bar.txt"
+        },
+        {
+            "comment": "URL path with extra slashes in the middle. Some are percent-encoded backslashes. [with drive, no hostname]",
+            "URL": "file:///C:/abc/%5C%5C%5C/foo/bar.txt",
+            "file_path_posix": "/C:/abc/\\\\\\/foo/bar.txt",
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL path with extra trailing slashes. Should be normalized to a single slash. [no drive, no hostname]",
+            "URL": "file:///abc/foo/bar///",
+            "file_path_posix": "/abc/foo/bar/",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL path with extra trailing slashes. Should be normalized to a single slash. [with drive, no hostname]",
+            "URL": "file:///C:/abc/foo/bar///",
+            "file_path_posix": "/C:/abc/foo/bar/",
+            "file_path_windows": "C:\\abc\\foo\\bar\\"
+        },
+        {
+            "comment": "URL path with extra trailing slashes. Some are percent-encoded backslashes. [with drive, no hostname]",
+            "URL": "file:///C:/abc/foo/bar/%5C%5C/",
+            "file_path_posix": "/C:/abc/foo/bar/\\\\/",
+            "file_path_windows": { "failure-reason": "encoded-separator" }
+        },
+        {
+            "comment": "URL with UNC path, extra slashes before share.",
+            "URL": "file://mypc////share./dir/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\share.\\dir\\"
+        },
+        {
+            "comment": "URL with UNC path, extra slashes between share/path.",
+            "URL": "file://mypc/share.////dir/",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\share.\\dir\\"
+        },
+        {
+            "comment": "URL with UNC path, extra trailing slashes.",
+            "URL": "file://mypc/share./dir////",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\share.\\dir\\"
+        },
+
+
+
+        { "__section__": "------------------------------ Query strings and fragments ------------------------------" },
+
+
+
+        {
+            "comment": "URL with query string. Should be ignored in the file path [no drive, no hostname]",
+            "URL": "file:///abc/foo/bar.txt?someQuery",
+            "file_path_posix": "/abc/foo/bar.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL with query string [with drive, no hostname]",
+            "URL": "file:///C:/abc/foo/bar.txt?someQuery",
+            "file_path_posix": "/C:/abc/foo/bar.txt",
+            "file_path_windows": "C:\\abc\\foo\\bar.txt"
+        },
+        {
+            "comment": "URL with query string [no drive, with hostname]",
+            "URL": "file://mypc/abc/foo/bar.txt?someQuery",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\abc\\foo\\bar.txt"
+        },
+        {
+            "comment": "URL with query string. Leading double-slashes make it look a bit like a Win32 file namespace path.",
+            "URL": "file:////?/abc/foo/bar.txt?notTheStartOfTheQuery",
+            "file_path_posix": "//",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL with fragment. Should be ignored in the file path [no drive, no hostname]",
+            "URL": "file:///abc/foo/bar.txt#someFragment",
+            "file_path_posix": "/abc/foo/bar.txt",
+            "file_path_windows": { "failure-reason": "relative-path" }
+        },
+        {
+            "comment": "URL with query string [with drive, no hostname]",
+            "URL": "file:///C:/abc/foo/bar.txt#someFragment",
+            "file_path_posix": "/C:/abc/foo/bar.txt",
+            "file_path_windows": "C:\\abc\\foo\\bar.txt"
+        },
+        {
+            "comment": "URL with query string [no drive, with hostname]",
+            "URL": "file://mypc/abc/foo/bar.txt#someFragment",
+            "file_path_posix": { "failure-reason": "unsupported-non-local-file" },
+            "file_path_windows": "\\\\mypc\\abc\\foo\\bar.txt"
+        },
+
+
+
+        { "__section__": "------------------------------ The End ------------------------------" }
+    ]
+}

--- a/src/openassetio-python/tests/package/utils/test_utils.py
+++ b/src/openassetio-python/tests/package/utils/test_utils.py
@@ -1,0 +1,206 @@
+#
+#   Copyright 2023 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Tests that cover the openassetio.utils namespace.
+"""
+import collections
+import json
+import os
+import re
+from pathlib import Path
+
+# pylint: disable=invalid-name,redefined-outer-name, too-few-public-methods
+# pylint: disable=missing-class-docstring,missing-function-docstring
+import pytest
+
+from openassetio import utils
+from openassetio.errors import InputValidationException
+from openassetio.utils import PathType
+
+
+URLMap = collections.namedtuple("URLMap", ("path_type", "path", "url"))
+
+relative_path_error_message = "Relative paths cannot be converted to a URL ('{}')"
+non_file_scheme_error_message = "Must be a 'file' scheme URL ('{}')"
+server_invalid_on_posix_error_message = (
+    "Server name components are invalid on POSIX for file scheme URLs ('{}')"
+)
+
+error_messages = {
+    "relative-path": "Path is relative ('{}')",
+    "empty-input": "Path is empty",
+    "invalid-namespaced-path": "Path is ill-formed ('{}')",
+    "invalid-hostname": "Path references an invalid hostname ('{}')",
+    "unsupported-namespaced-path": "Unsupported Win32 device path ('{}')",
+    "upwards-traversal": "Path contains upwards traversal ('{}')",
+    "null-byte": "Path contains NULL bytes",
+    "unsupported-non-local-file": "Unsupported non-local file ('{}')",
+    "not-a-file-url": "Not a file URL ('{}')",
+    "encoded-separator": "Percent-encoded path separator ('{}')",
+    "unsupported-hostname": "Unsupported hostname ('{}')",
+}
+
+
+class Test_pathToUrl:
+    def test_posix(self, subtests, file_path_to_url_json, url_path_converter):
+        for case in file_path_to_url_json:
+            with subtests.test(msg=case["comment"], path=case["file_path"], url=case["URL_posix"]):
+                self.assert_expected_url(
+                    URLMap(
+                        PathType.kPOSIX,
+                        case["file_path"],
+                        str_or_error(case["URL_posix"], case["file_path"]),
+                    ),
+                    url_path_converter,
+                )
+
+    def test_windows(self, subtests, file_path_to_url_json, url_path_converter):
+        for case in file_path_to_url_json:
+            with subtests.test(
+                msg=case["comment"], path=case["file_path"], url=case["URL_windows"]
+            ):
+                self.assert_expected_url(
+                    URLMap(
+                        PathType.kWindows,
+                        case["file_path"],
+                        str_or_error(case["URL_windows"], case["file_path"]),
+                    ),
+                    url_path_converter,
+                )
+
+    def assert_expected_url(self, url_map, url_path_converter):
+        os_path_type = PathType.kWindows if os.name == "nt" else PathType.kPOSIX
+
+        # Happy.
+        if isinstance(url_map.path, str) and isinstance(url_map.url, str):
+            assert url_path_converter.pathToUrl(url_map.path, url_map.path_type) == url_map.url
+
+            if os_path_type == url_map.path_type:
+                assert url_path_converter.pathToUrl(url_map.path, PathType.kSystem) == url_map.url
+                assert url_path_converter.pathToUrl(url_map.path) == url_map.url
+
+        # Bad path.
+        elif isinstance(url_map.path, str) and isinstance(url_map.url, Exception):
+
+            with pytest.raises(type(url_map.url), match=exc_to_regex(url_map.url)):
+                _unexpected = url_path_converter.pathToUrl(url_map.path, url_map.path_type)
+
+            if os_path_type == url_map.path_type:
+                with pytest.raises(type(url_map.url), match=exc_to_regex(url_map.url)):
+                    url_path_converter.pathToUrl(url_map.path, PathType.kSystem)
+                with pytest.raises(type(url_map.url), match=exc_to_regex(url_map.url)):
+                    url_path_converter.pathToUrl(url_map.path)
+        else:
+            raise RuntimeError("Unhandled URL mapping")
+
+
+class Test_pathFromUrl:
+    def test_common(self, url_path_converter):
+        with pytest.raises(InputValidationException, match="Invalid URL"):
+            url_path_converter.pathFromUrl("file://^")
+
+    def test_posix(self, subtests, url_to_file_path_json, url_path_converter):
+        for case in url_to_file_path_json:
+            with subtests.test(msg=case["comment"], path=case["file_path_posix"], url=case["URL"]):
+                self.assert_expected_path(
+                    URLMap(
+                        PathType.kPOSIX,
+                        str_or_error(case["file_path_posix"], case["URL"]),
+                        case["URL"],
+                    ),
+                    url_path_converter,
+                )
+
+    def test_windows(self, subtests, url_to_file_path_json, url_path_converter):
+        for case in url_to_file_path_json:
+            with subtests.test(
+                msg=case["comment"], path=case["file_path_windows"], url=case["URL"]
+            ):
+                self.assert_expected_path(
+                    URLMap(
+                        PathType.kWindows,
+                        str_or_error(case["file_path_windows"], case["URL"]),
+                        case["URL"],
+                    ),
+                    url_path_converter,
+                )
+
+    def assert_expected_path(self, url_map, url_path_converter):
+        os_path_type = PathType.kWindows if os.name == "nt" else PathType.kPOSIX
+
+        # Happy.
+        if isinstance(url_map.path, str) and isinstance(url_map.url, str):
+            assert url_path_converter.pathFromUrl(url_map.url, url_map.path_type) == url_map.path
+
+            if os_path_type == url_map.path_type:
+                assert (
+                    url_path_converter.pathFromUrl(url_map.url, PathType.kSystem) == url_map.path
+                )
+                assert url_path_converter.pathFromUrl(url_map.url) == url_map.path
+
+        # Bad URL.
+        elif isinstance(url_map.path, Exception) and isinstance(url_map.url, str):
+            with pytest.raises(type(url_map.path), match=exc_to_regex(url_map.path)):
+                _ = url_path_converter.pathFromUrl(url_map.url, url_map.path_type)
+
+            if os_path_type == url_map.path_type:
+                with pytest.raises(type(url_map.path), match=exc_to_regex(url_map.path)):
+                    url_path_converter.pathFromUrl(url_map.url, PathType.kSystem)
+                with pytest.raises(type(url_map.path), match=exc_to_regex(url_map.path)):
+                    url_path_converter.pathFromUrl(url_map.url)
+
+        else:
+            raise RuntimeError("Unhandled URL mapping")
+
+
+def exc_to_regex(exc):
+    return re.escape(str(exc))
+
+
+def str_or_error(maybe_error, path_or_url):
+    if isinstance(maybe_error, dict):
+        return InputValidationException(
+            error_messages[maybe_error["failure-reason"]].format(path_or_url)
+        )
+    return maybe_error
+
+
+# "module" scope to ensure we test re-using long-lived instance.
+@pytest.fixture(scope="module")
+def url_path_converter():
+    return utils.FileUrlPathConverter()
+
+
+@pytest.fixture
+def file_path_to_url_json(file_url_path_tests_json):
+    return (
+        case for case in file_url_path_tests_json["file_path_to_url"] if "__section__" not in case
+    )
+
+
+@pytest.fixture
+def url_to_file_path_json(file_url_path_tests_json):
+    return (
+        case for case in file_url_path_tests_json["url_to_file_path"] if "__section__" not in case
+    )
+
+
+@pytest.fixture(scope="session")
+def file_url_path_tests_json():
+    with open(
+        Path(__file__).parent / "resources" / "file_url_path_tests.json", "r", encoding="utf-8"
+    ) as json_file:
+        return json.load(json_file)

--- a/src/openassetio-python/tests/requirements.txt
+++ b/src/openassetio-python/tests/requirements.txt
@@ -1,2 +1,2 @@
-pytest==6.2.4
-
+pytest==7.4.4
+pytest-subtests==0.11.0


### PR DESCRIPTION
## Description

Closes #1117

A new class is added, `FileUrlPathConverter`. Upon construction, a bunch of regexes are pre-compiled. The class then exposes `pathToUrl` and `pathFromUrl` methods for conversion between file URLs and paths.

The PCRE2 library is added as a dependency to handle regular expressions.  The Ada library is added for URL parsing.  See issue for details of why these were chosen.

There are extensive test cases (=1332) thanks to a JSON database from the swift-url project. The presented implementation aims to match those test cases without modification. As such, some functionality that could be supported is not, and some compromises in code structure are made (in particular, the priority of error cases when an input has more than one error).

Unsupported functionality is detailed in the public docstrings, and may be revisited in future.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.
