### PR TITLE
Re-enable BAL integration tests

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -61,24 +61,23 @@ jobs:
           # `openassetio` package.
           python -m pip install pytest
 
-# Disable pending merge of OpenAssetIO/OpenAssetIO-Manager-BAL#99
-#      - name: Checkout BAL
-#        uses: actions/checkout@v4
-#        with:
-#          repository: OpenAssetIO/OpenAssetIO-Manager-BAL
-#          path: external/BAL
-#
-#      - name: Test BAL
-#        run: |
-#          python -m pip install external/BAL
-#          python -m pip install -r external/BAL/tests/requirements.txt
-#          python -m pytest -v external/BAL/tests
-#
-#      - name: Test Simple Resolver
-#        run: |
-#          python -m pytest -v examples/host/simpleResolver
-#        env:
-#          OPENASSETIO_PLUGIN_PATH: ${{ github.workspace }}/external/BAL/plugin
+      - name: Checkout BAL
+        uses: actions/checkout@v4
+        with:
+          repository: OpenAssetIO/OpenAssetIO-Manager-BAL
+          path: external/BAL
+
+      - name: Test BAL
+        run: |
+          python -m pip install external/BAL
+          python -m pip install -r external/BAL/tests/requirements.txt
+          python -m pytest -v external/BAL/tests
+
+      - name: Test Simple Resolver
+        run: |
+          python -m pytest -v examples/host/simpleResolver
+        env:
+          OPENASSETIO_PLUGIN_PATH: ${{ github.workspace }}/external/BAL/plugin
 
       - name: Checkout TraitGen
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Part of #1255. Re-enable BAL integration tests now that OpenAssetIO/OpenAssetIO-Manager-BAL#99 has been merged with support for the latest API changes.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~

