### PR TITLE
[Docs] Add `[comment]` to review feedback ladder

### DIFF
--- a/doc/contributing/CODE_REVIEWS.md
+++ b/doc/contributing/CODE_REVIEWS.md
@@ -99,6 +99,9 @@ as follows:
   the importance of the consideration.
 - `[question]` Something that needs clarifying before an action can be
   determined.
+- `[comment]` Something to mention but that requires no action, e.g.
+  praise or additional context. Can be resolved by either the reviewer
+  or contributor at any time.
 
 
 ## Verifying amendments


### PR DESCRIPTION
This came out of a Retrospective meeting discussion. We often wish to make a note of something that requires no action by the contributor, but did not have an appropriate feedback ladder tag for this.

## Description

Closes # (issue)

- [ ] ~~I have updated the release notes.~~
- [x] I have updated all relevant user documentation.
