### PR TITLE
Refactor convenience signatures

### DIFF
--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -69,6 +69,7 @@ target_sources(
     src/errors/exceptionMessages.cpp
     src/hostApi/HostInterface.cpp
     src/hostApi/Manager.cpp
+    src/hostApi/ManagerConveniences.cpp
     src/hostApi/ManagerFactory.cpp
     src/hostApi/ManagerImplementationFactoryInterface.cpp
     src/hostApi/EntityReferencePager.cpp

--- a/src/openassetio-core/src/hostApi/Manager.cpp
+++ b/src/openassetio-core/src/hostApi/Manager.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2023 The Foundry Visionmongers Ltd
+// Copyright 2013-2024 The Foundry Visionmongers Ltd
 #include <array>
-#include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -12,15 +12,12 @@
 #include <openassetio/errors/exceptions.hpp>
 #include <openassetio/hostApi/EntityReferencePager.hpp>
 #include <openassetio/hostApi/Manager.hpp>
-#include <openassetio/internal.hpp>
 #include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/trait/TraitsData.hpp>
 #include <openassetio/typedefs.hpp>
-
-#include "../errors/exceptionMessages.hpp"
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -224,88 +221,6 @@ void Manager::resolve(const EntityReferences &entityReferences, const trait::Tra
                              successCallback, errorCallback);
 }
 
-// Singular Except
-trait::TraitsDataPtr hostApi::Manager::resolve(
-    const EntityReference &entityReference, const trait::TraitSet &traitSet,
-    const access::ResolveAccess resolveAccess, const ContextConstPtr &context,
-    [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
-  trait::TraitsDataPtr resolveResult;
-  resolve(
-      {entityReference}, traitSet, resolveAccess, context,
-      [&resolveResult]([[maybe_unused]] std::size_t index, trait::TraitsDataPtr data) {
-        resolveResult = std::move(data);
-      },
-      [&entityReference, resolveAccess](std::size_t index, errors::BatchElementError error) {
-        auto msg = errors::createBatchElementExceptionMessage(
-            error, index, entityReference, static_cast<internal::access::Access>(resolveAccess));
-        throw errors::BatchElementException(index, std::move(error), msg);
-      });
-
-  return resolveResult;
-}
-
-// Singular variant
-std::variant<errors::BatchElementError, trait::TraitsDataPtr> hostApi::Manager::resolve(
-    const EntityReference &entityReference, const trait::TraitSet &traitSet,
-    const access::ResolveAccess resolveAccess, const ContextConstPtr &context,
-    [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
-  std::variant<errors::BatchElementError, trait::TraitsDataPtr> resolveResult;
-  resolve(
-      {entityReference}, traitSet, resolveAccess, context,
-      [&resolveResult]([[maybe_unused]] std::size_t index, trait::TraitsDataPtr data) {
-        resolveResult = std::move(data);
-      },
-      [&resolveResult]([[maybe_unused]] std::size_t index, errors::BatchElementError error) {
-        resolveResult = std::move(error);
-      });
-
-  return resolveResult;
-}
-
-// Multi except
-std::vector<trait::TraitsDataPtr> hostApi::Manager::resolve(
-    const EntityReferences &entityReferences, const trait::TraitSet &traitSet,
-    const access::ResolveAccess resolveAccess, const ContextConstPtr &context,
-    [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
-  std::vector<trait::TraitsDataPtr> resolveResult;
-  resolveResult.resize(entityReferences.size());
-
-  resolve(
-      entityReferences, traitSet, resolveAccess, context,
-      [&resolveResult](std::size_t index, trait::TraitsDataPtr data) {
-        resolveResult[index] = std::move(data);
-      },
-      [&entityReferences, resolveAccess](std::size_t index, errors::BatchElementError error) {
-        // Implemented as if FAILFAST is true.
-        auto msg = errors::createBatchElementExceptionMessage(
-            error, index, entityReferences[index],
-            static_cast<internal::access::Access>(resolveAccess));
-        throw errors::BatchElementException(index, std::move(error), msg);
-      });
-
-  return resolveResult;
-}
-
-// Multi variant
-std::vector<std::variant<errors::BatchElementError, trait::TraitsDataPtr>>
-hostApi::Manager::resolve(
-    const EntityReferences &entityReferences, const trait::TraitSet &traitSet,
-    const access::ResolveAccess resolveAccess, const ContextConstPtr &context,
-    [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
-  std::vector<std::variant<errors::BatchElementError, trait::TraitsDataPtr>> resolveResult;
-  resolveResult.resize(entityReferences.size());
-  resolve(
-      entityReferences, traitSet, resolveAccess, context,
-      [&resolveResult](std::size_t index, trait::TraitsDataPtr data) {
-        resolveResult[index] = std::move(data);
-      },
-      [&resolveResult](std::size_t index, errors::BatchElementError error) {
-        resolveResult[index] = std::move(error);
-      });
-
-  return resolveResult;
-}
-
 void Manager::defaultEntityReference(const trait::TraitSets &traitSets,
                                      const access::DefaultEntityAccess defaultEntityAccess,
                                      const ContextConstPtr &context,
@@ -388,84 +303,6 @@ void Manager::preflight(const EntityReferences &entityReferences,
                                hostSession_, successCallback, errorCallback);
 }
 
-EntityReference Manager::preflight(
-    const EntityReference &entityReference, const trait::TraitsDataPtr &traitsHint,
-    const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
-    [[maybe_unused]] const Manager::BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
-  EntityReference result{""};
-  preflight(
-      {entityReference}, {traitsHint}, publishingAccess, context,
-      [&result]([[maybe_unused]] std::size_t index, EntityReference preflightedRef) {
-        result = std::move(preflightedRef);
-      },
-      [&entityReference, publishingAccess](std::size_t index, errors::BatchElementError error) {
-        auto msg = errors::createBatchElementExceptionMessage(
-            error, index, entityReference,
-            static_cast<internal::access::Access>(publishingAccess));
-        throw errors::BatchElementException(index, std::move(error), msg);
-      });
-
-  return result;
-}
-
-std::variant<errors::BatchElementError, EntityReference> Manager::preflight(
-    const EntityReference &entityReference, const trait::TraitsDataPtr &traitsHint,
-    const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
-    [[maybe_unused]] const Manager::BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
-  std::variant<errors::BatchElementError, EntityReference> result;
-  preflight(
-      {entityReference}, {traitsHint}, publishingAccess, context,
-      [&result]([[maybe_unused]] std::size_t index, EntityReference preflightedRef) {
-        result = std::move(preflightedRef);
-      },
-      [&result]([[maybe_unused]] std::size_t index, errors::BatchElementError error) {
-        result = std::move(error);
-      });
-
-  return result;
-}
-
-EntityReferences Manager::preflight(
-    const EntityReferences &entityReferences, const trait::TraitsDatas &traitsHints,
-    access::PublishingAccess publishingAccess, const ContextConstPtr &context,
-    [[maybe_unused]] const Manager::BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
-  EntityReferences results;
-  results.resize(entityReferences.size(), EntityReference{""});
-
-  preflight(
-      entityReferences, traitsHints, publishingAccess, context,
-      [&results](std::size_t index, EntityReference preflightedRef) {
-        results[index] = std::move(preflightedRef);
-      },
-      [&entityReferences, publishingAccess](std::size_t index, errors::BatchElementError error) {
-        // Implemented as if FAILFAST is true.
-        auto msg = errors::createBatchElementExceptionMessage(
-            error, index, entityReferences[index],
-            static_cast<internal::access::Access>(publishingAccess));
-        throw errors::BatchElementException(index, std::move(error), msg);
-      });
-
-  return results;
-}
-
-std::vector<std::variant<errors::BatchElementError, EntityReference>> Manager::preflight(
-    const EntityReferences &entityReferences, const trait::TraitsDatas &traitsHints,
-    const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
-    [[maybe_unused]] const Manager::BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
-  std::vector<std::variant<errors::BatchElementError, EntityReference>> results;
-  results.resize(entityReferences.size());
-  preflight(
-      entityReferences, traitsHints, publishingAccess, context,
-      [&results](std::size_t index, EntityReference entityReference) {
-        results[index] = std::move(entityReference);
-      },
-      [&results](std::size_t index, errors::BatchElementError error) {
-        results[index] = std::move(error);
-      });
-
-  return results;
-}
-
 void Manager::register_(const EntityReferences &entityReferences,
                         const trait::TraitsDatas &entityTraitsDatas,
                         const access::PublishingAccess publishingAccess,
@@ -482,88 +319,6 @@ void Manager::register_(const EntityReferences &entityReferences,
   }
   return managerInterface_->register_(entityReferences, entityTraitsDatas, publishingAccess,
                                       context, hostSession_, successCallback, errorCallback);
-}
-
-// Singular Except
-EntityReference hostApi::Manager::register_(
-    const EntityReference &entityReference, const trait::TraitsDataPtr &entityTraitsData,
-    const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
-    [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
-  EntityReference result("");
-  register_(
-      {entityReference}, {entityTraitsData}, publishingAccess, context,
-      [&result]([[maybe_unused]] std::size_t index, EntityReference registeredRef) {
-        result = std::move(registeredRef);
-      },
-      [&entityReference, publishingAccess](std::size_t index, errors::BatchElementError error) {
-        auto msg = errors::createBatchElementExceptionMessage(
-            error, index, entityReference,
-            static_cast<internal::access::Access>(publishingAccess));
-        throw errors::BatchElementException(index, std::move(error), msg);
-      });
-
-  return result;
-}
-
-// Singular variant
-std::variant<errors::BatchElementError, EntityReference> hostApi::Manager::register_(
-    const EntityReference &entityReference, const trait::TraitsDataPtr &entityTraitsData,
-    const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
-    [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
-  std::variant<errors::BatchElementError, EntityReference> result;
-  register_(
-      {entityReference}, {entityTraitsData}, publishingAccess, context,
-      [&result]([[maybe_unused]] std::size_t index, EntityReference registeredRef) {
-        result = std::move(registeredRef);
-      },
-      [&result]([[maybe_unused]] std::size_t index, errors::BatchElementError error) {
-        result = std::move(error);
-      });
-
-  return result;
-}
-
-// Multi except
-std::vector<EntityReference> hostApi::Manager::register_(
-    const EntityReferences &entityReferences, const trait::TraitsDatas &entityTraitsDatas,
-    const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
-    [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
-  std::vector<EntityReference> result;
-  result.resize(entityReferences.size(), EntityReference{""});
-
-  register_(
-      entityReferences, entityTraitsDatas, publishingAccess, context,
-      [&result](std::size_t index, EntityReference registeredRef) {
-        result[index] = std::move(registeredRef);
-      },
-      [&entityReferences, publishingAccess](std::size_t index, errors::BatchElementError error) {
-        // Implemented as if FAILFAST is true.
-        auto msg = errors::createBatchElementExceptionMessage(
-            error, index, entityReferences[index],
-            static_cast<internal::access::Access>(publishingAccess));
-        throw errors::BatchElementException(index, std::move(error), msg);
-      });
-
-  return result;
-}
-
-// Multi variant
-std::vector<std::variant<errors::BatchElementError, EntityReference>> hostApi::Manager::register_(
-    const EntityReferences &entityReferences, const trait::TraitsDatas &entityTraitsDatas,
-    const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
-    [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
-  std::vector<std::variant<errors::BatchElementError, EntityReference>> result;
-  result.resize(entityReferences.size());
-  register_(
-      entityReferences, entityTraitsDatas, publishingAccess, context,
-      [&result](std::size_t index, EntityReference registeredRef) {
-        result[index] = std::move(registeredRef);
-      },
-      [&result](std::size_t index, errors::BatchElementError error) {
-        result[index] = std::move(error);
-      });
-
-  return result;
 }
 
 }  // namespace hostApi

--- a/src/openassetio-core/src/hostApi/ManagerConveniences.cpp
+++ b/src/openassetio-core/src/hostApi/ManagerConveniences.cpp
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <utility>
+#include <vector>
+
+#include <openassetio/Context.hpp>
+#include <openassetio/EntityReference.hpp>
+#include <openassetio/errors/exceptions.hpp>
+#include <openassetio/hostApi/Manager.hpp>
+#include <openassetio/trait/TraitsData.hpp>
+#include <openassetio/typedefs.hpp>
+
+#include "../errors/exceptionMessages.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace hostApi {
+// The definitions below are the "convenience" method signatures -
+// alternate, often friendlier signatures wrapping the core batch-first
+// callback-based member functions found in `Manager.cpp`
+
+// Singular Except
+trait::TraitsDataPtr hostApi::Manager::resolve(
+    const EntityReference &entityReference, const trait::TraitSet &traitSet,
+    const access::ResolveAccess resolveAccess, const ContextConstPtr &context,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
+  trait::TraitsDataPtr resolveResult;
+  resolve(
+      {entityReference}, traitSet, resolveAccess, context,
+      [&resolveResult]([[maybe_unused]] std::size_t index, trait::TraitsDataPtr data) {
+        resolveResult = std::move(data);
+      },
+      [&entityReference, resolveAccess](std::size_t index, errors::BatchElementError error) {
+        auto msg = errors::createBatchElementExceptionMessage(
+            error, index, entityReference, static_cast<internal::access::Access>(resolveAccess));
+        throw errors::BatchElementException(index, std::move(error), msg);
+      });
+
+  return resolveResult;
+}
+
+// Singular variant
+std::variant<errors::BatchElementError, trait::TraitsDataPtr> hostApi::Manager::resolve(
+    const EntityReference &entityReference, const trait::TraitSet &traitSet,
+    const access::ResolveAccess resolveAccess, const ContextConstPtr &context,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
+  std::variant<errors::BatchElementError, trait::TraitsDataPtr> resolveResult;
+  resolve(
+      {entityReference}, traitSet, resolveAccess, context,
+      [&resolveResult]([[maybe_unused]] std::size_t index, trait::TraitsDataPtr data) {
+        resolveResult = std::move(data);
+      },
+      [&resolveResult]([[maybe_unused]] std::size_t index, errors::BatchElementError error) {
+        resolveResult = std::move(error);
+      });
+
+  return resolveResult;
+}
+
+// Multi except
+std::vector<trait::TraitsDataPtr> hostApi::Manager::resolve(
+    const EntityReferences &entityReferences, const trait::TraitSet &traitSet,
+    const access::ResolveAccess resolveAccess, const ContextConstPtr &context,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
+  std::vector<trait::TraitsDataPtr> resolveResult;
+  resolveResult.resize(entityReferences.size());
+
+  resolve(
+      entityReferences, traitSet, resolveAccess, context,
+      [&resolveResult](std::size_t index, trait::TraitsDataPtr data) {
+        resolveResult[index] = std::move(data);
+      },
+      [&entityReferences, resolveAccess](std::size_t index, errors::BatchElementError error) {
+        // Implemented as if FAILFAST is true.
+        auto msg = errors::createBatchElementExceptionMessage(
+            error, index, entityReferences[index],
+            static_cast<internal::access::Access>(resolveAccess));
+        throw errors::BatchElementException(index, std::move(error), msg);
+      });
+
+  return resolveResult;
+}
+
+// Multi variant
+std::vector<std::variant<errors::BatchElementError, trait::TraitsDataPtr>>
+hostApi::Manager::resolve(
+    const EntityReferences &entityReferences, const trait::TraitSet &traitSet,
+    const access::ResolveAccess resolveAccess, const ContextConstPtr &context,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
+  std::vector<std::variant<errors::BatchElementError, trait::TraitsDataPtr>> resolveResult;
+  resolveResult.resize(entityReferences.size());
+  resolve(
+      entityReferences, traitSet, resolveAccess, context,
+      [&resolveResult](std::size_t index, trait::TraitsDataPtr data) {
+        resolveResult[index] = std::move(data);
+      },
+      [&resolveResult](std::size_t index, errors::BatchElementError error) {
+        resolveResult[index] = std::move(error);
+      });
+
+  return resolveResult;
+}
+
+EntityReference Manager::preflight(
+    const EntityReference &entityReference, const trait::TraitsDataPtr &traitsHint,
+    const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
+    [[maybe_unused]] const Manager::BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
+  EntityReference result{""};
+  preflight(
+      {entityReference}, {traitsHint}, publishingAccess, context,
+      [&result]([[maybe_unused]] std::size_t index, EntityReference preflightedRef) {
+        result = std::move(preflightedRef);
+      },
+      [&entityReference, publishingAccess](std::size_t index, errors::BatchElementError error) {
+        auto msg = errors::createBatchElementExceptionMessage(
+            error, index, entityReference,
+            static_cast<internal::access::Access>(publishingAccess));
+        throw errors::BatchElementException(index, std::move(error), msg);
+      });
+
+  return result;
+}
+
+std::variant<errors::BatchElementError, EntityReference> Manager::preflight(
+    const EntityReference &entityReference, const trait::TraitsDataPtr &traitsHint,
+    const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
+    [[maybe_unused]] const Manager::BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
+  std::variant<errors::BatchElementError, EntityReference> result;
+  preflight(
+      {entityReference}, {traitsHint}, publishingAccess, context,
+      [&result]([[maybe_unused]] std::size_t index, EntityReference preflightedRef) {
+        result = std::move(preflightedRef);
+      },
+      [&result]([[maybe_unused]] std::size_t index, errors::BatchElementError error) {
+        result = std::move(error);
+      });
+
+  return result;
+}
+
+EntityReferences Manager::preflight(
+    const EntityReferences &entityReferences, const trait::TraitsDatas &traitsHints,
+    access::PublishingAccess publishingAccess, const ContextConstPtr &context,
+    [[maybe_unused]] const Manager::BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
+  EntityReferences results;
+  results.resize(entityReferences.size(), EntityReference{""});
+
+  preflight(
+      entityReferences, traitsHints, publishingAccess, context,
+      [&results](std::size_t index, EntityReference preflightedRef) {
+        results[index] = std::move(preflightedRef);
+      },
+      [&entityReferences, publishingAccess](std::size_t index, errors::BatchElementError error) {
+        // Implemented as if FAILFAST is true.
+        auto msg = errors::createBatchElementExceptionMessage(
+            error, index, entityReferences[index],
+            static_cast<internal::access::Access>(publishingAccess));
+        throw errors::BatchElementException(index, std::move(error), msg);
+      });
+
+  return results;
+}
+
+std::vector<std::variant<errors::BatchElementError, EntityReference>> Manager::preflight(
+    const EntityReferences &entityReferences, const trait::TraitsDatas &traitsHints,
+    const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
+    [[maybe_unused]] const Manager::BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
+  std::vector<std::variant<errors::BatchElementError, EntityReference>> results;
+  results.resize(entityReferences.size());
+  preflight(
+      entityReferences, traitsHints, publishingAccess, context,
+      [&results](std::size_t index, EntityReference entityReference) {
+        results[index] = std::move(entityReference);
+      },
+      [&results](std::size_t index, errors::BatchElementError error) {
+        results[index] = std::move(error);
+      });
+
+  return results;
+}
+
+// Singular Except
+EntityReference hostApi::Manager::register_(
+    const EntityReference &entityReference, const trait::TraitsDataPtr &entityTraitsData,
+    const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
+  EntityReference result("");
+  register_(
+      {entityReference}, {entityTraitsData}, publishingAccess, context,
+      [&result]([[maybe_unused]] std::size_t index, EntityReference registeredRef) {
+        result = std::move(registeredRef);
+      },
+      [&entityReference, publishingAccess](std::size_t index, errors::BatchElementError error) {
+        auto msg = errors::createBatchElementExceptionMessage(
+            error, index, entityReference,
+            static_cast<internal::access::Access>(publishingAccess));
+        throw errors::BatchElementException(index, std::move(error), msg);
+      });
+
+  return result;
+}
+
+// Singular variant
+std::variant<errors::BatchElementError, EntityReference> hostApi::Manager::register_(
+    const EntityReference &entityReference, const trait::TraitsDataPtr &entityTraitsData,
+    const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
+  std::variant<errors::BatchElementError, EntityReference> result;
+  register_(
+      {entityReference}, {entityTraitsData}, publishingAccess, context,
+      [&result]([[maybe_unused]] std::size_t index, EntityReference registeredRef) {
+        result = std::move(registeredRef);
+      },
+      [&result]([[maybe_unused]] std::size_t index, errors::BatchElementError error) {
+        result = std::move(error);
+      });
+
+  return result;
+}
+
+// Multi except
+std::vector<EntityReference> hostApi::Manager::register_(
+    const EntityReferences &entityReferences, const trait::TraitsDatas &entityTraitsDatas,
+    const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
+  std::vector<EntityReference> result;
+  result.resize(entityReferences.size(), EntityReference{""});
+
+  register_(
+      entityReferences, entityTraitsDatas, publishingAccess, context,
+      [&result](std::size_t index, EntityReference registeredRef) {
+        result[index] = std::move(registeredRef);
+      },
+      [&entityReferences, publishingAccess](std::size_t index, errors::BatchElementError error) {
+        // Implemented as if FAILFAST is true.
+        auto msg = errors::createBatchElementExceptionMessage(
+            error, index, entityReferences[index],
+            static_cast<internal::access::Access>(publishingAccess));
+        throw errors::BatchElementException(index, std::move(error), msg);
+      });
+
+  return result;
+}
+
+// Multi variant
+std::vector<std::variant<errors::BatchElementError, EntityReference>> hostApi::Manager::register_(
+    const EntityReferences &entityReferences, const trait::TraitsDatas &entityTraitsDatas,
+    const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
+  std::vector<std::variant<errors::BatchElementError, EntityReference>> result;
+  result.resize(entityReferences.size());
+  register_(
+      entityReferences, entityTraitsDatas, publishingAccess, context,
+      [&result](std::size_t index, EntityReference registeredRef) {
+        result[index] = std::move(registeredRef);
+      },
+      [&result](std::size_t index, errors::BatchElementError error) {
+        result[index] = std::move(error);
+      });
+
+  return result;
+}
+
+}  // namespace hostApi
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-python/cmodule/src/errors/BatchElementErrorBinding.cpp
+++ b/src/openassetio-python/cmodule/src/errors/BatchElementErrorBinding.cpp
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2024 The Foundry Visionmongers Ltd
 #include <string_view>
 
+#include <fmt/format.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 
 #include <openassetio/errors/BatchElementError.hpp>
+#include <openassetio/typedefs.hpp>
 
 #include "../_openassetio.hpp"
 
-void registerBatchElementError(const py::module &mod) {
+void registerBatchElementError(const py::module& mod) {
   using openassetio::errors::BatchElementError;
 
   py::class_<BatchElementError> batchElementError{mod, "BatchElementError", py::is_final()};
@@ -28,5 +30,9 @@ void registerBatchElementError(const py::module &mod) {
            py::arg("message"))
       .def(py::self == py::self)  // NOLINT(misc-redundant-expression)
       .def_readonly("code", &BatchElementError::code)
-      .def_readonly("message", &BatchElementError::message);
+      .def_readonly("message", &BatchElementError::message)
+      .def("__repr__", [](const BatchElementError& self) {
+        return fmt::format("BatchElementError({}, '{}')",
+                           py::str(py::cast(self.code)).cast<std::string_view>(), self.message);
+      });
 }

--- a/src/openassetio-python/tests/package/test_batchelementerror.py
+++ b/src/openassetio-python/tests/package/test_batchelementerror.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2022 The Foundry Visionmongers Ltd
+#   Copyright 2022-2024 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -106,6 +106,20 @@ class Test_BatchElementError_equality:
         b_batch_element_error = BatchElementError(expected_code, "another message")
 
         assert a_batch_element_error != b_batch_element_error
+
+
+class Test_BatchElementError_repr:
+    def test(self):
+        batch_element_error = BatchElementError(
+            BatchElementError.ErrorCode.kEntityResolutionError, "some error happened"
+        )
+
+        assert str(batch_element_error) == repr(batch_element_error)
+
+        assert (
+            str(batch_element_error)
+            == "BatchElementError(ErrorCode.kEntityResolutionError, 'some error happened')"
+        )
 
 
 class Test_BatchElementException:


### PR DESCRIPTION
## Description

Closes #1239.

* Refactor tests of batch-first callback-based methods to use a common base class. The base class includes assertion methods to capture the commonality between the test cases for the various methods. This is less compact than it could be, since an attempt has been made to future-proof against upcoming convenience signatures for other methods.
* Create a `ManagerConveniences.cpp` and move convenience overloads from `Manager.cpp`. 

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~

