### PR TITLE
[Docs] Update BUILDING.md with new dependencies

### DIFF
--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -38,6 +38,8 @@ available.
 - [pybind11](https://pybind11.readthedocs.io/en/stable/) 2.8.1+
 - [toml++](https://marzer.github.io/tomlplusplus/) 3.2.0+
 - [fmt](https://github.com/fmtlib/fmt) 9.1.0
+- [Ada](https://github.com/ada-url/ada) 2.7.4
+- [PCRE2](https://github.com/PCRE2Project/pcre2) 10.42
 
 ### Test dependencies
 


### PR DESCRIPTION
New dependencies were added for the `FilePathUrlConverter` added in #1117. However, we forgot to update the list of dependencies in the BUILDING.md doc.

## Description

Closes # (issue)

- [ ] ~~I have updated the release notes.~~
- [x] I have updated all relevant user documentation.

## Reviewer Notes

Whoops.
