### PR TITLE
[CI] Add markdown link check

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Check Python formatting
         run: black --config src/openassetio-python/pyproject.toml --check --diff .
 
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+
   # Note: in order to keep an `actions/cache` cache up to date, we must
   # use the approach detailed in
   # https://github.com/actions/cache/blob/main/workarounds.md#update-a-cache

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -45,7 +45,7 @@ available.
 
 Building and running tests requires the following additional packages:
 
-- [catch2](https://catch2.docsforge.com/) 2.13
+- [catch2](https://github.com/catchorg/Catch2/) 2.13
 - [trompeloeil](https://github.com/rollbear/trompeloeil) 42
 
 We use the CMake build system for compiling the C++ core library and

--- a/doc/decisions/DR017-Entity-version-queries.md
+++ b/doc/decisions/DR017-Entity-version-queries.md
@@ -67,9 +67,10 @@ These were used in production to:
 ###  The evolution of the entity data model
 
 As described in
-[DR007](./DR007-Hierarchical-or-compositional-traits.md) and
-[DR008](./DR008-Unify-the-entity-data-model.md), the OpenAssetIO data
-model has evolved significantly since these methods were introduced.
+[DR007](./DR007-Hierarchical-or-compositional-traits-for-specifications.md)
+and [DR008](./DR008-Unify-the-entity-data-model.md), the OpenAssetIO
+data model has evolved significantly since these methods were
+introduced.
 
 Critically, traits facilitate structured data groupings that can be
 resolved independently for any given entity.

--- a/doc/decisions/DR018-Result-pager-design.md
+++ b/doc/decisions/DR018-Result-pager-design.md
@@ -10,7 +10,7 @@
 ## Background
 
 Certain OpenAssetIO API methods can produce large sets of data.
-[DR016](DRDR016-One-to-many-result-paging.md) covers the evolution in
+[DR016](DR016-One-to-many-result-paging.md) covers the evolution in
 thinking that lead us to expose this data through a lazy "result pager".
 
 These pagers are supplied by the relevant `Manager` methods. The caller
@@ -25,7 +25,7 @@ should be used when evolving the pager interface in the future.
 
 ## Relevant data
 
-- [DR016](DRDR016-One-to-many-result-paging.md) opted for the pager
+- [DR016](DR016-One-to-many-result-paging.md) opted for the pager
   solution partly as it facilitates future extensions to data set
   navigation with minimal disruption to the rest of the API.
 


### PR DESCRIPTION
Part of #737 

Add CI checker that asserts all the links in markdown files are valid. Fix broken links throughout the repo.