### PR TITLE
[Core] Add convenience signatures for entityTraits

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,12 @@ v1.0.0-beta.x.y
   non-normalised device paths (i.e. `\\?\`-prefixed).
   [#1257](https://github.com/OpenAssetIO/OpenAssetIO/issues/1257)
 
+- Added `entityTraits` overloads for convenience, providing alternatives
+  to the core callback-based workflow. Includes a more direct method for
+  resolving a single entity reference, and exception vs. result object
+  workflows.
+  [#1217](https://github.com/OpenAssetIO/OpenAssetIO/issues/1217)
+
 v1.0.0-beta.2.0
 ---------------
 

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -836,6 +836,160 @@ class OPENASSETIO_CORE_EXPORT Manager final {
                             const ContextConstPtr& context,
                             const EntityTraitsSuccessCallback& successCallback,
                             const BatchElementErrorCallback& errorCallback);
+
+  /**
+   * Retrieve the @ref trait_set of an @ref entity.
+   *
+   * See documentation for the <!--
+   * --> @ref entityTraits(const EntityReferences&, <!--
+   * --> access::EntityTraitsAccess ,const ContextConstPtr&, <!--
+   * --> const EntityTraitsSuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback)
+   * "callback variation" for more details on resolution behaviour.
+   *
+   * Errors that occur will be thrown as an exception, either from the
+   * @ref manager plugin (for errors not specific to the entity
+   * reference) or as a @fqref{errors.BatchElementException}
+   * "BatchElementException"-derived error.
+   *
+   * @param entityReference Entity reference to query.
+   *
+   * @param entityTraitsAccess The intended usage of the data.
+   *
+   * @param context The calling context.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Exception.
+   *
+   * @return Populated trait set.
+   *
+   * @throws errors.BatchElementException Converted exception thrown
+   * when the manager emits a @fqref{errors.BatchElementError}
+   * "BatchElementError".
+   */
+  trait::TraitSet entityTraits(const EntityReference& entityReference,
+                               access::EntityTraitsAccess entityTraitsAccess,
+                               const ContextConstPtr& context,
+                               const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
+
+  /**
+   * Provides either a populated @ref trait_set or a
+   * @fqref{errors.BatchElementError} "BatchElementError".
+   *
+   * If successful, the result is populated with the trait set of the
+   * @ref entity.
+   *
+   * Otherwise, the result is populated with an error object detailing
+   * the reason for the failure to retrieve the traits this particular
+   * entity.
+   *
+   * Errors that are not specific to the entity being queried will be
+   * thrown as an exception.
+   *
+   * See documentation for the <!--
+   * --> @ref entityTraits(const EntityReferences&, <!--
+   * --> access::EntityTraitsAccess, const ContextConstPtr&, <!--
+   * --> const EntityTraitsSuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback)
+   * "callback variation" for more details on resolution behaviour.
+   *
+   * @param entityReference Entity reference to query.
+   *
+   * @param entityTraitsAccess The intended usage of the data.
+   *
+   * @param context The calling context.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Variant.
+   *
+   * @return Object containing either the populated trait set or an
+   * error object.
+   */
+  std::variant<errors::BatchElementError, trait::TraitSet> entityTraits(
+      const EntityReference& entityReference, access::EntityTraitsAccess entityTraitsAccess,
+      const ContextConstPtr& context, const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
+
+  /**
+   * Retrieve the @ref trait_set of one or more @ref entity "entities".
+   *
+   * See documentation for the <!--
+   * --> @ref entityTraits(const EntityReferences&, <!--
+   * --> access::EntityTraitsAccess, const ContextConstPtr&, <!--
+   * --> const EntityTraitsSuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback)
+   * "callback variation" for more details on resolution behaviour.
+   *
+   * Any errors that occur will be immediately thrown as an exception,
+   * either from the @ref manager plugin (for errors not specific to the
+   * entity reference) or as a @fqref{errors.BatchElementException}
+   * "BatchElementException"-derived error.
+   *
+   * @param entityReferences Entity references to query.
+   *
+   * @param entityTraitsAccess The intended usage of the data.
+   *
+   * @param context The calling context.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Exception.
+   *
+   * @return List of populated trait sets.
+   *
+   * @throws errors.BatchElementException Converted exception thrown
+   * when the manager emits a @fqref{errors.BatchElementError}
+   * "BatchElementError".
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kResolution.
+   */
+  std::vector<trait::TraitSet> entityTraits(
+      const EntityReferences& entityReferences, access::EntityTraitsAccess entityTraitsAccess,
+      const ContextConstPtr& context,
+      const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
+
+  /**
+   * Provides either a populated @ref trait_set or a
+   * @fqref{errors.BatchElementError} "BatchElementError" for each given
+   * @ref entity_reference.
+   *
+   * For successful references, the corresponding element of the result
+   * is populated with its trait set.
+   *
+   * Otherwise, the corresponding element of the result is populated
+   * with an error object detailing the reason for the failure to
+   * entityTraits that particular entity.
+   *
+   * Errors that are not specific to an entity will be thrown as an
+   * exception, failing the whole batch.
+   *
+   * See documentation for the <!--
+   * --> @ref entityTraits(const EntityReferences&, <!--
+   * --> access::EntityTraitsAccess, const ContextConstPtr&, <!--
+   * --> const EntityTraitsSuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback)
+   * "callback variation" for more details on resolution behaviour.
+   *
+   * @param entityReferences Entity references to query.
+   *
+   * @param entityTraitsAccess The intended usage of the data.
+   *
+   * @param context The calling context.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tag dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Variant.
+   *
+   * @return List of objects, each containing either the populated trait
+   * set or an error.
+   */
+  std::vector<std::variant<errors::BatchElementError, trait::TraitSet>> entityTraits(
+      const EntityReferences& entityReferences, access::EntityTraitsAccess entityTraitsAccess,
+      const ContextConstPtr& context, const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
+
   /**
    * @}
    */

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -100,10 +100,65 @@ void registerManager(const py::module& mod) {
       .def("entityExists", &Manager::entityExists, py::arg("entityReferences"),
            py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"),
            py::call_guard<py::gil_scoped_release>{})
-      .def("entityTraits", &Manager::entityTraits, py::arg("entityReferences"),
-           py::arg("entityTraitsAccess"), py::arg("context").none(false),
-           py::arg("successCallback"), py::arg("errorCallback"),
+      .def("entityTraits",
+           py::overload_cast<const EntityReferences&, access::EntityTraitsAccess,
+                             const ContextConstPtr&, const Manager::EntityTraitsSuccessCallback&,
+                             const Manager::BatchElementErrorCallback&>(&Manager::entityTraits),
+           py::arg("entityReferences"), py::arg("entityTraitsAccess"),
+           py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"),
            py::call_guard<py::gil_scoped_release>{})
+      .def("entityTraits",
+           py::overload_cast<const EntityReference&, access::EntityTraitsAccess,
+                             const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::entityTraits),
+           py::arg("entityReference"), py::arg("entityTraitsAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("entityTraits",
+           py::overload_cast<const EntityReference&, access::EntityTraitsAccess,
+                             const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::entityTraits),
+           py::arg("entityReference"), py::arg("entityTraitsAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def(
+          "entityTraits",
+          // TODO(DF): Technically we shouldn't need this overload,
+          // see similar comment for `resolve`.
+          [](Manager& self, const EntityReference& entityReference,
+             const access::EntityTraitsAccess access, const ContextConstPtr& context) {
+            return self.entityTraits(entityReference, access, context);
+          },
+          py::arg("entityReference"), py::arg("entityTraitsAccess"),
+          py::arg("context").none(false), py::call_guard<py::gil_scoped_release>{})
+      .def("entityTraits",
+           py::overload_cast<const EntityReferences&, access::EntityTraitsAccess,
+                             const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::entityTraits),
+           py::arg("entityReferences"), py::arg("entityTraitsAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("entityTraits",
+           py::overload_cast<const EntityReferences&, access::EntityTraitsAccess,
+                             const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::entityTraits),
+           py::arg("entityReferences"), py::arg("entityTraitsAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def(
+          "entityTraits",
+          // TODO(DF): Technically we shouldn't need this overload,
+          // see similar comment for `resolve`.
+          [](Manager& self, const EntityReferences& entityReferences,
+             const access::EntityTraitsAccess entityTraitsAccess, const ContextConstPtr& context) {
+            return self.entityTraits(entityReferences, entityTraitsAccess, context);
+          },
+          py::arg("entityReferences"), py::arg("entityTraitsAccess"),
+          py::arg("context").none(false), py::call_guard<py::gil_scoped_release>{})
       .def("hasCapability", &Manager::hasCapability, py::arg("capability"),
            py::call_guard<py::gil_scoped_release>{})
       .def("updateTerminology", &Manager::updateTerminology, py::arg("terms"),

--- a/src/openassetio-python/tests/cmodule/gil/test_manager_gil.py
+++ b/src/openassetio-python/tests/cmodule/gil/test_manager_gil.py
@@ -111,12 +111,18 @@ class Test_Manager_gil:
 
         a_threaded_manager.entityExists([], a_context, fail, fail)
 
-    def test_entityTraits(self, a_threaded_manager, a_context):
-        # Defend against forgetting to include convenience signatures in
-        # this test, once added.
-        assert "Overloaded" not in a_threaded_manager.entityExists.__doc__
+    def test_entityTraits(self, a_threaded_manager, a_context, an_entity_reference):
+        ref = an_entity_reference
+        an_access = access.EntityTraitsAccess.kRead
+        tag = Manager.BatchElementErrorPolicyTag
 
-        a_threaded_manager.entityTraits([], access.EntityTraitsAccess.kRead, a_context, fail, fail)
+        a_threaded_manager.entityTraits([], an_access, a_context, fail, fail)
+        a_threaded_manager.entityTraits(ref, an_access, a_context)
+        a_threaded_manager.entityTraits(ref, an_access, a_context, tag.kException)
+        a_threaded_manager.entityTraits(ref, an_access, a_context, tag.kVariant)
+        a_threaded_manager.entityTraits([], an_access, a_context)
+        a_threaded_manager.entityTraits([], an_access, a_context, tag.kException)
+        a_threaded_manager.entityTraits([], an_access, a_context, tag.kVariant)
 
     def test_flushCaches(self, a_threaded_manager):
         a_threaded_manager.flushCaches()


### PR DESCRIPTION
## Description

Closes #1217. The batch-first callback-based API introduces a lot of boilerplate for hosts that only need to query a single entity, or prefer error cases to be realised as exceptions or alternate result types. Other API methods already have convenience signatures wrapping the core callback-based API, but many are still missing these, `entityTraits` being one of them.

So add convenience signatures mirroring those that exist for other member functions (e.g. `resolve`), largely duplicating the format of the docstrings for `resolve`.

- [x] I have updated the release notes.
- [ ] ~~I have updated all relevant user documentation.~~
