### PR TITLE
[CI] Remove MacOS LDFLAGS preamble

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,12 +33,6 @@ jobs:
         - os: ubuntu-20.04
           shell: bash
         - os: macos-11
-          # MacOS toolchain doesn't search /usr/local by default:
-          # https://gitlab.kitware.com/cmake/cmake/-/issues/19120
-          # The CMake FindPython module's Python::Python target (used
-          # via pybind11::embed in python-bridge-test) transitively adds
-          # linker flags to system libs, which fail due to this issue.
-          preamble: export LDFLAGS="-L/usr/local/lib"
           shell: bash
     defaults:
       run:

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -115,12 +115,6 @@ jobs:
         - os: ubuntu-20.04
           site-packages: lib/python3.9/site-packages
         - os: macos-11
-          # MacOS toolchain doesn't search /usr/local by default:
-          # https://gitlab.kitware.com/cmake/cmake/-/issues/19120
-          # The CMake FindPython module's Python::Python target (used in
-          # OpenAssetIO-Test-CMake) transitively adds linker flags to
-          # system libs, which fail due to this issue.
-          preamble: export LDFLAGS="-L/usr/local/lib"
           site-packages: lib/python3.9/site-packages
     defaults:
       run:

--- a/.github/workflows/upload-release-builds.yml
+++ b/.github/workflows/upload-release-builds.yml
@@ -41,21 +41,13 @@ jobs:
         - os: ubuntu-20.04
           shell: bash
           build-type: Release
-          # MacOS toolchain doesn't search /usr/local by default:
-          # https://gitlab.kitware.com/cmake/cmake/-/issues/19120
-          # The CMake FindPython module's Python::Python target (used
-          # via pybind11::embed in python-bridge-test) transitively adds
-          # linker flags to system libs, which fail due to this issue.
         - os: macos-11
-          preamble: export LDFLAGS="-L/usr/local/lib"
           shell: bash
           build-type: Debug
         - os: macos-11
-          preamble: export LDFLAGS="-L/usr/local/lib"
           shell: bash
           build-type: RelWithDebInfo
         - os: macos-11
-          preamble: export LDFLAGS="-L/usr/local/lib"
           shell: bash
           build-type: Release
     defaults:


### PR DESCRIPTION
## Description

Closes #1245. We removed the Conan `cpython` package dependency in #1038, meaning this preamble is no longer needed.

Removing this should enable yet further CI simplification, i.e. #1114.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~
