### PR TITLE
[CI] Platform-agnostic build/test

### DIFF
--- a/.github/bootstrap_platform/action.yml
+++ b/.github/bootstrap_platform/action.yml
@@ -22,15 +22,15 @@ runs:
     uses: actions/cache@v3
     with:
       path: ~/conan
-      key: ${{ matrix.config.os }}-conan-${{ github.run_id }}
-      restore-keys: ${{ matrix.config.os }}-conan-
+      key: ${{ matrix.os }}-conan-${{ github.run_id }}
+      restore-keys: ${{ matrix.os }}-conan-
 
   - name: Install dependencies (Unix)
     if: runner.os != 'Windows'
     # Configure the system and install library dependencies via conan
     # packages.
     run: |
-      source resources/build/bootstrap-${{ matrix.config.os }}.sh
+      source resources/build/bootstrap-${{ matrix.os }}.sh
     env:
       WORKSPACE: ${{ github.workspace }}
     # Annoyingly required for Github composite actions.
@@ -41,7 +41,7 @@ runs:
     # Configure the system and install library dependencies via conan
     # packages.
     run: |
-      cmd /C resources\build\bootstrap-${{ matrix.config.os }}.bat
+      cmd /C resources\build\bootstrap-${{ matrix.os }}.bat
     env:
       WORKSPACE: ${{ github.workspace }}
     # Annoyingly required for Github composite actions.

--- a/.github/workflows/build-instructions.yml
+++ b/.github/workflows/build-instructions.yml
@@ -29,7 +29,7 @@ jobs:
         docker run -v `pwd`:/src ghcr.io/openassetio/openassetio-build bash -c '
           cd /src && \
           cmake -S . -B build && \
-          cmake --build build && \
+          cmake --build build --parallel && \
           cmake --install build'
 
     - name: Build, install and test (Docker)

--- a/.github/workflows/build-vfx-reference-platform.yml
+++ b/.github/workflows/build-vfx-reference-platform.yml
@@ -40,7 +40,7 @@ jobs:
         cmake -G Ninja -S . -B build
         -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
-        cmake --build build
+        cmake --build build --parallel
 
         cmake --install build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,27 +18,21 @@ concurrency:
 
 jobs:
   build:
-    name: ${{ matrix.config.os }}
-    runs-on: ${{ matrix.config.os }}
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         # We can't properly align to the VFX Reference Platform as this
         # requires glibc 2.17, which is older than any of the available
         # environments.
-        config:
-        - os: windows-2019
-          preamble: call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64
-          shell: cmd
-        - os: ubuntu-20.04
-          shell: bash
-        - os: macos-11
-          shell: bash
+        os: [windows-2019, ubuntu-20.04, macos-11]
+
+    env:
+      BUILD_CONFIG: RelWithDebInfo
     defaults:
       run:
-        # Annoyingly required here since `matrix` isn't available in
-        # the `shell` property of individual steps.
-        shell: ${{ matrix.config.shell }}
+        shell: bash
 
     steps:
     - uses: actions/checkout@v4
@@ -49,33 +43,28 @@ jobs:
      # We don't want to publish the test build, it gets too big.
     - name: Build and Install (No tests)
       run: >
-        ${{ matrix.config.preamble }}
+        cmake -S . -B build
+        --install-prefix '${{ github.workspace }}/dist'
+        --toolchain '${{ github.workspace }}/.conan/conan_paths.cmake'
+        -DCMAKE_BUILD_TYPE=${{ env.BUILD_CONFIG }}
 
-        cmake -S . -B build -G Ninja
-        --install-prefix ${{ github.workspace }}/dist
-        --toolchain ${{ github.workspace }}/.conan/conan_paths.cmake
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        cmake --build build --parallel --config ${{ env.BUILD_CONFIG }}
 
-        cmake --build build
-
-        cmake --install build
+        cmake --install build --config ${{ env.BUILD_CONFIG }}
 
     - name: Upload archive
       uses: actions/upload-artifact@v3
       with:
-        name: openassetio-${{ matrix.config.os }}
+        name: openassetio-${{ matrix.os }}
         path: |
-          ${{ github.workspace }}/dist
+          '${{ github.workspace }}/dist'
 
     # Reconfigure to add the test target. Ctest should rebuild using
     # the cached build from prior.
     - name: Test
-      run: >
-        ${{ matrix.config.preamble }}
-
+      run: |
         cmake --preset test build
-
-        ctest -VV --test-dir build --parallel 2
+        ctest -VV --test-dir build --parallel 4 --build-config ${{ env.BUILD_CONFIG }}
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,12 +33,6 @@ jobs:
         - os: ubuntu-20.04
           shell: bash
         - os: macos-11
-          # MacOS toolchain doesn't search /usr/local by default:
-          # https://gitlab.kitware.com/cmake/cmake/-/issues/19120
-          # The CMake FindPython module's Python::Python target (used
-          # via pybind11::embed in python-bridge-test) transitively adds
-          # linker flags to system libs, which fail due to this issue.
-          preamble: export LDFLAGS="-L/usr/local/lib"
           shell: bash
     defaults:
       run:

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -115,12 +115,6 @@ jobs:
         - os: ubuntu-20.04
           site-packages: lib/python3.9/site-packages
         - os: macos-11
-          # MacOS toolchain doesn't search /usr/local by default:
-          # https://gitlab.kitware.com/cmake/cmake/-/issues/19120
-          # The CMake FindPython module's Python::Python target (used in
-          # OpenAssetIO-Test-CMake) transitively adds linker flags to
-          # system libs, which fail due to this issue.
-          preamble: export LDFLAGS="-L/usr/local/lib"
           site-packages: lib/python3.9/site-packages
     defaults:
       run:

--- a/.github/workflows/upload-release-builds.yml
+++ b/.github/workflows/upload-release-builds.yml
@@ -47,15 +47,12 @@ jobs:
           # via pybind11::embed in python-bridge-test) transitively adds
           # linker flags to system libs, which fail due to this issue.
         - os: macos-11
-          preamble: export LDFLAGS="-L/usr/local/lib"
           shell: bash
           build-type: Debug
         - os: macos-11
-          preamble: export LDFLAGS="-L/usr/local/lib"
           shell: bash
           build-type: RelWithDebInfo
         - os: macos-11
-          preamble: export LDFLAGS="-L/usr/local/lib"
           shell: bash
           build-type: Release
     defaults:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,7 @@ include(ThirdParty)
 # (default on Linux) is used, so we must shell out the install.
 
 add_custom_target(openassetio.internal.install
-    COMMAND "${CMAKE_COMMAND}" --build "${PROJECT_BINARY_DIR}" --target install)
+    COMMAND "${CMAKE_COMMAND}" --build "${PROJECT_BINARY_DIR}" --target install --config $<CONFIG>)
 
 
 #-----------------------------------------------------------------------

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -62,7 +62,8 @@ endfunction()
 function(openassetio_add_generic_test_target target_name)
     add_test(
         NAME ${target_name}
-        COMMAND ${CMAKE_COMMAND} --build "${PROJECT_BINARY_DIR}" --target ${target_name}
+        COMMAND ${CMAKE_COMMAND} --build "${PROJECT_BINARY_DIR}"
+        --target ${target_name} --config $<CONFIG>
     )
 endfunction()
 

--- a/src/openassetio-python/setup.py
+++ b/src/openassetio-python/setup.py
@@ -58,8 +58,8 @@ class build_ext(setuptools.command.build_ext.build_ext):
                 str(cmake_project_path),
                 "-B",
                 self.build_temp,
-                "-G",
-                "Ninja",
+                "--config",
+                "Release",
                 # Place output artifacts where setuptools expects.
                 "--install-prefix",
                 os.path.abspath(self.build_lib),
@@ -71,7 +71,17 @@ class build_ext(setuptools.command.build_ext.build_ext):
             ]
         )
 
-        self.__cmake(["--build", self.build_temp, "--target", "openassetio-python-module"])
+        self.__cmake(
+            [
+                "--build",
+                self.build_temp,
+                "--target",
+                "openassetio-python-module",
+                "--config",
+                "Release",
+                "--parallel"
+            ]
+        )
 
         self.__cmake(
             [
@@ -79,6 +89,8 @@ class build_ext(setuptools.command.build_ext.build_ext):
                 self.build_temp,
                 "--component",
                 "openassetio-python-module",
+                "--config",
+                "Release"
             ]
         )
 


### PR DESCRIPTION
## Description

Closes #1114. We spend too much time waiting for CI runs when we could
be doing more productive things. We should have an easy time of making
changes and reusing bits of CI across workflows/repos, so should
simplify it where possible.

So use the default generator for the platform and platform-agnostic
CMake command lines.

This also makes downstream adoption more natural, removing the
dependency on Ninja and the need for the `vcvarsall.bat` preamble, and
ensures our CI tests reflect the standard build configuration across
platforms.

Modernise to use parallel builds where possible, and use all available
cores on runners.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~

