### PR TITLE
[CI] Bump parallelism for ctests

### DIFF
--- a/.github/workflows/build-instructions.yml
+++ b/.github/workflows/build-instructions.yml
@@ -29,7 +29,7 @@ jobs:
         docker run -v `pwd`:/src ghcr.io/openassetio/openassetio-build bash -c '
           cd /src && \
           cmake -S . -B build && \
-          cmake --build build && \
+          cmake --build build --parallel && \
           cmake --install build'
 
     - name: Build, install and test (Docker)
@@ -37,7 +37,7 @@ jobs:
         docker run -v `pwd`:/src ghcr.io/openassetio/openassetio-build bash -c '
           cd /src && \
           cmake -S . -B build -DOPENASSETIO_ENABLE_TESTS=ON && \
-          ctest --test-dir build --output-on-failure'
+          ctest --test-dir build --output-on-failure --parallel 4'
 
   pip_install:
     name: Pip install on  ${{ matrix.config.os }}

--- a/.github/workflows/build-vfx-reference-platform.yml
+++ b/.github/workflows/build-vfx-reference-platform.yml
@@ -57,4 +57,4 @@ jobs:
 
         cmake --preset test build
 
-        ctest -VV --test-dir build --parallel 2
+        ctest -VV --test-dir build --parallel 4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
 
         cmake --preset test build
 
-        ctest -VV --test-dir build --parallel 2
+        ctest -VV --test-dir build --parallel 4
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Build and test
         run: |
           /usr/bin/ccache -s
-          ctest -VV --test-dir build --parallel 2
+          ctest -VV --test-dir build --parallel 4
           /usr/bin/ccache -s
         env:
           CCACHE_DIR: /tmp/ccache

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -189,7 +189,7 @@ jobs:
 
           cmake --build build --parallel --config RelWithDebInfo
 
-          ctest -VV --test-dir build --build-config RelWithDebInfo
+          ctest -VV --test-dir build --build-config RelWithDebInfo --parallel 4
         env:
           CMAKE_PREFIX_PATH: ${{ github.workspace }}/dist
           CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/.conan/conan_paths.cmake


### PR DESCRIPTION
## Description

GitHub runners currently provide 4 vCPUs, so we can reduce our CI wait times by bumping our `ctest` invocations to make use of the full number of processes.

Note that for builds where we use the Ninja generator, the builds are automatically parallel.

- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have updated all relevant user documentation.~~
