### PR TITLE
C++ plugin system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,8 @@
 # * FindPython's Development.Module component was added in 3.18, and
 #   pybind11 recommends 3.18.2+.
 # * PROJECT_IS_TOP_LEVEL requires 3.21+
-cmake_minimum_required(VERSION 3.21)
+# * $<INSTALL_PREFIX> usage in `install(CODE` requires 3.27+
+cmake_minimum_required(VERSION 3.27)
 
 # Additional include directories for CMake utils.
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,20 @@
 Release Notes
 =============
 
+v1.0.0-beta.x.y
+---------------
+
+### New Features
+
+- Added a C++ plugin system. In particular, hosts can use the
+  `CppPluginSystemManagerImplementationFactory` class (as a drop-in
+  replacement for `PythonPluginSystemManagerImplementationFactory`) in
+  order to load C++ manager plugins. Manager plugin authors provide
+  a shared library that exposes an `openassetioPlugin` function that
+  returns a `PluginFactory` function pointer, which in turn returns
+  a `CppPluginSystemManagerPlugin` object.
+  [#1115](https://github.com/OpenAssetIO/OpenAssetIO/issues/1115)
+
 v1.0.0-beta.2.1
 ---------------
 

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -76,6 +76,14 @@ openassetio_add_test_fixture_target(openassetio.internal.install)
 
 
 #-----------------------------------------------------------------------
+# Variables for use in tests.
+
+# Subdirectory under INSTALL_PREFIX where C++ test plugins will be
+# installed
+set(OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/plugins)
+
+
+#-----------------------------------------------------------------------
 # Python-specific helpers
 
 if (OPENASSETIO_ENABLE_PYTHON)
@@ -96,6 +104,12 @@ if (OPENASSETIO_ENABLE_PYTHON)
             openassetio_add_test_fixture_dependencies(${target_name} openassetio-python-venv)
         endif ()
     endfunction()
+
+    #-------------------------------------------------------------------
+    # Common environment variables for pytest tests.
+
+    set(_pytest_env
+        OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR=${OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR})
 
     #-------------------------------------------------------------------
     # Gather ASan-specific environment variables to prepend to the
@@ -126,7 +140,8 @@ if (OPENASSETIO_ENABLE_PYTHON)
         # memory allocator to use the C (or rather, ASan's) `malloc`
         # rather than the optimized `pymalloc`, so that ASan can
         # properly count memory (de)allocations.
-        set(_pytest_env PYTHONMALLOC=malloc LD_PRELOAD=${asan_path}:${_openassetio_path})
+        set(_pytest_env
+            PYTHONMALLOC=malloc LD_PRELOAD=${asan_path}:${_openassetio_path} ${_pytest_env})
     endif ()
 
 

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2013-2022 The Foundry Visionmongers Ltd
+# Copyright 2013-2024 The Foundry Visionmongers Ltd
 
 # Don't re-process this module if it's already included by a project.
 include_guard(GLOBAL)
@@ -137,20 +137,17 @@ if (OPENASSETIO_ENABLE_PYTHON)
     # (and is useful for debugging regardless).
     function(openassetio_add_pytest_target
         target_name description target_directory working_directory)
-
-        # Account for windows not being able to set variables inline
         if (WIN32)
             list(JOIN ARGN $<SEMICOLON> pythonpath)
-            set(combined_pytest_env set PYTHONPATH=${pythonpath} ${_pytest_env})
         else ()
             list(JOIN ARGN ":" pythonpath)
-            set(combined_pytest_env export PYTHONPATH=${pythonpath} ${_pytest_env})
         endif ()
+        set(pytest_env PYTHONPATH=${pythonpath} ${_pytest_env})
 
         add_custom_target(
             ${target_name}
-            COMMAND cmake -E echo -- ${description}
-            COMMAND ${combined_pytest_env} &&
+            COMMAND ${CMAKE_COMMAND} -E echo -- ${description}
+            COMMAND ${CMAKE_COMMAND} -E env ${pytest_env}
             ${OPENASSETIO_PYTHON_EXE} -m pytest -v --capture=tee-sys
             ${target_directory}
             WORKING_DIRECTORY "${working_directory}"

--- a/resources/build/Dockerfile
+++ b/resources/build/Dockerfile
@@ -74,6 +74,9 @@ COPY --from=openassetio-dependencies /usr/local/cmake/pcre2-config-version.cmake
 COPY --from=openassetio-dependencies /usr/local/lib64/cmake/trompeloeil /usr/local/lib64/cmake/trompeloeil
 COPY --from=openassetio-dependencies /usr/local/include/trompeloeil.hpp /usr/local/include/trompeloeil.hpp
 
+# Update CMake. See cmake_minimum_required in top-level CMakeLists.txt.
+RUN pip install cmake==3.28.3
+
 LABEL org.opencontainers.image.name="openassetio-build"
 LABEL org.opencontainers.image.title="OpenAssetIO VFX CY2022 Build Docker Image"
 LABEL org.opencontainers.image.description="Extends ASWF CY2022, adds OpenAssetIO dependencies"

--- a/resources/build/requirements.txt
+++ b/resources/build/requirements.txt
@@ -1,4 +1,4 @@
 conan==1.59.0
-cmake==3.21
+cmake==3.28.3
 ninja==1.10.2.3
 pip>=21.3

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -81,6 +81,8 @@ target_sources(
     src/managerApi/ManagerInterface.cpp
     src/managerApi/EntityReferencePagerInterface.cpp
     src/pluginSystem/CppPluginSystem.cpp
+    src/pluginSystem/CppPluginSystemManagerImplementationFactory.cpp
+    src/pluginSystem/CppPluginSystemManagerPlugin.cpp
     src/pluginSystem/CppPluginSystemPlugin.cpp
     src/trait/TraitsData.cpp
     src/utils/Regex.cpp

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -80,6 +80,8 @@ target_sources(
     src/managerApi/HostSession.cpp
     src/managerApi/ManagerInterface.cpp
     src/managerApi/EntityReferencePagerInterface.cpp
+    src/pluginSystem/CppPluginSystem.cpp
+    src/pluginSystem/CppPluginSystemPlugin.cpp
     src/trait/TraitsData.cpp
     src/utils/Regex.cpp
     src/utils/path.cpp
@@ -110,6 +112,8 @@ target_link_libraries(
     # (Static) private library dependencies
     ada::ada
     PCRE2::8BIT
+    # For dlopen et al.
+    ${CMAKE_DL_LIBS}
 )
 
 #-----------------------------------------------------------------------

--- a/src/openassetio-core/include/openassetio/hostApi/ManagerImplementationFactoryInterface.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/ManagerImplementationFactoryInterface.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2024 The Foundry Visionmongers Ltd
 #pragma once
 
 #include <memory>
@@ -45,7 +45,7 @@ class OPENASSETIO_CORE_EXPORT ManagerImplementationFactoryInterface {
    * Construct an instance of this class.
    *
    * @param logger Logger object that should be used for all logging
-   * by the factory. Obtainable in subclasses through @ref logger_.
+   * by the factory. Obtainable in subclasses through @ref logger.
    */
   explicit ManagerImplementationFactoryInterface(log::LoggerInterfacePtr logger);
 
@@ -72,11 +72,12 @@ class OPENASSETIO_CORE_EXPORT ManagerImplementationFactoryInterface {
       const Identifier& identifier) = 0;
 
  protected:
-  /// Logger instance that should be used for all logging.
-  // Allow violation of no protected members, since this is const and
-  // within an abstract interface.
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-  const log::LoggerInterfacePtr logger_;
+  /// Get logger instance.
+  [[nodiscard]] const log::LoggerInterfacePtr& logger() const;
+
+ private:
+  /// Logger instance that should be used for all logging
+  log::LoggerInterfacePtr logger_;
 };
 }  // namespace hostApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystem.hpp
+++ b/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystem.hpp
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#pragma once
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <openassetio/export.h>
+#include <openassetio/typedefs.hpp>
+
+OPENASSETIO_FWD_DECLARE(log, LoggerInterface)
+OPENASSETIO_FWD_DECLARE(pluginSystem, CppPluginSystemPlugin)
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace pluginSystem {
+
+OPENASSETIO_DECLARE_PTR(CppPluginSystem)
+
+/**
+ * Generic plugin system for C++ plugins.
+ *
+ * The API broadly mirrors the @ref pluginSystem.PythonPluginSystem
+ * "PythonPluginSystem".
+ *
+ * @see @ref scan
+ * @see @ref PluginFactory
+ * @see @ref CppPluginSystemPlugin
+ */
+class OPENASSETIO_CORE_EXPORT CppPluginSystem {
+ public:
+  OPENASSETIO_ALIAS_PTR(CppPluginSystem)
+  /// Pair of absolute path to plugin and shared_ptr to plugin instance.
+  using PathAndPlugin = std::pair<std::filesystem::path, CppPluginSystemPluginPtr>;
+
+  /**
+   * Constructs a new CppPluginSystem.
+   *
+   * @param logger Logger used to log progress and warnings. Note that
+   * most logs are at @ref log.LoggerInterface.Severity.kDebug "debug"
+   * severity.
+   *
+   * @return Newly constructed CppPluginSystem wrapped in a shared_ptr.
+   */
+  static CppPluginSystemPtr make(log::LoggerInterfacePtr logger);
+
+  /**
+   * Clear any previously loaded plugins.
+   *
+   * Note this does not unload/unlink any previously loaded binary
+   * shared libraries from the application.
+   */
+  void reset();
+
+  /**
+   * Searches the supplied paths for plugin modules.
+   *
+   * Paths are searched left-to-right, but only the first instance of
+   * any given plugin identifier will be used, and subsequent
+   * registrations ignored. This means entries to the left of the
+   * paths list take precedence over ones to the right.
+   *
+   * @note Precedence order is undefined for plugins sharing the
+   * same identifier within the same directory.
+   *
+   * Each given directory is scanned for shared libraries that expose an
+   * `openassetioPlugin` entry point function (with C linkage), which is
+   * expected to return a @ref PluginFactory function pointer, which
+   * when called returns an instantiated (subclass of) @ref
+   * CppPluginSystemPlugin.
+   *
+   * Discovered plugins are registered by their exposed identifier, and
+   * subsequent registrations with the same identifier will be skipped.
+   *
+   * No attempt is made to catch exceptions during static initialisation
+   * or during the call to the provided @ref PluginFactory, and any such
+   * exception will almost definitely terminate the process.
+   *
+   * @param paths A list of paths to search, delimited by operating
+   * system specific path separator (i.e. `:` for POSIX, `;` for
+   * Windows).
+   */
+  void scan(std::string_view paths);
+
+  /**
+   * Returns the identifiers known to the plugin system.
+   *
+   * If @ref scan has not been called, then this will be empty.
+   */
+  [[nodiscard]] openassetio::Identifiers identifiers() const;
+
+  /**
+   * Retrieves the plugin that provides the given identifier.
+   *
+   * @param identifier Identifier to look up.
+   *
+   * @return A pair of plugin path and instance.
+   *
+   * @exception errors.InputValidationException Raised if no plugin
+   * provides the specified identifier.
+   */
+  const PathAndPlugin& plugin(const openassetio::Identifier& identifier) const;
+
+ private:
+  /// Mapping of plugin identifier to file path and instance.
+  using PluginMap = std::unordered_map<openassetio::Identifier, PathAndPlugin>;
+  /// Optional pair of plugin identifier and instance.
+  using MaybeIdentifierAndPlugin =
+      std::optional<std::pair<openassetio::Identifier, CppPluginSystemPluginPtr>>;
+  /// Attempt to load a plugin at a given path, returning nullopt on
+  /// failure.
+  MaybeIdentifierAndPlugin maybeLoadPlugin(const std::filesystem::path& filePath);
+
+  /// Private constructor. See @ref make.
+  explicit CppPluginSystem(log::LoggerInterfacePtr logger);
+
+  /// Logger for logging progress, warnings and errors.
+  log::LoggerInterfacePtr logger_;
+  /// Map of discovered plugin identifiers to their file path and
+  /// instance.
+  PluginMap plugins_;
+};
+}  // namespace pluginSystem
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystemManagerImplementationFactory.hpp
+++ b/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystemManagerImplementationFactory.hpp
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#pragma once
+#include <filesystem>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+
+#include <openassetio/export.h>
+#include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
+#include <openassetio/typedefs.hpp>
+
+OPENASSETIO_FWD_DECLARE(managerApi, ManagerInterface)
+OPENASSETIO_FWD_DECLARE(pluginSystem, CppPluginSystemManagerPlugin)
+OPENASSETIO_FWD_DECLARE(pluginSystem, CppPluginSystem)
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace pluginSystem {
+
+OPENASSETIO_DECLARE_PTR(CppPluginSystemManagerImplementationFactory)
+
+/**
+ * A factory to manage @ref CppPluginSystemManagerPlugin derived
+ * plugins.
+ *
+ * This class is not usually used directly by a @ref host, which instead
+ * uses the @ref hostApi.ManagerFactory "ManagerFactory".
+ *
+ * The factory loads plugins found under paths specified in the
+ * `OPENASSETIO_PLUGIN_PATH` env var.
+ *
+ * @envvar **OPENASSETIO_PLUGIN_PATH** *str* A **PATH**-style list of
+ * directories to search for
+ * @fqref{pluginSystem.CppPluginSystemManagerPlugin}
+ * "CppPluginSystemManagerPlugin" based plugins. It uses the
+ * platform-native delimiter. Searched left to right. Note that this
+ * environment variable is also used by the @ref
+ * openassetio.pluginSystem.PythonPluginSystemManagerImplementationFactory
+ * "PythonPluginSystemManagerImplementationFactory".
+ *
+ * Plugins are scanned and loaded lazily when required. In particular,
+ * this means no plugin scanning is done on construction.
+ *
+ * @see CppPluginSystem
+ * @see CppPluginSystemManagerPlugin
+ */
+class OPENASSETIO_CORE_EXPORT CppPluginSystemManagerImplementationFactory
+    : public hostApi::ManagerImplementationFactoryInterface {
+ public:
+  OPENASSETIO_ALIAS_PTR(CppPluginSystemManagerImplementationFactory)
+
+  /// Environment variable to read the plugin search path from.
+  static constexpr std::string_view kPluginEnvVar = "OPENASSETIO_PLUGIN_PATH";
+
+  /**
+   * Construct a new instance.
+   *
+   * Plugin search path(s) will be taken from the @ref kPluginEnvVar
+   * environment variable.
+   *
+   * @param logger Logger for progress and warnings.
+   *
+   * @return New instance.
+   */
+  static CppPluginSystemManagerImplementationFactoryPtr make(log::LoggerInterfacePtr logger);
+
+  /**
+   * Construct a new instance.
+   *
+   * The @ref kPluginEnvVar environment variable will be ignored.
+   *
+   * @param paths Plugin search paths.
+   *
+   * @param logger Logger for progress and warnings.
+   *
+   * @return New instance.
+   */
+  static Ptr make(openassetio::Str paths, log::LoggerInterfacePtr logger);
+
+  /**
+   * Get a list of all manager plugin identifiers known to the factory.
+   *
+   * @return List of known manager plugin identifiers.
+   */
+  Identifiers identifiers() override;
+
+  /**
+   * Create an instance of the @fqref{managerApi.ManagerInterface}
+   * "ManagerInterface" with the specified identifier.
+   *
+   * @param identifier Identifier of the `ManagerInterface` to
+   * instantiate.
+   *
+   * @return Newly created interface.
+   *
+   * @throws InputValidationException if the requested identifier has
+   * not been registered as a manager plugin.
+   */
+  managerApi::ManagerInterfacePtr instantiate(const Identifier& identifier) override;
+
+ private:
+  /// Private constructor. See @ref make.
+  explicit CppPluginSystemManagerImplementationFactory(log::LoggerInterfacePtr logger);
+  /// Private constructor. See @ref make.
+  CppPluginSystemManagerImplementationFactory(openassetio::Str paths,
+                                              log::LoggerInterfacePtr logger);
+
+  /// Search paths provided on construction.
+  openassetio::Str paths_;
+
+  /**
+   * Underlying plugin system for loading generic OpenAssetIO plugins.
+   *
+   * Plugins reported by the plugin system are further filtered such
+   * that only those that expose a @ref CppPluginSystemManagerPlugin
+   * are considered.
+   */
+  CppPluginSystemPtr pluginSystem_;
+};
+}  // namespace pluginSystem
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystemManagerPlugin.hpp
+++ b/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystemManagerPlugin.hpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#pragma once
+
+#include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+#include <openassetio/typedefs.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace pluginSystem {
+
+OPENASSETIO_DECLARE_PTR(CppPluginSystemManagerPlugin)
+
+/**
+ * Base class to be subclassed by plugins binding a @ref host to an @ref
+ * asset_management_system.
+ *
+ * This is used by the dynamic plugin discovery mechanism to instantiate
+ * the @ref managerApi.ManagerInterface "ManagerInterface"
+ * implementation for the asset management system.
+ *
+ * Plugin authors must subclass this class and expose instances of it
+ * via a @ref PluginFactory function pointer, which is in turn exposed
+ * in the plugin binary by a top level C linkage `openassetioPlugin`
+ * function.
+ *
+ * @see CppPluginSystemManagerImplementationFactory
+ */
+class OPENASSETIO_CORE_EXPORT CppPluginSystemManagerPlugin : public CppPluginSystemPlugin {
+ public:
+  OPENASSETIO_ALIAS_PTR(CppPluginSystemManagerPlugin)
+
+  /// No-op destructor.
+  ~CppPluginSystemManagerPlugin() override;
+
+  /**
+   * Constructs an instance of the @ref managerApi.ManagerInterface
+   * "ManagerInterface".
+   *
+   * This is an instance of some class derived from ManagerInterface
+   * to be bound to the Host-facing @ref hostApi.Manager "Manager".
+   *
+   * Generally this is only directly called by the @ref
+   * pluginSystem.CppPluginSystemManagerImplementationFactory
+   * "CppPluginSystemManagerImplementationFactory".
+   *
+   * @return ManagerInterface instance
+   */
+  [[nodiscard]] virtual managerApi::ManagerInterfacePtr interface() = 0;
+};
+}  // namespace pluginSystem
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystemPlugin.hpp
+++ b/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystemPlugin.hpp
@@ -13,6 +13,8 @@ OPENASSETIO_DECLARE_PTR(CppPluginSystemPlugin)
 
 /**
  * The base class that defines a plugin of the C++ plugin system.
+ *
+ * @see CppPluginSystemManagerPlugin for a more concrete use case.
  */
 class OPENASSETIO_CORE_EXPORT CppPluginSystemPlugin {
  public:

--- a/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystemPlugin.hpp
+++ b/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystemPlugin.hpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#pragma once
+
+#include <openassetio/export.h>
+#include <openassetio/typedefs.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace pluginSystem {
+
+OPENASSETIO_DECLARE_PTR(CppPluginSystemPlugin)
+
+/**
+ * The base class that defines a plugin of the C++ plugin system.
+ */
+class OPENASSETIO_CORE_EXPORT CppPluginSystemPlugin {
+ public:
+  OPENASSETIO_ALIAS_PTR(CppPluginSystemPlugin)
+  /// No-op virtual destructor.
+  virtual ~CppPluginSystemPlugin();
+
+  /**
+   * Get the unique identifier of the plugin.
+   *
+   * The identifier should use only alpha-numeric characters and '.',
+   * '_' or '-'. For example:
+   *
+   *    "org.openassetio.test.manager"
+   *
+   * @return Plugin's unique identifier.
+   */
+  [[nodiscard]] virtual openassetio::Identifier identifier() const = 0;
+};
+
+/**
+ * Function pointer to a factory that produces instances of
+ * @ref CppPluginSystemPlugin wrapped in a shared_ptr.
+ *
+ * A pointer to such a function must be returned from an exposed
+ * `openassetioPlugin` entry point function (with C linkage) from a
+ * plugin shared library binary. This function pointer is then called to
+ * get the @ref CppPluginSystemPlugin instance.
+ *
+ * This two-step process is required to work around Windows disallowing
+ * C linkage functions from returning C++ types. That is, the
+ * `openassetioPlugin` entry point with C linkage returns a raw pointer
+ * (to a function). The returned PluginFactory function pointer can then
+ * point to a C++ linkage function, which is allowed to return a
+ * CppPluginSystemPluginPtr on Windows.
+ *
+ * Exception behaviour varies by platform for functions called via
+ * pointers retrieved in this way. In particular, the process is
+ * terminated with an "access violation" error on Windows. So for
+ * cross-platform consistency, the function is marked `noexcept` - it is
+ * not valid to throw an exception within a PluginFactory.
+ */
+using PluginFactory = openassetio::pluginSystem::CppPluginSystemPluginPtr (*)() noexcept;
+}  // namespace pluginSystem
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/hostApi/ManagerImplementationFactoryInterface.cpp
+++ b/src/openassetio-core/src/hostApi/ManagerImplementationFactoryInterface.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2024 The Foundry Visionmongers Ltd
 #include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
 
 namespace openassetio {
@@ -11,6 +11,10 @@ ManagerImplementationFactoryInterface::~ManagerImplementationFactoryInterface() 
 ManagerImplementationFactoryInterface::ManagerImplementationFactoryInterface(
     log::LoggerInterfacePtr logger)
     : logger_{std::move(logger)} {}
+
+const log::LoggerInterfacePtr& ManagerImplementationFactoryInterface::logger() const {
+  return logger_;
+}
 }  // namespace hostApi
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/src/pluginSystem/CppPluginSystem.cpp
+++ b/src/openassetio-core/src/pluginSystem/CppPluginSystem.cpp
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright Contributors to the OpenImageIO project.
+// Much of the cross-platform code below is taken and modified from the
+// OpenImageIO project.
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+#include <filesystem>
+
+#include <fmt/format.h>
+
+#include <openassetio/errors/exceptions.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/pluginSystem/CppPluginSystem.hpp>
+#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace pluginSystem {
+
+namespace {
+constexpr const char* kEntrypointFnName = "openassetioPlugin";
+
+#if defined(_WIN32)
+// Dummy values
+#define RTLD_LAZY 0
+#define RTLD_LOCAL 0
+
+/**
+ * Implement POSIX dlopen for Windows.
+ *
+ * For unicode support, using wchar_t / LoadLibraryW. Handily, on
+ * Windows std::filesystem::path::c_str returns a wchar_t*, so the
+ * divergence between POSIX/Windows dlopen and path::c_str marries up
+ * appropriately for the platform.
+ *
+ * Note that the second parameter, the RTLD_ mode, is ignored. Windows
+ * approximates RTLD_LOCAL.
+ */
+void* dlopen(const wchar_t* filename, [[maybe_unused]] int mode) { return LoadLibraryW(filename); }
+
+/**
+ * Implement POSIX dlclose for Windows.
+ */
+bool dlclose(void* handle) { return FreeLibrary(static_cast<HMODULE>(handle)) != 0; }
+
+/**
+ * Implement POSIX dlsym for Windows.
+ */
+void* dlsym(void* handle, const char* symbol) {
+  return static_cast<void*>(GetProcAddress(static_cast<HMODULE>(handle), symbol));
+}
+
+/**
+ * Implement POSIX dlerror for Windows.
+ *
+ * Diverge from POSIX by returning a std::string rather than char*, so
+ * we don't have to worry about keeping track of global state. Handlily,
+ * all our usages of dlerror can accept either a std::string or a char*
+ * so it works cross-platform.
+ */
+std::string dlerror() {
+  LPVOID lpMsgBuf{};
+  std::string win32Error;
+  if (FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                         FORMAT_MESSAGE_IGNORE_INSERTS,
+                     NULL, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                     (LPSTR)&lpMsgBuf, 0, NULL)) {
+    win32Error = (LPSTR)lpMsgBuf;
+  }
+  LocalFree(lpMsgBuf);
+  return win32Error;
+}
+#endif
+
+#if defined(_WIN32)
+// Shared module library file extension.
+constexpr std::string_view kLibExt = ".dll";
+// Path separator for encoding multiple search paths in a single string.
+constexpr char kPathSep = ';';
+#else
+// Shared module library file extension.
+constexpr std::string_view kLibExt = ".so";
+// Path separator for encoding multiple search paths in a single string.
+constexpr char kPathSep = ':';
+#endif
+}  // namespace
+
+CppPluginSystemPtr CppPluginSystem::make(log::LoggerInterfacePtr logger) {
+  return std::make_shared<CppPluginSystem>(CppPluginSystem{std::move(logger)});
+}
+
+void CppPluginSystem::reset() {
+  // Note: do not dlclose plugins - they may be in use.
+  plugins_.clear();
+}
+
+CppPluginSystem::CppPluginSystem(log::LoggerInterfacePtr logger) : logger_{std::move(logger)} {}
+
+void CppPluginSystem::scan(const std::string_view paths) {
+  std::size_t pathsStartIdx = 0;
+  std::size_t pathsEndIdx = 0;
+
+  // Loop through each path in ';'/:'-delimited paths string.
+  while ((pathsStartIdx = paths.find_first_not_of(kPathSep, pathsEndIdx)) != std::string::npos) {
+    pathsEndIdx = paths.find(kPathSep, pathsStartIdx);
+    const std::filesystem::path directoryPath =
+        paths.substr(pathsStartIdx, pathsEndIdx - pathsStartIdx);
+
+    // Check the provided path is actually a searchable directory.
+    if (!std::filesystem::is_directory(directoryPath)) {
+      logger_->debug(fmt::format("CppPluginSystem: Skipping as not a directory '{}'",
+                                 directoryPath.string()));
+      continue;
+    }
+
+    // Loop each item in the provided search path.
+    for (const std::filesystem::directory_entry& directoryEntry :
+         std::filesystem::directory_iterator{directoryPath}) {
+      std::filesystem::path filePath = directoryEntry.path();
+
+      // Assume the item in the search path is a plugin file and attempt
+      // to load it.
+      if (MaybeIdentifierAndPlugin idAndPlugin = maybeLoadPlugin(filePath)) {
+        logger_->debug(fmt::format("CppPluginSystem: Registered plug-in '{}' from '{}'",
+                                   idAndPlugin->first, filePath.string()));
+        // Register the successfully loaded plugin.
+        plugins_[std::move(idAndPlugin->first)] = {std::move(filePath),
+                                                   std::move(idAndPlugin->second)};
+      }
+    }
+  }
+}
+
+openassetio::Identifiers CppPluginSystem::identifiers() const {
+  openassetio::Identifiers result;
+  result.reserve(plugins_.size());
+  std::transform(begin(plugins_), end(plugins_), std::back_inserter(result),
+                 [](const auto& iter) { return iter.first; });
+  return result;
+}
+
+const CppPluginSystem::PathAndPlugin& CppPluginSystem::plugin(const Identifier& identifier) const {
+  const auto iter = plugins_.find(identifier);
+  if (iter == plugins_.end()) {
+    throw errors::InputValidationException{fmt::format(
+        "CppPluginSystem: No plug-in registered with the identifier '{}'", identifier)};
+  }
+
+  return iter->second;
+}
+
+CppPluginSystem::MaybeIdentifierAndPlugin CppPluginSystem::maybeLoadPlugin(
+    const std::filesystem::path& filePath) {
+  // Check the proposed path is actually a file.
+  if (!std::filesystem::is_regular_file(filePath)) {
+    logger_->debug(fmt::format("CppPluginSystem: Ignoring as it is not a library binary '{}'",
+                               filePath.string()));
+    return {};
+  }
+
+  // Check the proposed file name looks like a shared library.
+  if (filePath.extension() != kLibExt) {
+    logger_->debug(fmt::format("CppPluginSystem: Ignoring as it is not a library binary '{}'",
+                               filePath.string()));
+    return {};
+  }
+
+  // Open the binary.
+  //
+  // Use RTLD_LOCAL to avoid pollution of global namespace, and to
+  // better match Windows behaviour (which ignores the flags, see
+  // above).
+  //
+  // Note that this is considered a `noexcept` operation. On GCC it is
+  // hackily possible to catch exceptions at static initialization time,
+  // but is UB.
+  void* handle = dlopen(filePath.c_str(), RTLD_LAZY | RTLD_LOCAL);
+
+  if (!handle) {
+    logger_->debug(fmt::format("CppPluginSystem: Failed to open library '{}': {}",
+                               filePath.string(), dlerror()));
+    return {};
+  }
+
+  // Get the entrypoint function.
+  void* entrypoint = dlsym(handle, kEntrypointFnName);
+  if (!entrypoint) {
+    logger_->debug(fmt::format("CppPluginSystem: No top-level '{}' function in '{}': {}",
+                               kEntrypointFnName, filePath.string(), dlerror()));
+    dlclose(handle);
+    return {};
+  }
+
+  // Load the plugin object.
+  //
+  // Note that this is considered a `noexcept` operation. This is for
+  // the best cross-platform consistency. I.e. By default, POSIX can
+  // support exceptions from both the initial entrypoint function
+  // and from the PluginFactory function pointer. Windows
+  // cannot support exceptions (fatal "access violation") from either.
+
+  // The entry point function should be a no-argument function that
+  // returns a function pointer. I.e. a factory function for creating a
+  // PluginFactory.
+  const auto pluginFactoryFactory = reinterpret_cast<PluginFactory (*)()>(entrypoint);
+
+  // Calling the entry point function yields a PluginFactory function
+  // pointer. As noted above, this is a `noexcept` operation.
+  const PluginFactory pluginFactory = pluginFactoryFactory();
+
+  // Finally, we get the actual plugin object from the factory function
+  // pointer. Again, this is a `noexcept` operation.
+  CppPluginSystemPluginPtr plugin = pluginFactory();
+
+  // Check if the shared_ptr contains nullptr.
+  if (!plugin) {
+    logger_->warning(
+        fmt::format("CppPluginSystem: Null plugin returned by '{}'", filePath.string()));
+
+    dlclose(handle);
+    return {};
+  }
+
+  // Get plugin's unique identifier.
+  openassetio::Identifier identifier;
+  try {
+    identifier = plugin->identifier();
+  } catch (const std::exception& exc) {
+    logger_->warning(
+        fmt::format("CppPluginSystem: Caught exception calling 'identifier' of '{}': {}",
+                    filePath.string(), exc.what()));
+    plugin.reset();
+  } catch (...) {
+    logger_->warning(
+        fmt::format("CppPluginSystem: Caught exception calling 'identifier' of '{}':"
+                    " <unknown non-exception value caught>",
+                    filePath.string()));
+    plugin.reset();
+  }
+
+  // Unload the library if an exception was caught whilst retrieving the
+  // identifier.
+  //
+  // Must wait til after the try-catch to close handle, since exception
+  // object needs a chance to destruct whilst the plugin binary is still
+  // loaded.
+  if (!plugin) {
+    dlclose(handle);
+    return {};
+  }
+
+  // Ensure it's not already been registered.
+  if (const auto iter = plugins_.find(identifier); iter != plugins_.end()) {
+    logger_->debug(
+        fmt::format("CppPluginSystem: Skipping '{}' defined in '{}'. Already registered by '{}'",
+                    identifier, filePath.string(), iter->second.first.string()));
+    plugin.reset();  // Must destroy _before_ closing lib.
+    dlclose(handle);
+    return {};
+  }
+
+  return {{std::move(identifier), std::move(plugin)}};
+}
+}  // namespace pluginSystem
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/pluginSystem/CppPluginSystemManagerImplementationFactory.cpp
+++ b/src/openassetio-core/src/pluginSystem/CppPluginSystemManagerImplementationFactory.cpp
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <openassetio/pluginSystem/CppPluginSystemManagerImplementationFactory.hpp>
+
+#include <cstdlib>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+
+#include <fmt/format.h>
+
+#include <openassetio/errors/exceptions.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/pluginSystem/CppPluginSystem.hpp>
+#include <openassetio/pluginSystem/CppPluginSystemManagerPlugin.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace pluginSystem {
+
+CppPluginSystemManagerImplementationFactoryPtr CppPluginSystemManagerImplementationFactory::make(
+    openassetio::Str paths, log::LoggerInterfacePtr logger) {
+  return std::make_shared<CppPluginSystemManagerImplementationFactory>(
+      CppPluginSystemManagerImplementationFactory{std::move(paths), std::move(logger)});
+}
+
+CppPluginSystemManagerImplementationFactoryPtr CppPluginSystemManagerImplementationFactory::make(
+    log::LoggerInterfacePtr logger) {
+  return std::make_shared<CppPluginSystemManagerImplementationFactory>(
+      CppPluginSystemManagerImplementationFactory{std::move(logger)});
+}
+
+CppPluginSystemManagerImplementationFactory::CppPluginSystemManagerImplementationFactory(
+    openassetio::Str paths, log::LoggerInterfacePtr logger)
+    : ManagerImplementationFactoryInterface{std::move(logger)}, paths_{std::move(paths)} {
+  if (paths_.empty()) {
+    this->logger()->log(
+        log::LoggerInterface::Severity::kWarning,
+        fmt::format("No search paths specified, no plugins will load - check ${} is set",
+                    kPluginEnvVar));
+  }
+}
+
+CppPluginSystemManagerImplementationFactory::CppPluginSystemManagerImplementationFactory(
+    log::LoggerInterfacePtr logger)
+    : CppPluginSystemManagerImplementationFactory{
+          // getenv returns nullptr if var not set, which cannot be
+          // used to construct a std::string.
+          [paths = std::getenv(kPluginEnvVar.data())] { return paths ? paths : ""; }(),
+          std::move(logger)} {}
+
+Identifiers CppPluginSystemManagerImplementationFactory::identifiers() {
+  if (!pluginSystem_) {
+    // Lazy load plugins.
+    pluginSystem_ = CppPluginSystem::make(logger());
+    pluginSystem_->scan(paths_);
+  }
+
+  // Get all OpenAssetIO plugins, whether manager plugins or otherwise.
+  openassetio::Identifiers pluginIds = pluginSystem_->identifiers();
+
+  // Filter plugins to only those that are manager plugins.
+  pluginIds.erase(
+      std::remove_if(
+          begin(pluginIds), end(pluginIds),
+          [&](const auto& identifier) {
+            const auto& [path, plugin] = pluginSystem_->plugin(identifier);
+
+            auto managerPlugin = std::dynamic_pointer_cast<CppPluginSystemManagerPlugin>(plugin);
+
+            if (!managerPlugin) {
+              logger()->log(
+                  log::LoggerInterface::Severity::kWarning,
+                  fmt::format(
+                      "Plugin '{}' from '{}' is not a manager plugin as it cannot be cast to a"
+                      " CppPluginSystemManagerPlugin",
+                      identifier, path.string()));
+            }
+
+            return !managerPlugin;
+          }),
+      end(pluginIds));
+  return pluginIds;
+}
+
+managerApi::ManagerInterfacePtr CppPluginSystemManagerImplementationFactory::instantiate(
+    const Identifier& identifier) {
+  if (!pluginSystem_) {
+    // Lazy load plugins.
+    pluginSystem_ = CppPluginSystem::make(logger());
+    pluginSystem_->scan(paths_);
+  }
+  const auto& [path, plugin] = pluginSystem_->plugin(identifier);
+
+  auto managerPlugin = std::dynamic_pointer_cast<CppPluginSystemManagerPlugin>(plugin);
+
+  if (!managerPlugin) {
+    throw errors::InputValidationException{
+        fmt::format("Plugin '{}' from '{}' is not a manager plugin as it cannot be cast to a"
+                    " CppPluginSystemManagerPlugin",
+                    identifier, path.string())};
+  }
+
+  return managerPlugin->interface();
+}
+}  // namespace pluginSystem
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/pluginSystem/CppPluginSystemManagerPlugin.cpp
+++ b/src/openassetio-core/src/pluginSystem/CppPluginSystemManagerPlugin.cpp
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <openassetio/pluginSystem/CppPluginSystemManagerPlugin.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace pluginSystem {
+// Define destructor in .cpp to avoid undefined reference errors when
+// dynamic loading on Windows.
+CppPluginSystemManagerPlugin::~CppPluginSystemManagerPlugin() = default;
+}  // namespace pluginSystem
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/pluginSystem/CppPluginSystemPlugin.cpp
+++ b/src/openassetio-core/src/pluginSystem/CppPluginSystemPlugin.cpp
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace pluginSystem {
+// Define destructor in .cpp to avoid undefined reference errors when
+// dynamic loading on Windows.
+CppPluginSystemPlugin::~CppPluginSystemPlugin() = default;
+}  // namespace pluginSystem
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/tests/CMakeLists.txt
+++ b/src/openassetio-core/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022-2024 The Foundry Visionmongers Ltd
+
 #-----------------------------------------------------------------------
 # C++ API test target
 
@@ -122,3 +125,9 @@ openassetio_add_test_fixture_dependencies(
     openassetio.internal.core-cpp-internal-test
     openassetio.internal.install
 )
+
+
+#-----------------------------------------------------------------------
+# Test resources
+
+add_subdirectory(pluginSystem/resources/plugins)

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/CMakeLists.txt
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/CMakeLists.txt
@@ -1,0 +1,22 @@
+#-----------------------------------------------------------------------
+# Common test plugin helpers
+
+# Function to make installed library file name simpler and more
+# predictable cross-platform.
+function(openassetio_simplify_lib_name target_name lib_name)
+    set_target_properties(
+        ${target_name}
+        PROPERTIES
+        OUTPUT_NAME ${lib_name}
+        PREFIX ""
+        SOVERSION ""
+        VERSION ""
+    )
+endfunction()
+
+
+#-----------------------------------------------------------------------
+# Plugin sets to build/install for tests.
+
+add_subdirectory(working)
+add_subdirectory(broken)

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/broken/CMakeLists.txt
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/broken/CMakeLists.txt
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 The Foundry Visionmongers Ltd
+
+include(GenerateExportHeader)
+#-----------------------------------------------------------------------
+# A non-library file with a non-library extension.
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/not-a-lib.txt "Not a lib")
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/not-a-lib.txt
+    DESTINATION ${OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR}/broken
+)
+
+#-----------------------------------------------------------------------
+# A non-library file masquerading as a library.
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/fake-lib${CMAKE_SHARED_MODULE_SUFFIX} "Fake lib")
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/fake-lib${CMAKE_SHARED_MODULE_SUFFIX}
+    DESTINATION ${OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR}/broken
+)
+
+#-----------------------------------------------------------------------
+# A directory (i.e. std::filesystem::is_regular_file is false).
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/a-directory${CMAKE_SHARED_MODULE_SUFFIX})
+install(
+    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/a-directory${CMAKE_SHARED_MODULE_SUFFIX}
+    DESTINATION ${OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR}/broken
+)
+
+#-----------------------------------------------------------------------
+# A library that doesn't expose the required entrypoint.
+
+add_library(openassetio-core-pluginSystem-test-nonplugin MODULE nonPlugin.cpp)
+openassetio_set_default_target_properties(openassetio-core-pluginSystem-test-nonplugin)
+openassetio_simplify_lib_name(openassetio-core-pluginSystem-test-nonplugin nonplugin)
+install(
+    TARGETS openassetio-core-pluginSystem-test-nonplugin
+    EXPORT ${PROJECT_NAME}_EXPORTED_TARGETS
+    DESTINATION ${OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR}/broken
+)
+
+#-----------------------------------------------------------------------
+# Broken plugins
+
+# Create a test plugin..
+function(openassetio_test_pluginSystem_generate_broken_plugin target_suffix src_file)
+
+    #-------------------------------------------------------------------
+    # Create plugin
+
+    add_library(openassetio-core-pluginSystem-test-broken-${target_suffix} MODULE)
+    openassetio_set_default_target_properties(
+        openassetio-core-pluginSystem-test-broken-${target_suffix})
+    openassetio_simplify_lib_name(
+        openassetio-core-pluginSystem-test-broken-${target_suffix} ${target_suffix})
+    # Add to the set of installable targets.
+    install(
+        TARGETS openassetio-core-pluginSystem-test-broken-${target_suffix}
+        EXPORT ${PROJECT_NAME}_EXPORTED_TARGETS
+        DESTINATION ${OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR}/broken
+    )
+
+    #-------------------------------------------------------------------
+    # Target dependencies
+
+    target_sources(
+        openassetio-core-pluginSystem-test-broken-${target_suffix}
+        PRIVATE
+        ${src_file}
+    )
+
+    target_link_libraries(
+        openassetio-core-pluginSystem-test-broken-${target_suffix}
+        PRIVATE
+        # Core library
+        openassetio-core
+    )
+
+    target_include_directories(
+        openassetio-core-pluginSystem-test-broken-${target_suffix}
+        PRIVATE
+        # For export header
+        ${CMAKE_CURRENT_BINARY_DIR}/${target_suffix}/include
+    )
+
+    #-------------------------------------------------------------------
+    # API export header
+
+    generate_export_header(
+        openassetio-core-pluginSystem-test-broken-${target_suffix}
+        EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/${target_suffix}/include/export.h
+        EXPORT_MACRO_NAME OPENASSETIO_CORE_PLUGINSYSTEM_TEST_EXPORT
+    )
+
+endfunction()
+
+# A plugin that returns a `nullptr` from the factory function.
+openassetio_test_pluginSystem_generate_broken_plugin(factory-return-null factoryReturnNull.cpp)
+# A plugin that throws a std::exception in the plugin's `identifier`
+# function.
+openassetio_test_pluginSystem_generate_broken_plugin(
+    identifier-throw-exception identifierThrowException.cpp)
+# A plugin that throws a non-std::exception in the plugin's `identifier`
+# function.
+openassetio_test_pluginSystem_generate_broken_plugin(
+    identifier-throw-nonexception identifierThrowNonException.cpp)

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/broken/factoryReturnNull.cpp
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/broken/factoryReturnNull.cpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <export.h>
+#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+
+extern "C" {
+OPENASSETIO_CORE_PLUGINSYSTEM_TEST_EXPORT
+openassetio::pluginSystem::PluginFactory openassetioPlugin() noexcept {
+  return []() noexcept -> openassetio::pluginSystem::CppPluginSystemPluginPtr { return nullptr; };
+}
+}

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/broken/identifierThrowException.cpp
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/broken/identifierThrowException.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <export.h>
+#include <openassetio/errors/exceptions.hpp>
+#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+
+class ThrowingPlugin : public openassetio::pluginSystem::CppPluginSystemPlugin {
+ public:
+  [[nodiscard]] openassetio::Str identifier() const override {
+    throw openassetio::errors::NotImplementedException{"Thrown from identifier"};
+  }
+};
+
+extern "C" {
+OPENASSETIO_CORE_PLUGINSYSTEM_TEST_EXPORT
+openassetio::pluginSystem::PluginFactory openassetioPlugin() noexcept {
+  return []() noexcept -> openassetio::pluginSystem::CppPluginSystemPluginPtr {
+    return std::make_shared<ThrowingPlugin>();
+  };
+}
+}

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/broken/identifierThrowNonException.cpp
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/broken/identifierThrowNonException.cpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <export.h>
+#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+
+class ThrowingPlugin : public openassetio::pluginSystem::CppPluginSystemPlugin {
+  [[nodiscard]] openassetio::Str identifier() const override { throw 0; }
+};
+
+extern "C" {
+OPENASSETIO_CORE_PLUGINSYSTEM_TEST_EXPORT
+openassetio::pluginSystem::PluginFactory openassetioPlugin() noexcept {
+  return []() noexcept -> openassetio::pluginSystem::CppPluginSystemPluginPtr {
+    return std::make_shared<ThrowingPlugin>();
+  };
+}
+}

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/broken/nonPlugin.cpp
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/broken/nonPlugin.cpp
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/working/CMakeLists.txt
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/working/CMakeLists.txt
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 The Foundry Visionmongers Ltd
+
+#-----------------------------------------------------------------------
+# Test Plugins
+
+# Create a test plugin with a particular path and id suffix.
+function(openassetio_test_pluginSystem_generate_plugin path_suffix id_suffix src_file)
+
+    #-------------------------------------------------------------------
+    # Create plugin
+
+    add_library(openassetio-core-pluginSystem-test-${path_suffix} MODULE)
+    openassetio_set_default_target_properties(openassetio-core-pluginSystem-test-${path_suffix})
+    openassetio_simplify_lib_name(openassetio-core-pluginSystem-test-${path_suffix} ${path_suffix})
+    # Add to the set of installable targets.
+    install(
+        TARGETS openassetio-core-pluginSystem-test-${path_suffix}
+        EXPORT ${PROJECT_NAME}_EXPORTED_TARGETS
+        DESTINATION ${OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR}/${path_suffix}
+    )
+
+    #-------------------------------------------------------------------
+    # Plugin identification
+
+    target_compile_definitions(
+        openassetio-core-pluginSystem-test-${path_suffix}
+        PRIVATE
+        # Suffix for plugin path
+        OPENASSETIO_CORE_PLUGINSYSTEM_TEST_PLUGIN_PATH_SUFFIX="${path_suffix}"
+        # Suffix for plugin identifier
+        OPENASSETIO_CORE_PLUGINSYSTEM_TEST_PLUGIN_ID_SUFFIX="${id_suffix}"
+    )
+
+    #-------------------------------------------------------------------
+    # Target dependencies
+
+    target_sources(
+        openassetio-core-pluginSystem-test-${path_suffix}
+        PRIVATE
+        ${src_file}
+    )
+
+    target_link_libraries(
+        openassetio-core-pluginSystem-test-${path_suffix}
+        PRIVATE
+        # Core library
+        openassetio-core
+    )
+
+    target_include_directories(
+        openassetio-core-pluginSystem-test-${path_suffix}
+        PRIVATE
+        # For export header
+        ${CMAKE_CURRENT_BINARY_DIR}/${path_suffix}/include
+    )
+
+    #-------------------------------------------------------------------
+    # API export header
+
+    include(GenerateExportHeader)
+    generate_export_header(
+        openassetio-core-pluginSystem-test-${path_suffix}
+        EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/${path_suffix}/include/export.h
+        EXPORT_MACRO_NAME OPENASSETIO_CORE_PLUGINSYSTEM_TEST_EXPORT
+    )
+
+endfunction()
+
+# Plugins for testing the CppPluginSystem
+#
+# Path/ID chosen to mirror Python plugin system test plugins.
+openassetio_test_pluginSystem_generate_plugin(pathA pluginA genericPlugin.cpp)
+openassetio_test_pluginSystem_generate_plugin(pathB pluginB genericPlugin.cpp)
+openassetio_test_pluginSystem_generate_plugin(pathC pluginA genericPlugin.cpp)
+
+if (OPENASSETIO_ENABLE_PYTHON)
+    # Plugin for testing the Python GIL is released
+    openassetio_test_pluginSystem_generate_plugin(
+        python-gil-check python-gil-check pythonGilCheckGenericPlugin.cpp)
+    target_link_libraries(
+        openassetio-core-pluginSystem-test-python-gil-check
+        PRIVATE
+        $<BUILD_INTERFACE:pybind11::module>
+    )
+endif ()
+
+
+#-----------------------------------------------------------------------
+# Create symlinks in install tree for symlink plugin loading test.
+#
+# See Test_CppPluginSystem_scan
+# test_when_path_contains_symlinks_then_plugins_are_loaded
+
+# cmake-lint: disable=C0301
+install(CODE "
+    file(
+        CREATE_LINK
+        \"$<INSTALL_PREFIX>/${OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR}/pathA\"
+        \"$<INSTALL_PREFIX>/${OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR}/pathASymlink\"
+        SYMBOLIC
+    )
+
+    file(MAKE_DIRECTORY \"$<INSTALL_PREFIX>/${OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR}/symlinkPath\")
+    file(
+        CREATE_LINK
+        \"$<INSTALL_PREFIX>/${OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR}/pathA/$<TARGET_FILE_NAME:openassetio-core-pluginSystem-test-pathA>\"
+        \"$<INSTALL_PREFIX>/${OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR}/symlinkPath/$<TARGET_FILE_NAME:openassetio-core-pluginSystem-test-pathA>\"
+        SYMBOLIC
+    )
+    file(
+        CREATE_LINK
+        \"$<INSTALL_PREFIX>/${OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR}/pathB/$<TARGET_FILE_NAME:openassetio-core-pluginSystem-test-pathB>\"
+        \"$<INSTALL_PREFIX>/${OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR}/symlinkPath/$<TARGET_FILE_NAME:openassetio-core-pluginSystem-test-pathB>\"
+        SYMBOLIC
+    )
+")

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/working/CMakeLists.txt
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/working/CMakeLists.txt
@@ -77,13 +77,17 @@ openassetio_test_pluginSystem_generate_plugin(pathC pluginA genericPlugin.cpp)
 if (OPENASSETIO_ENABLE_PYTHON)
     # Plugin for testing the Python GIL is released
     openassetio_test_pluginSystem_generate_plugin(
-        python-gil-check python-gil-check pythonGilCheckGenericPlugin.cpp)
+        python-gil-check python-gil-check pythonGilCheckManagerPlugin.cpp)
     target_link_libraries(
         openassetio-core-pluginSystem-test-python-gil-check
         PRIVATE
         $<BUILD_INTERFACE:pybind11::module>
     )
 endif ()
+
+# Plugins for testing the CppPluginSystemManagerImplementationFactory.
+openassetio_test_pluginSystem_generate_plugin(managerA pluginA managerPlugin.cpp)
+openassetio_test_pluginSystem_generate_plugin(managerB pluginB managerPlugin.cpp)
 
 
 #-----------------------------------------------------------------------

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/working/StubManagerInterface.hpp
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/working/StubManagerInterface.hpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#pragma once
+
+#include <openassetio/errors/exceptions.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
+
+struct StubManagerInterface : openassetio::managerApi::ManagerInterface {
+  [[nodiscard]] openassetio::Identifier identifier() const override {
+    return "org.openassetio.test.pluginSystem."
+           "resources." OPENASSETIO_CORE_PLUGINSYSTEM_TEST_PLUGIN_ID_SUFFIX;
+  }
+
+  [[nodiscard]] openassetio::Str displayName() const override {
+    return OPENASSETIO_CORE_PLUGINSYSTEM_TEST_PLUGIN_ID_SUFFIX;
+  }
+
+  bool hasCapability([[maybe_unused]] Capability capability) override { return false; }
+
+  // Deliberately throw an exception, for use in checking RTTI.
+  openassetio::InfoDictionary info() override {
+    throw openassetio::errors::NotImplementedException{"Stub doesn't support info"};
+  }
+};

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/working/genericPlugin.cpp
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/working/genericPlugin.cpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+// #include <openassetio_test/export.h>
+#include <memory>
+
+#include <export.h>
+
+#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+
+struct Plugin : openassetio::pluginSystem::CppPluginSystemPlugin {
+  [[nodiscard]] openassetio::Str identifier() const override {
+    return "org.openassetio.test.pluginSystem."
+           "resources." OPENASSETIO_CORE_PLUGINSYSTEM_TEST_PLUGIN_ID_SUFFIX;
+  }
+};
+
+extern "C" {
+
+OPENASSETIO_CORE_PLUGINSYSTEM_TEST_EXPORT
+openassetio::pluginSystem::PluginFactory openassetioPlugin() noexcept {
+  return []() noexcept -> openassetio::pluginSystem::CppPluginSystemPluginPtr {
+    return std::make_shared<Plugin>();
+  };
+}
+}

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/working/managerPlugin.cpp
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/working/managerPlugin.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <memory>
+
+#include <export.h>
+
+#include <openassetio/pluginSystem/CppPluginSystemManagerPlugin.hpp>
+
+#include "StubManagerInterface.hpp"
+
+struct Plugin : openassetio::pluginSystem::CppPluginSystemManagerPlugin {
+  [[nodiscard]] openassetio::Identifier identifier() const override {
+    return "org.openassetio.test.pluginSystem."
+           "resources." OPENASSETIO_CORE_PLUGINSYSTEM_TEST_PLUGIN_ID_SUFFIX;
+  }
+  openassetio::managerApi::ManagerInterfacePtr interface() override {
+    return std::make_shared<StubManagerInterface>();
+  }
+};
+
+extern "C" {
+
+OPENASSETIO_CORE_PLUGINSYSTEM_TEST_EXPORT
+openassetio::pluginSystem::PluginFactory openassetioPlugin() noexcept {
+  return []() noexcept -> openassetio::pluginSystem::CppPluginSystemPluginPtr {
+    return std::make_shared<Plugin>();
+  };
+}
+}

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/working/pythonGilCheckGenericPlugin.cpp
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/working/pythonGilCheckGenericPlugin.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <memory>
+
+#include <export.h>
+
+#include <Python.h>
+
+#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+
+struct Plugin : openassetio::pluginSystem::CppPluginSystemPlugin {
+  [[nodiscard]] openassetio::Str identifier() const override {
+    if (PyGILState_Check()) {
+      throw std::runtime_error{"GIL was not released when identifying C++ plugin"};
+    }
+    return "org.openassetio.test.pluginSystem."
+           "resources." OPENASSETIO_CORE_PLUGINSYSTEM_TEST_PLUGIN_ID_SUFFIX;
+  }
+};
+
+extern "C" {
+
+OPENASSETIO_CORE_PLUGINSYSTEM_TEST_EXPORT
+openassetio::pluginSystem::PluginFactory openassetioPlugin() noexcept {
+  return []() noexcept -> openassetio::pluginSystem::CppPluginSystemPluginPtr {
+    return std::make_shared<Plugin>();
+  };
+}
+}

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/working/pythonGilCheckManagerPlugin.cpp
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/working/pythonGilCheckManagerPlugin.cpp
@@ -6,15 +6,23 @@
 
 #include <Python.h>
 
-#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+#include <openassetio/pluginSystem/CppPluginSystemManagerPlugin.hpp>
 
-struct Plugin : openassetio::pluginSystem::CppPluginSystemPlugin {
+#include "StubManagerInterface.hpp"
+
+struct Plugin : openassetio::pluginSystem::CppPluginSystemManagerPlugin {
   [[nodiscard]] openassetio::Str identifier() const override {
     if (PyGILState_Check()) {
       throw std::runtime_error{"GIL was not released when identifying C++ plugin"};
     }
     return "org.openassetio.test.pluginSystem."
            "resources." OPENASSETIO_CORE_PLUGINSYSTEM_TEST_PLUGIN_ID_SUFFIX;
+  }
+  openassetio::managerApi::ManagerInterfacePtr interface() override {
+    if (PyGILState_Check()) {
+      throw std::runtime_error{"GIL was not released when instantiating manager from C++ plugin"};
+    }
+    return std::make_shared<StubManagerInterface>();
   }
 };
 

--- a/src/openassetio-python/cmodule/CMakeLists.txt
+++ b/src/openassetio-python/cmodule/CMakeLists.txt
@@ -62,6 +62,8 @@ target_sources(
     src/managerApi/EntityReferencePagerInterfaceBinding.cpp
     src/managerApi/ManagerInterfaceBinding.cpp
     src/managerApi/ManagerStateBaseBinding.cpp
+    src/pluginSystem/CppPluginSystemBinding.cpp
+    src/pluginSystem/CppPluginSystemPluginBinding.cpp
     src/trait/TraitsDataBinding.cpp
     src/utilsBinding.cpp
 )

--- a/src/openassetio-python/cmodule/CMakeLists.txt
+++ b/src/openassetio-python/cmodule/CMakeLists.txt
@@ -64,6 +64,7 @@ target_sources(
     src/managerApi/ManagerStateBaseBinding.cpp
     src/pluginSystem/CppPluginSystemBinding.cpp
     src/pluginSystem/CppPluginSystemPluginBinding.cpp
+    src/pluginSystem/CppPluginSystemManagerImplementationFactoryBinding.cpp
     src/trait/TraitsDataBinding.cpp
     src/utilsBinding.cpp
 )

--- a/src/openassetio-python/cmodule/src/_openassetio.cpp
+++ b/src/openassetio-python/cmodule/src/_openassetio.cpp
@@ -28,6 +28,7 @@ PYBIND11_MODULE(_openassetio, mod) {
   const py::module errors = mod.def_submodule("errors");
   const py::module trait = mod.def_submodule("trait");
   py::module utils = mod.def_submodule("utils");
+  const py::module pluginSystem = mod.def_submodule("pluginSystem");
 
   registerVersion(mod);
   registerAccess(access);
@@ -51,6 +52,8 @@ PYBIND11_MODULE(_openassetio, mod) {
   registerManager(hostApi);
   registerManagerFactory(hostApi);
   registerUtils(utils);
+  registerCppPluginSystemPlugin(pluginSystem);
+  registerCppPluginSystem(pluginSystem);
 
 #ifdef OPENASSETIO_ENABLE_TESTS
   registerTestUtils(mod);

--- a/src/openassetio-python/cmodule/src/_openassetio.cpp
+++ b/src/openassetio-python/cmodule/src/_openassetio.cpp
@@ -54,6 +54,7 @@ PYBIND11_MODULE(_openassetio, mod) {
   registerUtils(utils);
   registerCppPluginSystemPlugin(pluginSystem);
   registerCppPluginSystem(pluginSystem);
+  registerCppPluginSystemManagerImplementationFactory(pluginSystem);
 
 #ifdef OPENASSETIO_ENABLE_TESTS
   registerTestUtils(mod);

--- a/src/openassetio-python/cmodule/src/_openassetio.hpp
+++ b/src/openassetio-python/cmodule/src/_openassetio.hpp
@@ -114,3 +114,6 @@ void registerCppPluginSystemPlugin(const py::module& mod);
 
 // Register the C++ plugin system
 void registerCppPluginSystem(const py::module& mod);
+
+// Register the C++ plugin system manager factory
+void registerCppPluginSystemManagerImplementationFactory(const py::module& mod);

--- a/src/openassetio-python/cmodule/src/_openassetio.hpp
+++ b/src/openassetio-python/cmodule/src/_openassetio.hpp
@@ -108,3 +108,9 @@ void registerEntityReferencePagerInterface(const py::module& mod);
 
 /// Register the utils namespace with Python.
 void registerUtils(py::module& mod);
+
+// Register the C++ plugin system plugin
+void registerCppPluginSystemPlugin(const py::module& mod);
+
+// Register the C++ plugin system
+void registerCppPluginSystem(const py::module& mod);

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerImplementationFactoryInterfaceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerImplementationFactoryInterfaceBinding.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2024 The Foundry Visionmongers Ltd
 #include <pybind11/stl.h>
 
 #include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
@@ -35,7 +35,7 @@ struct PyManagerImplementationFactoryInterface : ManagerImplementationFactoryInt
                                        identifier);
   }
 
-  using ManagerImplementationFactoryInterface::logger_;
+  using ManagerImplementationFactoryInterface::logger;
 };
 
 }  // namespace hostApi
@@ -57,5 +57,5 @@ void registerManagerImplementationFactoryInterface(const py::module& mod) {
            py::call_guard<py::gil_scoped_release>{})
       .def("instantiate", &ManagerImplementationFactoryInterface::instantiate,
            py::arg("identifier"), py::call_guard<py::gil_scoped_release>{})
-      .def_readonly("_logger", &PyManagerImplementationFactoryInterface::logger_);
+      .def_property_readonly("_logger", &PyManagerImplementationFactoryInterface::logger);
 }

--- a/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemBinding.cpp
+++ b/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemBinding.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl/filesystem.h>
+
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/pluginSystem/CppPluginSystem.hpp>
+#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+
+#include "../_openassetio.hpp"
+
+void registerCppPluginSystem(const py::module_ &mod) {
+  using openassetio::pluginSystem::CppPluginSystem;
+
+  // Only bother releasing the GIL for `scan`, since that's the only
+  // method that potentially calls out to virtual method(s). Tests will
+  // catch if this changes (e.g. if we add logger calls in the other
+  // methods).
+
+  py::class_<CppPluginSystem, CppPluginSystem::Ptr>(mod, "CppPluginSystem")
+      .def(py::init(RetainCommonPyArgs::forFn<&CppPluginSystem::make>()),
+           py::arg("logger").none(false))
+      .def("reset", &CppPluginSystem::reset)
+      .def("scan", &CppPluginSystem::scan, py::arg("paths"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("identifiers", &CppPluginSystem::identifiers)
+      .def("plugin", &CppPluginSystem::plugin, py::arg("identifier"));
+}

--- a/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemManagerImplementationFactoryBinding.cpp
+++ b/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemManagerImplementationFactoryBinding.cpp
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/pluginSystem/CppPluginSystemManagerImplementationFactory.hpp>
+
+#include "../_openassetio.hpp"
+#include "../overrideMacros.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace pluginSystem {
+namespace {
+using openassetio::pluginSystem::CppPluginSystemManagerImplementationFactory;
+struct PyCppPluginSystemManagerImplementationFactory
+    : CppPluginSystemManagerImplementationFactory {
+  using CppPluginSystemManagerImplementationFactory::CppPluginSystemManagerImplementationFactory;
+
+  [[nodiscard]] openassetio::Identifiers identifiers() override {
+    OPENASSETIO_PYBIND11_OVERRIDE_PURE(
+        openassetio::Identifiers, CppPluginSystemManagerImplementationFactory, identifiers,
+        /* no args */);
+  }
+
+  [[nodiscard]] openassetio::managerApi::ManagerInterfacePtr instantiate(
+      const openassetio::Identifier& identifier) override {
+    OPENASSETIO_PYBIND11_OVERRIDE_PURE(PyRetainingSharedPtr<managerApi::ManagerInterface>,
+                                       CppPluginSystemManagerImplementationFactory, instantiate,
+                                       identifier);
+  }
+};
+}  // namespace
+}  // namespace pluginSystem
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio
+
+void registerCppPluginSystemManagerImplementationFactory(const py::module_& mod) {
+  using openassetio::hostApi::ManagerImplementationFactoryInterface;
+  using openassetio::log::LoggerInterfacePtr;
+  using openassetio::pluginSystem::CppPluginSystemManagerImplementationFactory;
+  using openassetio::pluginSystem::PyCppPluginSystemManagerImplementationFactory;
+
+  py::class_<CppPluginSystemManagerImplementationFactory, ManagerImplementationFactoryInterface,
+             PyCppPluginSystemManagerImplementationFactory,
+             CppPluginSystemManagerImplementationFactory::Ptr>(
+      mod, "CppPluginSystemManagerImplementationFactory")
+      .def_readonly_static("kPluginEnvVar",
+                           &CppPluginSystemManagerImplementationFactory::kPluginEnvVar)
+      .def(py::init(
+               RetainCommonPyArgs::forFn<py::overload_cast<openassetio::Str, LoggerInterfacePtr>(
+                   &CppPluginSystemManagerImplementationFactory::make)>()),
+           py::arg("paths"), py::arg("logger").none(false))
+      .def(py::init(RetainCommonPyArgs::forFn<py::overload_cast<LoggerInterfacePtr>(
+                        &CppPluginSystemManagerImplementationFactory::make)>()),
+           py::arg("logger").none(false))
+      .def("identifiers", &CppPluginSystemManagerImplementationFactory::identifiers,
+           py::call_guard<py::gil_scoped_release>{})
+      .def("instantiate", &CppPluginSystemManagerImplementationFactory::instantiate,
+           py::arg("identifier"), py::call_guard<py::gil_scoped_release>{});
+}

--- a/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemPluginBinding.cpp
+++ b/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemPluginBinding.cpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <pybind11/pybind11.h>
+
+#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+
+#include "../_openassetio.hpp"
+#include "../overrideMacros.hpp"
+
+namespace {
+using openassetio::pluginSystem::CppPluginSystemPlugin;
+struct PyCppPluginSystemPlugin : CppPluginSystemPlugin {
+  [[nodiscard]] openassetio::Identifier identifier() const override {
+    OPENASSETIO_PYBIND11_OVERRIDE_PURE(openassetio::Identifier, CppPluginSystemPlugin, identifier,
+                                       /* no args */);
+  }
+};
+}  // namespace
+
+void registerCppPluginSystemPlugin(const py::module_ &mod) {
+  using openassetio::pluginSystem::CppPluginSystemPlugin;
+
+  py::class_<CppPluginSystemPlugin, PyCppPluginSystemPlugin, CppPluginSystemPlugin::Ptr>(
+      mod, "CppPluginSystemPlugin")
+      .def(py::init())
+      .def("identifier", &CppPluginSystemPlugin::identifier,
+           py::call_guard<py::gil_scoped_release>{});
+}

--- a/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystem.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystem.py
@@ -94,7 +94,7 @@ class PythonPluginSystem(object):
                     _, ext = os.path.splitext(itemPath)
                     if ext not in self.__validModuleExtensions:
                         self.__logger.debug(
-                            f"PythonPluginSystem: Ignoring as its not a python module {itemPath}"
+                            f"PythonPluginSystem: Ignoring as it is not a Python module {itemPath}"
                         )
                         continue
 

--- a/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystem.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystem.py
@@ -58,7 +58,7 @@ class PythonPluginSystem(object):
         Searches the supplied paths for modules that define a
         PythonPluginSystemPlugin through a top-level `plugin` variable.
 
-        Paths are searched right-to-left, but only the first instance of
+        Paths are searched left-to-right, but only the first instance of
         any given plugin identifier will be used, and subsequent
         registrations ignored. This means entries to the left of the
         paths list take precedence over ones to the right.

--- a/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystemManagerImplementationFactory.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystemManagerImplementationFactory.py
@@ -42,16 +42,19 @@ class PythonPluginSystemManagerImplementationFactory(ManagerImplementationFactor
     additional plugins found under paths specified in the
     `OPENASSETIO_PLUGIN_PATH` env var.
 
-    @envvar **OPENASSETIO_PLUGIN_PATH** *str* A PATH-style list of
+    @envvar **OPENASSETIO_PLUGIN_PATH** *str* A **PATH**-style list of
     directories to search for @ref
-    openassetio.pluginSystem.PythonPluginSystemManagerPlugin based
-    plugins. It uses the platform-native delimiter.  Searched left to
-    right. Plugins found here will take precedence over those discovered
-    through package entry points. Note: this search path is entirely
-    independent of **PYTHONPATH** and doesn't need to be a subset of
-    those paths. This allows OpenAssetIO plugins to be managed entirely
-    independent of the python runtime if desired, and masked from
-    `import` statements.
+    openassetio.pluginSystem.PythonPluginSystemManagerPlugin
+    "PythonPluginSystemManagerPlugin" based plugins. It uses the
+    platform-native delimiter.  Searched left to right. Plugins found
+    here will take precedence over those discovered through package
+    entry points. Note: this search path is entirely independent of
+    **PYTHONPATH** and doesn't need to be a subset of those paths. This
+    allows OpenAssetIO plugins to be managed entirely independent of the
+    python runtime if desired, and masked from `import` statements. Note
+    that this environment variable is also used by the
+    @fqref{pluginSystem.CppPluginSystemManagerImplementationFactory}
+    "CppPluginSystemManagerImplementationFactory".
 
     @envvar **OPENASSETIO_DISABLE_ENTRYPOINTS_PLUGINS** when set,
     disables entry point based plugin discovery. This can be useful if

--- a/src/openassetio-python/package/openassetio/pluginSystem/__init__.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/__init__.py
@@ -30,3 +30,6 @@ from .. import _openassetio  # pylint: disable=no-name-in-module
 
 CppPluginSystem = _openassetio.pluginSystem.CppPluginSystem
 CppPluginSystemPlugin = _openassetio.pluginSystem.CppPluginSystemPlugin
+CppPluginSystemManagerImplementationFactory = (
+    _openassetio.pluginSystem.CppPluginSystemManagerImplementationFactory
+)

--- a/src/openassetio-python/package/openassetio/pluginSystem/__init__.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/__init__.py
@@ -19,10 +19,14 @@ This module provides a plugin system that can be used to register and
 instantiate manager plugins from code that lives outside of the
 openassetio package.
 """
-
 from .PythonPluginSystemManagerPlugin import PythonPluginSystemManagerPlugin
 from .PythonPluginSystem import PythonPluginSystem
 from .PythonPluginSystemPlugin import PythonPluginSystemPlugin
 from .PythonPluginSystemManagerImplementationFactory import (
     PythonPluginSystemManagerImplementationFactory,
 )
+
+from .. import _openassetio  # pylint: disable=no-name-in-module
+
+CppPluginSystem = _openassetio.pluginSystem.CppPluginSystem
+CppPluginSystemPlugin = _openassetio.pluginSystem.CppPluginSystemPlugin

--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -4,7 +4,9 @@
 [build-system]
 requires = [
     "setuptools>=65.5.0",
-    "cmake>=3.24.1.1",
+    # CMake 3.29 PyPI package requires importlib_metadata, which is not
+    # available in a fresh Python 3.7 environment.
+    "cmake==3.28.3",
     "ninja>=1.10.2.4"
 ]
 build-backend = "setuptools.build_meta"

--- a/src/openassetio-python/tests/cmodule/gil/conftest.py
+++ b/src/openassetio-python/tests/cmodule/gil/conftest.py
@@ -48,7 +48,29 @@ def find_unimplemented_test_cases():
 
 @pytest.fixture
 def a_threaded_mock_manager_interface(mock_manager_interface):
+    """
+    Wrap in a C++ proxy manager that asserts the Python GIL is released
+    before forwarding calls to mock_manager_interface in a separate
+    thread.
+
+    This is used to (indirectly) detect that Python binding API entry
+    points release the GIL before continuing on to the C++
+    implementation.
+    """
     return _openassetio._testutils.gil.wrapInThreadedManagerInterface(mock_manager_interface)
+
+
+@pytest.fixture
+def a_threaded_logger_interface(mock_logger):
+    """
+    Wrap in a C++ proxy logger that asserts the Python GIL is released
+    before forwarding calls to mock_logger in a separate thread.
+
+    This is used to (indirectly) detect that Python binding API entry
+    points release the GIL before continuing on to the C++
+    implementation.
+    """
+    return _openassetio._testutils.gil.wrapInThreadedLoggerInterface(mock_logger)
 
 
 @pytest.fixture

--- a/src/openassetio-python/tests/cmodule/gil/test_cpppluginsystem_gil.py
+++ b/src/openassetio-python/tests/cmodule/gil/test_cpppluginsystem_gil.py
@@ -1,0 +1,191 @@
+#
+#   Copyright 2024 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Testing that ManagerFactory/CppPluginSystemPlugin
+methods release the GIL.
+"""
+import os
+import sysconfig
+
+# pylint: disable=redefined-outer-name,protected-access
+# pylint: disable=invalid-name,c-extension-no-member
+# pylint: disable=missing-class-docstring,missing-function-docstring
+from unittest import mock
+
+import openassetio
+import pytest
+
+# pylint: disable=no-name-in-module
+from openassetio import _openassetio
+from openassetio.pluginSystem import CppPluginSystem, CppPluginSystemPlugin
+
+
+class Test_CppPluginSystemPlugin_gil:
+    """
+    Check all methods release the GIL during C++ function body
+    execution.
+
+    See docstring for similar test under `gil/Test_ManagerInterface.py`
+    for details on how these tests are structured.
+    """
+
+    def test_all_methods_covered(self, find_unimplemented_test_cases):
+        """
+        Ensure this test class covers all methods.
+        """
+        unimplemented = find_unimplemented_test_cases(CppPluginSystemPlugin, self)
+
+        if unimplemented:
+            print("\nSome test cases not implemented. Method templates can be found below:\n")
+            for method in unimplemented:
+                print(
+                    f"""
+    def test_{method}(self, a_threaded_cpp_plugin):
+        a_threaded_cpp_plugin.{method}()
+"""
+                )
+
+        assert unimplemented == []
+
+    def test_identifier(self, mock_cpp_plugin, a_threaded_cpp_plugin):
+        mock_cpp_plugin.mock.identifier.return_value = "something"
+        a_threaded_cpp_plugin.identifier()
+
+
+class Test_CppPluginSystem_gil:
+    """
+    Check that the GIL is released in the CppPluginSystem bindings,
+    especially where a method calls out to a virtual method.
+
+    Such a virtual method could be in the plugin itself, or in the
+    logger, both of which are mocked such that they throw if the GIL
+    is held when they are called.
+    """
+
+    def test_all_methods_covered(self, find_unimplemented_test_cases):
+        """
+        Ensure this test class covers all methods.
+        """
+        unimplemented = find_unimplemented_test_cases(CppPluginSystem, self)
+
+        if unimplemented:
+            print("\nSome test cases not implemented. Method templates can be found below:\n")
+            for method in unimplemented:
+                print(
+                    f"""
+    def test_{method}(self, a_cpp_plugin_system):
+        a_cpp_plugin_system.{method}()
+"""
+                )
+
+        assert unimplemented == []
+
+    def test_scan(
+        self,
+        the_cpp_gil_check_plugin_path,
+        a_cpp_plugin_system,
+    ):
+        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path)
+
+    def test_identifiers(
+        self,
+        the_cpp_gil_check_plugin_identifier,
+        the_cpp_gil_check_plugin_path,
+        a_cpp_plugin_system,
+    ):
+        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path)
+
+        assert a_cpp_plugin_system.identifiers() == [the_cpp_gil_check_plugin_identifier]
+
+    def test_reset(
+        self,
+        the_cpp_gil_check_plugin_path,
+        a_cpp_plugin_system,
+    ):
+        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path)
+        a_cpp_plugin_system.reset()
+
+    def test_plugin(
+        self,
+        the_cpp_gil_check_plugin_identifier,
+        the_cpp_gil_check_plugin_path,
+        a_cpp_plugin_system,
+    ):
+        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path)
+
+        _path, _plugin = a_cpp_plugin_system.plugin(the_cpp_gil_check_plugin_identifier)
+
+
+@pytest.fixture
+def a_cpp_plugin_system(a_threaded_logger_interface):
+    return CppPluginSystem(a_threaded_logger_interface)
+
+
+@pytest.fixture
+def a_threaded_cpp_plugin(mock_cpp_plugin):
+    return _openassetio._testutils.gil.wrapInThreadedCppPluginSystemPlugin(mock_cpp_plugin)
+
+
+@pytest.fixture
+def mock_cpp_plugin():
+    return MockCppPluginSystemPlugin()
+
+
+class MockCppPluginSystemPlugin(CppPluginSystemPlugin):
+    """
+    `CppPluginSystemPlugin` implementation that delegates all
+     calls to a public `Mock` instance.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.mock = mock.create_autospec(CppPluginSystemPlugin, spec_set=True, instance=True)
+
+    def identifier(self):
+        return self.mock.identifier()
+
+
+@pytest.fixture(scope="session")
+def the_cpp_gil_check_plugin_identifier():
+    return "org.openassetio.test.pluginSystem.resources.python-gil-check"
+
+
+@pytest.fixture(scope="module")
+def the_cpp_gil_check_plugin_path():
+    scheme = f"{os.name}_user"
+    plugin_path = os.path.normpath(
+        os.path.join(
+            # Top-level __init__.py
+            openassetio.__file__,
+            # up to openassetio dir
+            "..",
+            # up to site-packages
+            "..",
+            # up to install tree root (i.e. posix ../../.., nt ../..)
+            os.path.relpath(
+                sysconfig.get_path("data", scheme), sysconfig.get_path("platlib", scheme)
+            ),
+            # down to install location of C++ plugin
+            os.getenv("OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR", ""),
+            "python-gil-check",
+        )
+    )
+    if (
+        not os.path.isdir(plugin_path)
+        and os.environ.get("OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR") is None
+    ):
+        pytest.skip("Skipping C++ plugin system tests as no test plugins are available")
+    return plugin_path

--- a/src/openassetio-python/tests/cmodule/gil/test_loggerinterface_gil.py
+++ b/src/openassetio-python/tests/cmodule/gil/test_loggerinterface_gil.py
@@ -19,10 +19,8 @@ Testing that LoggerInterface methods release the GIL.
 # pylint: disable=redefined-outer-name,protected-access
 # pylint: disable=invalid-name,c-extension-no-member
 # pylint: disable=missing-class-docstring,missing-function-docstring
-import pytest
 
 # pylint: disable=no-name-in-module
-from openassetio import _openassetio
 from openassetio.log import LoggerInterface
 
 
@@ -76,8 +74,3 @@ class Test_LoggerInterface_gil:
 
     def test_warning(self, a_threaded_logger_interface):
         a_threaded_logger_interface.warning("")
-
-
-@pytest.fixture
-def a_threaded_logger_interface(mock_logger):
-    return _openassetio._testutils.gil.wrapInThreadedLoggerInterface(mock_logger)

--- a/src/openassetio-python/tests/cmodule/resources/_testutils/gilTest.cpp
+++ b/src/openassetio-python/tests/cmodule/resources/_testutils/gilTest.cpp
@@ -13,6 +13,7 @@
 #include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
 
 /*
  * Hack trompeloeil to make use of its internals, but provide our own
@@ -167,6 +168,19 @@ struct ThreadedManagerImplFactory : hostApi::ManagerImplementationFactoryInterfa
   IMPLEMENT_MOCK0(identifiers);
   IMPLEMENT_MOCK1(instantiate);
 };
+
+namespace pluginSystem = openassetio::pluginSystem;
+
+struct ThreadedCppPluginSystemPlugin : pluginSystem::CppPluginSystemPlugin {
+  using Base = pluginSystem::CppPluginSystemPlugin;
+  static Ptr make(Ptr wrapped) {
+    return std::make_shared<ThreadedCppPluginSystemPlugin>(std::move(wrapped));
+  }
+  explicit ThreadedCppPluginSystemPlugin(Ptr wrapped) : wrapped_{std::move(wrapped)} {}
+  Ptr wrapped_;
+
+  IMPLEMENT_CONST_MOCK0(identifier);
+};
 }  // namespace
 
 void registerRunInThread(py::module_& mod) {
@@ -220,4 +234,5 @@ void registerRunInThread(py::module_& mod) {
   gil.def("wrapInThreadedHostInterface", &ThreadedHostInterface::make);
   gil.def("wrapInThreadedLoggerInterface", &ThreadedLoggerInterface::make);
   gil.def("wrapInThreadedManagerImplFactory", &ThreadedManagerImplFactory::make);
+  gil.def("wrapInThreadedCppPluginSystemPlugin", &ThreadedCppPluginSystemPlugin::make);
 }

--- a/src/openassetio-python/tests/package/pluginSystem/conftest.py
+++ b/src/openassetio-python/tests/package/pluginSystem/conftest.py
@@ -25,23 +25,28 @@ import pytest
 
 
 @pytest.fixture
-def module_plugin_identifier():
-    return "org.openassetio.test.pluginSystem.resources.modulePlugin"
+def plugin_a_identifier():
+    return "org.openassetio.test.pluginSystem.resources.pluginA"
 
 
 @pytest.fixture
-def package_plugin_identifier():
-    return "org.openassetio.test.pluginSystem.resources.packagePlugin"
+def plugin_b_identifier():
+    return "org.openassetio.test.pluginSystem.resources.pluginB"
 
 
 @pytest.fixture
-def entry_point_plugin_identifier(package_plugin_identifier):
-    return package_plugin_identifier
+def entry_point_plugin_identifier(plugin_b_identifier):
+    return plugin_b_identifier
 
 
 @pytest.fixture
-def a_plugin_path_with_symlinks(the_resources_directory_path):
-    return os.path.join(the_resources_directory_path, "symlinkPath")
+def a_python_plugin_path_with_symlinks(the_python_resources_directory_path):
+    return os.path.join(the_python_resources_directory_path, "symlinkPath")
+
+
+@pytest.fixture
+def a_python_module_plugin_path(the_python_resources_directory_path):
+    return os.path.join(the_python_resources_directory_path, "pathA")
 
 
 @pytest.fixture
@@ -50,20 +55,20 @@ def a_module_plugin_path(the_resources_directory_path):
 
 
 @pytest.fixture
-def a_package_plugin_path(the_resources_directory_path):
-    return os.path.join(the_resources_directory_path, "pathB")
+def a_python_package_plugin_path(the_python_resources_directory_path):
+    return os.path.join(the_python_resources_directory_path, "pathB")
 
 
 @pytest.fixture
-def broken_plugins_path(the_resources_directory_path):
-    return os.path.join(the_resources_directory_path, "broken", "site-packages")
+def broken_python_plugins_path(the_python_resources_directory_path):
+    return os.path.join(the_python_resources_directory_path, "broken", "site-packages")
 
 
 @pytest.fixture
-def an_entry_point_package_plugin_root(the_resources_directory_path):
-    return os.path.join(the_resources_directory_path, "entryPoint", "site-packages")
+def an_entry_point_package_plugin_root(the_python_resources_directory_path):
+    return os.path.join(the_python_resources_directory_path, "entryPoint", "site-packages")
 
 
 @pytest.fixture
-def the_resources_directory_path():
+def the_python_resources_directory_path():
     return os.path.join(os.path.dirname(__file__), "resources")

--- a/src/openassetio-python/tests/package/pluginSystem/conftest.py
+++ b/src/openassetio-python/tests/package/pluginSystem/conftest.py
@@ -20,7 +20,9 @@ Helper fixtures for testing the Python plugin system
 # pylint: disable=invalid-name
 
 import os
+import sysconfig
 
+import openassetio
 import pytest
 
 
@@ -45,13 +47,23 @@ def a_python_plugin_path_with_symlinks(the_python_resources_directory_path):
 
 
 @pytest.fixture
+def a_cpp_plugin_path_with_symlinks(the_cpp_plugins_root_path):
+    return os.path.join(the_cpp_plugins_root_path, "symlinkPath")
+
+
+@pytest.fixture
+def a_symlink_to_a_cpp_plugin_path(the_cpp_plugins_root_path):
+    return os.path.join(the_cpp_plugins_root_path, "pathASymlink")
+
+
+@pytest.fixture
 def a_python_module_plugin_path(the_python_resources_directory_path):
     return os.path.join(the_python_resources_directory_path, "pathA")
 
 
 @pytest.fixture
-def a_module_plugin_path(the_resources_directory_path):
-    return os.path.join(the_resources_directory_path, "pathA")
+def a_cpp_plugin_path(the_cpp_plugins_root_path):
+    return os.path.join(the_cpp_plugins_root_path, "pathA")
 
 
 @pytest.fixture
@@ -65,6 +77,11 @@ def broken_python_plugins_path(the_python_resources_directory_path):
 
 
 @pytest.fixture
+def broken_cpp_plugins_path(the_cpp_plugins_root_path):
+    return os.path.join(the_cpp_plugins_root_path, "broken")
+
+
+@pytest.fixture
 def an_entry_point_package_plugin_root(the_python_resources_directory_path):
     return os.path.join(the_python_resources_directory_path, "entryPoint", "site-packages")
 
@@ -72,3 +89,32 @@ def an_entry_point_package_plugin_root(the_python_resources_directory_path):
 @pytest.fixture
 def the_python_resources_directory_path():
     return os.path.join(os.path.dirname(__file__), "resources")
+
+
+@pytest.fixture(scope="session")
+def the_cpp_plugins_root_path():
+    """
+    Assume C++ plugins are installed in
+    $<INSTALL_PREFIX>/${OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR}
+    """
+    scheme = f"{os.name}_user"
+    return os.path.normpath(
+        os.path.join(
+            # Top-level __init__.py
+            openassetio.__file__,
+            # up to openassetio dir
+            "..",
+            # up to site-packages
+            "..",
+            # up to install tree root (i.e. posix ../../.., nt ../..)
+            os.path.relpath(
+                sysconfig.get_path("data", scheme), sysconfig.get_path("platlib", scheme)
+            ),
+            # down to install location of C++ plugins. Environment
+            # variable set automatically if running pytest via CMake's
+            # ctest. Default value provides a valid path to check (and
+            # fail) in consuming fixtures - see
+            # `skip_if_no_test_plugins_available`.
+            os.getenv("OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR", "plugin-env-var-not-set"),
+        )
+    )

--- a/src/openassetio-python/tests/package/pluginSystem/conftest.py
+++ b/src/openassetio-python/tests/package/pluginSystem/conftest.py
@@ -67,6 +67,11 @@ def a_cpp_plugin_path(the_cpp_plugins_root_path):
 
 
 @pytest.fixture
+def a_cpp_manager_plugin_path(the_cpp_plugins_root_path):
+    return os.path.join(the_cpp_plugins_root_path, "managerA")
+
+
+@pytest.fixture
 def a_python_package_plugin_path(the_python_resources_directory_path):
     return os.path.join(the_python_resources_directory_path, "pathB")
 

--- a/src/openassetio-python/tests/package/pluginSystem/resources/entryPoint/site-packages/packaged_plugin/PackagePlugin.py
+++ b/src/openassetio-python/tests/package/pluginSystem/resources/entryPoint/site-packages/packaged_plugin/PackagePlugin.py
@@ -10,7 +10,7 @@ class PackagePlugin(PythonPluginSystemManagerPlugin):
 
     @classmethod
     def identifier(cls):
-        return "org.openassetio.test.pluginSystem.resources.packagePlugin"
+        return "org.openassetio.test.pluginSystem.resources.pluginB"
 
     @classmethod
     def interface(cls):

--- a/src/openassetio-python/tests/package/pluginSystem/resources/entryPoint/src/packaged_plugin/PackagePlugin.py
+++ b/src/openassetio-python/tests/package/pluginSystem/resources/entryPoint/src/packaged_plugin/PackagePlugin.py
@@ -10,7 +10,7 @@ class PackagePlugin(PythonPluginSystemManagerPlugin):
 
     @classmethod
     def identifier(cls):
-        return "org.openassetio.test.pluginSystem.resources.packagePlugin"
+        return "org.openassetio.test.pluginSystem.resources.pluginB"
 
     @classmethod
     def interface(cls):

--- a/src/openassetio-python/tests/package/pluginSystem/resources/pathA/modulePlugin.py
+++ b/src/openassetio-python/tests/package/pluginSystem/resources/pathA/modulePlugin.py
@@ -11,7 +11,7 @@ class ModulePlugin(PythonPluginSystemManagerPlugin):
 
     @classmethod
     def identifier(cls):
-        return "org.openassetio.test.pluginSystem.resources.modulePlugin"
+        return "org.openassetio.test.pluginSystem.resources.pluginA"
 
     @classmethod
     def interface(cls):

--- a/src/openassetio-python/tests/package/pluginSystem/resources/pathB/packagedPlugin/PackagePlugin.py
+++ b/src/openassetio-python/tests/package/pluginSystem/resources/pathB/packagedPlugin/PackagePlugin.py
@@ -10,7 +10,7 @@ class PackagePlugin(PythonPluginSystemManagerPlugin):
 
     @classmethod
     def identifier(cls):
-        return "org.openassetio.test.pluginSystem.resources.packagePlugin"
+        return "org.openassetio.test.pluginSystem.resources.pluginB"
 
     @classmethod
     def interface(cls):

--- a/src/openassetio-python/tests/package/pluginSystem/resources/pathC/modulePlugin.py
+++ b/src/openassetio-python/tests/package/pluginSystem/resources/pathC/modulePlugin.py
@@ -14,7 +14,7 @@ class ModulePlugin(PythonPluginSystemManagerPlugin):
 
     @classmethod
     def identifier(cls):
-        identifier = "org.openassetio.test.pluginSystem.resources.modulePlugin"
+        identifier = "org.openassetio.test.pluginSystem.resources.pluginA"
         return identifier
 
     @classmethod

--- a/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystem.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystem.py
@@ -1,0 +1,348 @@
+#
+#   Copyright 2013-2022 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+These tests check the functionality of the CppPluginSystem class.
+"""
+
+# pylint: disable=invalid-name,redefined-outer-name
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+import os
+import pathlib
+import re
+
+import pytest
+
+from openassetio import errors
+from openassetio.pluginSystem import CppPluginSystem
+
+
+lib_ext = "so" if os.name == "posix" else "dll"
+
+
+class Test_CppPluginSystem_scan:
+    def test_when_path_contains_a_module_plugin_definition_then_it_is_loaded(
+        self, a_plugin_system, a_cpp_plugin_path, plugin_a_identifier
+    ):
+        a_plugin_system.scan(a_cpp_plugin_path)
+        assert a_plugin_system.identifiers() == [
+            plugin_a_identifier,
+        ]
+
+    def test_when_path_contains_multiple_entries_then_all_plugins_are_loaded(
+        self,
+        a_plugin_system,
+        the_cpp_plugins_root_path,
+        plugin_b_identifier,
+        plugin_a_identifier,
+    ):
+        path_a = os.path.join(the_cpp_plugins_root_path, "pathA")
+        path_b = os.path.join(the_cpp_plugins_root_path, "pathB")
+        combined_path = os.pathsep.join([path_a, path_b])
+        a_plugin_system.scan(combined_path)
+
+        expected_identifiers = {plugin_b_identifier, plugin_a_identifier}
+        assert set(a_plugin_system.identifiers()) == expected_identifiers
+
+    def test_when_multiple_plugins_share_identifiers_then_leftmost_is_used(
+        self,
+        a_plugin_system,
+        the_cpp_plugins_root_path,
+        plugin_a_identifier,
+        mock_logger,
+    ):
+        # The module plugin exists in pathA and pathC
+        resources_path = pathlib.Path(the_cpp_plugins_root_path)
+        path_a = resources_path / "pathA"
+        path_c = resources_path / "pathC"
+        path_a_lib = path_a / f"pathA.{lib_ext}"
+        path_c_lib = path_c / f"pathC.{lib_ext}"
+
+        a_plugin_system.scan(paths=os.pathsep.join((str(path_a), str(path_c))))
+        path, _ = a_plugin_system.plugin(plugin_a_identifier)
+
+        assert "pathA" in path.parts
+        mock_logger.mock.log.assert_any_call(
+            mock_logger.Severity.kDebug,
+            f"CppPluginSystem: Skipping '{plugin_a_identifier}' defined in '{path_c_lib}'."
+            f" Already registered by '{path_a_lib}'",
+        )
+
+        a_plugin_system.reset()
+
+        a_plugin_system.scan(paths=os.pathsep.join((str(path_c), str(path_a))))
+        path, _ = a_plugin_system.plugin(plugin_a_identifier)
+
+        assert "pathC" in path.parts
+        mock_logger.mock.log.assert_any_call(
+            mock_logger.Severity.kDebug,
+            f"CppPluginSystem: Skipping '{plugin_a_identifier}' defined in '{path_a_lib}'."
+            f" Already registered by '{path_c_lib}'",
+        )
+
+    def test_when_multiple_plugin_loaders_load_duplicate_plugins_then_libraries_not_unloaded(
+        self,
+        plugin_a_identifier,
+        the_cpp_plugins_root_path,
+        mock_logger,
+    ):
+        # This is really a test that dlopen/dlclose is reference
+        # counted.
+
+        resources_path = pathlib.Path(the_cpp_plugins_root_path)
+        path_a = resources_path / "pathA"
+        path_c = resources_path / "pathC"
+        path_a_lib = path_a / f"pathA.{lib_ext}"
+        path_c_lib = path_c / f"pathC.{lib_ext}"
+
+        first_plugin_system = CppPluginSystem(mock_logger)
+        second_plugin_system = CppPluginSystem(mock_logger)
+        first_plugin_system.scan(paths=str(path_a))
+        # Will hit "Already registered" and dlclose `pathA.so`, which is
+        # needed by the first plugin system. But libs should be
+        # refcounted, so nothing breaks.
+        second_plugin_system.scan(paths=os.pathsep.join((str(path_c), str(path_a))))
+
+        # Confidence check that we hit the expected code path.
+        mock_logger.mock.log.assert_any_call(
+            mock_logger.Severity.kDebug,
+            f"CppPluginSystem: Skipping '{plugin_a_identifier}' defined in '{path_a_lib}'."
+            f" Already registered by '{path_c_lib}'",
+        )
+
+    def test_when_path_contains_symlinks_then_plugins_are_loaded(
+        self,
+        a_plugin_system,
+        a_cpp_plugin_path_with_symlinks,
+        plugin_b_identifier,
+        plugin_a_identifier,
+    ):
+        a_plugin_system.scan(a_cpp_plugin_path_with_symlinks)
+
+        expected_identifiers = {plugin_b_identifier, plugin_a_identifier}
+        assert set(a_plugin_system.identifiers()) == expected_identifiers
+
+    def test_when_search_path_is_a_symlink_then_plugins_are_loaded(
+        self,
+        a_plugin_system,
+        a_symlink_to_a_cpp_plugin_path,
+        plugin_a_identifier,
+    ):
+        a_plugin_system.scan(a_symlink_to_a_cpp_plugin_path)
+
+        expected_identifiers = {plugin_a_identifier}
+        assert set(a_plugin_system.identifiers()) == expected_identifiers
+
+    def test_when_scan_called_multiple_times_then_plugins_combined(
+        self,
+        a_plugin_system,
+        the_cpp_plugins_root_path,
+        plugin_b_identifier,
+        plugin_a_identifier,
+    ):
+        a_plugin_system.scan(paths=os.path.join(the_cpp_plugins_root_path, "pathA"))
+        a_plugin_system.scan(paths=os.path.join(the_cpp_plugins_root_path, "pathB"))
+
+        expected_identifiers = {plugin_b_identifier, plugin_a_identifier}
+        assert set(a_plugin_system.identifiers()) == expected_identifiers
+
+    def test_when_path_contains_duplicate_entries_then_plugin_remains_loaded(
+        self,
+        a_plugin_system,
+        a_cpp_plugin_path,
+        a_cpp_plugin_path_with_symlinks,
+        plugin_a_identifier,
+        mock_logger,
+    ):
+        # Essentially testing that dlclose is refcounted.
+
+        combined_path = os.pathsep.join([a_cpp_plugin_path_with_symlinks, a_cpp_plugin_path])
+        path_a_lib = os.path.join(a_cpp_plugin_path, f"pathA.{lib_ext}")
+        symlink_path_a_lib = os.path.join(a_cpp_plugin_path_with_symlinks, f"pathA.{lib_ext}")
+
+        a_plugin_system.scan(combined_path)
+
+        mock_logger.mock.log.assert_any_call(
+            mock_logger.Severity.kDebug,
+            f"CppPluginSystem: Skipping '{plugin_a_identifier}' defined in '{path_a_lib}'."
+            f" Already registered by '{symlink_path_a_lib}'",
+        )
+        # Confidence check: we can still use the plugin instance.
+        assert a_plugin_system.plugin(plugin_a_identifier)[1].identifier() == plugin_a_identifier
+
+    def test_when_path_is_not_a_directory_then_warning_is_logged(
+        self, a_plugin_system, mock_logger
+    ):
+        a_plugin_system.scan("/some/invalid/path")
+
+        mock_logger.mock.log.assert_called_with(
+            mock_logger.Severity.kDebug,
+            "CppPluginSystem: Skipping as not a directory '/some/invalid/path'",
+        )
+
+    def test_when_plugins_broken_then_skipped_with_expected_errors(
+        self, broken_cpp_plugins_path, a_plugin_system, mock_logger
+    ):
+        a_plugin_system.scan(broken_cpp_plugins_path)
+
+        assert not a_plugin_system.identifiers()
+
+        kDebug = mock_logger.Severity.kDebug
+        kWarning = mock_logger.Severity.kWarning
+
+        non_lib_path = os.path.join(broken_cpp_plugins_path, "not-a-lib.txt")
+        fake_lib_path = os.path.join(broken_cpp_plugins_path, f"fake-lib.{lib_ext}")
+        directory_path = os.path.join(broken_cpp_plugins_path, f"a-directory.{lib_ext}")
+        non_plugin_path = os.path.join(broken_cpp_plugins_path, f"nonplugin.{lib_ext}")
+        identifier_throw_exception_path = os.path.join(
+            broken_cpp_plugins_path, f"identifier-throw-exception.{lib_ext}"
+        )
+        identifier_throw_nonexception_path = os.path.join(
+            broken_cpp_plugins_path, f"identifier-throw-nonexception.{lib_ext}"
+        )
+        factory_return_null_path = os.path.join(
+            broken_cpp_plugins_path, f"factory-return-null.{lib_ext}"
+        )
+
+        mock_logger.mock.log.assert_any_call(
+            kDebug,
+            f"CppPluginSystem: Ignoring as it is not a library binary '{non_lib_path}'",
+        )
+        mock_logger.mock.log.assert_any_call(
+            kDebug,
+            f"CppPluginSystem: Ignoring as it is not a library binary '{directory_path}'",
+        )
+        mock_logger.mock.log.assert_any_call(
+            kDebug,
+            RegexMatch(
+                re.escape(f"CppPluginSystem: Failed to open library '{fake_lib_path}':") + " .+"
+            ),
+        )
+        mock_logger.mock.log.assert_any_call(
+            kDebug,
+            RegexMatch(
+                re.escape(
+                    "CppPluginSystem: No top-level 'openassetioPlugin' function in"
+                    f" '{non_plugin_path}':"
+                )
+                + " .+"
+            ),
+        )
+
+        mock_logger.mock.log.assert_any_call(
+            kWarning,
+            "CppPluginSystem: Caught exception calling 'identifier' of"
+            f" '{identifier_throw_exception_path}':"
+            " Thrown from identifier",
+        )
+
+        mock_logger.mock.log.assert_any_call(
+            kWarning,
+            "CppPluginSystem: Caught exception calling 'identifier' of"
+            f" '{identifier_throw_nonexception_path}':"
+            " <unknown non-exception value caught>",
+        )
+
+        mock_logger.mock.log.assert_any_call(
+            kWarning, f"CppPluginSystem: Null plugin returned by '{factory_return_null_path}'"
+        )
+
+
+class Test_CppPluginSystem_reset:
+    def test_when_reset_then_identifiers_empty(
+        self, a_plugin_system, a_cpp_plugin_path, plugin_a_identifier
+    ):
+        a_plugin_system.scan(a_cpp_plugin_path)
+        # Confidence check.
+        assert a_plugin_system.identifiers() == [plugin_a_identifier]
+
+        a_plugin_system.reset()
+
+        assert a_plugin_system.identifiers() == []
+
+    def test_when_plugin_system_reset_then_plugin_still_accessible(
+        self, a_plugin_system, a_cpp_plugin_path, plugin_a_identifier
+    ):
+        # Essentially testing that we don't dlclose the last reference
+        # to the dll on reset.
+
+        a_plugin_system.scan(a_cpp_plugin_path)
+        _path, plugin = a_plugin_system.plugin(plugin_a_identifier)
+
+        a_plugin_system.reset()
+
+        assert plugin.identifier() == plugin_a_identifier
+
+
+class Test_CppPluginSystem_destruction:
+    def test_when_plugin_system_destructs_then_plugin_still_accessible(
+        self, a_cpp_plugin_path, plugin_a_identifier, mock_logger
+    ):
+        # Essentially testing that we don't dlclose the last reference
+        # to the dll on destruction.
+
+        def get_plugin():
+            plugin_system = CppPluginSystem(mock_logger)
+            plugin_system.scan(a_cpp_plugin_path)
+            return plugin_system.plugin(plugin_a_identifier)
+
+        _path, plugin = get_plugin()
+
+        assert plugin.identifier() == plugin_a_identifier
+
+
+class Test_CppPluginSystem_plugin:
+    def test_when_plugin_not_found_then_raises_InputValidationException(self, a_plugin_system):
+        with pytest.raises(
+            errors.InputValidationException,
+            match="CppPluginSystem: No plug-in registered with the identifier 'nonexistent'",
+        ):
+            a_plugin_system.plugin("nonexistent")
+
+
+class RegexMatch:
+    def __init__(self, pattern):
+        self.__pattern = pattern
+
+    def __eq__(self, text):
+        return bool(re.search(self.__pattern, text))
+
+
+@pytest.fixture
+def a_plugin_system(mock_logger):
+    return CppPluginSystem(mock_logger)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_if_no_test_plugins_available(the_cpp_plugins_root_path):
+    """
+    Skip tests in this module if there are no plugins to test against.
+
+    Some test runs may genuinely not have access to the plugins, e.g.
+    when building/testing Python wheels, since the test plugins are
+    created by CMake when test targets are enabled. In this case, skip
+    the tests in this module.
+
+    If we know we are running via CTest (i.e.
+    OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR is defined), then the test
+    plugins should definitely exist. So in this case, ensure we do _not_
+    disable these tests.
+    """
+    if (
+        not os.path.isdir(the_cpp_plugins_root_path)
+        and os.environ.get("OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR") is None
+    ):
+        pytest.skip("Skipping C++ plugin system tests as no test plugins are available")

--- a/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystemmanagerimplementationfactory.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystemmanagerimplementationfactory.py
@@ -1,0 +1,219 @@
+#
+#   Copyright 2013-2024 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+These tests check the functionality of the plugin system based
+ManagerImplementationFactoryInterface implementation.
+"""
+# pylint: disable=unused-argument
+# pylint: disable=invalid-name,redefined-outer-name
+# pylint: disable=missing-class-docstring,missing-function-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison
+
+import os
+import re
+
+import pytest
+
+from openassetio import errors
+from openassetio.hostApi import ManagerFactory
+from openassetio.pluginSystem import CppPluginSystemManagerImplementationFactory
+
+
+lib_ext = "so" if os.name == "posix" else "dll"
+
+
+class Test_CppPluginSystemManagerImplementationFactory_kPluginEnvVar:
+    def test_exposes_plugin_path_var_name_with_expected_value(self):
+        assert (
+            CppPluginSystemManagerImplementationFactory.kPluginEnvVar == "OPENASSETIO_PLUGIN_PATH"
+        )
+
+
+class Test_CppPluginSystemManagerImplementationFactory_lazy_scanning:
+    def test_when_no_paths_then_warning_logged(self, mock_logger, monkeypatch):
+        expected_msg = (
+            "No search paths specified, no plugins will load - check"
+            f" ${CppPluginSystemManagerImplementationFactory.kPluginEnvVar} is set"
+        )
+        expected_severity = mock_logger.Severity.kWarning
+
+        monkeypatch.delenv(
+            CppPluginSystemManagerImplementationFactory.kPluginEnvVar, raising=False
+        )
+        factory = CppPluginSystemManagerImplementationFactory(mock_logger)
+        # Plugins are scanned lazily when first requested
+        assert factory.identifiers() == []
+
+        mock_logger.mock.log.assert_called_once_with(expected_severity, expected_msg)
+
+    def test_when_no_args_and_path_env_then_path_plugins_loaded(
+        self,
+        a_cpp_manager_plugin_path,
+        plugin_a_identifier,
+        mock_logger,
+        monkeypatch,
+    ):
+        monkeypatch.setenv(
+            CppPluginSystemManagerImplementationFactory.kPluginEnvVar,
+            a_cpp_manager_plugin_path,
+        )
+        factory = CppPluginSystemManagerImplementationFactory(mock_logger)
+        assert factory.identifiers() == [plugin_a_identifier]
+
+    def test_when_path_arg_set_then_overrides_path_env(
+        self,
+        the_cpp_plugins_root_path,
+        plugin_b_identifier,
+        mock_logger,
+        monkeypatch,
+    ):
+        monkeypatch.setenv(
+            CppPluginSystemManagerImplementationFactory.kPluginEnvVar,
+            os.path.join(the_cpp_plugins_root_path, "managerA"),
+        )
+
+        factory = CppPluginSystemManagerImplementationFactory(
+            paths=os.path.join(the_cpp_plugins_root_path, "managerB"), logger=mock_logger
+        )
+        assert factory.identifiers() == [plugin_b_identifier]
+
+    def test_when_paths_empty_then_returns_empty_list(self, mock_logger):
+        plugin_paths = ""
+        factory = CppPluginSystemManagerImplementationFactory(
+            paths=plugin_paths, logger=mock_logger
+        )
+        assert factory.identifiers() == []
+
+
+class Test_CppPluginSystemManagerImplementationFactory_identifiers:
+    def test_when_non_manager_plugin_then_logs_warning(
+        self, a_cpp_plugin_path, plugin_a_identifier, mock_logger
+    ):
+        expected_binary_path = os.path.join(a_cpp_plugin_path, f"pathA.{lib_ext}")
+        expected_log_message = (
+            f"Plugin '{plugin_a_identifier}' from '{expected_binary_path}' is not a manager plugin"
+            " as it cannot be cast to a CppPluginSystemManagerPlugin"
+        )
+        factory = CppPluginSystemManagerImplementationFactory(a_cpp_plugin_path, mock_logger)
+
+        assert factory.identifiers() == []
+
+        mock_logger.mock.log.assert_any_call(mock_logger.Severity.kWarning, expected_log_message)
+
+
+class Test_CppPluginSystemManagerImplementationFactory_instantiate:
+    def test_when_non_manager_plugin_then_raises_InputValidationException(
+        self, a_cpp_plugin_path, plugin_a_identifier, mock_logger
+    ):
+        expected_binary_path = os.path.join(a_cpp_plugin_path, f"pathA.{lib_ext}")
+        expected_error_message = (
+            f"Plugin '{plugin_a_identifier}' from '{expected_binary_path}' is not a manager plugin"
+            " as it cannot be cast to a CppPluginSystemManagerPlugin"
+        )
+        factory = CppPluginSystemManagerImplementationFactory(a_cpp_plugin_path, mock_logger)
+
+        with pytest.raises(
+            errors.InputValidationException, match=re.escape(expected_error_message)
+        ):
+            factory.instantiate(plugin_a_identifier)
+
+    def test_when_plugin_not_found_then_raises_InputValidationException(self, mock_logger):
+        expected_identifier = "doesnt-exist"
+        expected_error_message = (
+            f"CppPluginSystem: No plug-in registered with the identifier '{expected_identifier}'"
+        )
+        factory = CppPluginSystemManagerImplementationFactory("", mock_logger)
+
+        with pytest.raises(
+            errors.InputValidationException, match=re.escape(expected_error_message)
+        ):
+            factory.instantiate(expected_identifier)
+
+    def test_when_plugin_found_then_returns_instantiated_manager_implementation(
+        self, a_cpp_manager_plugin_path, plugin_a_identifier, mock_logger
+    ):
+        factory = CppPluginSystemManagerImplementationFactory(
+            a_cpp_manager_plugin_path, mock_logger
+        )
+
+        manager_interface = factory.instantiate(plugin_a_identifier)
+
+        assert manager_interface.identifier() == plugin_a_identifier
+
+    def test_when_plugin_throws_exception_then_exception_can_be_caught(
+        self, a_cpp_manager_plugin_path, plugin_a_identifier, mock_logger
+    ):
+        # Confidence check that RTTI is working.
+
+        factory = CppPluginSystemManagerImplementationFactory(
+            a_cpp_manager_plugin_path, mock_logger
+        )
+        manager_interface = factory.instantiate(plugin_a_identifier)
+
+        # See StubManagerInterface - the `info()` method is overridden
+        # to throw an OpenAssetIO-specific exception.
+        with pytest.raises(errors.NotImplementedException, match="Stub doesn't support info"):
+            manager_interface.info()
+
+
+class Test_ManagerFactory_CppPluginSystemManagerImplementationFactory:
+    def test(
+        self,
+        a_cpp_manager_plugin_path,
+        plugin_a_identifier,
+        mock_logger,
+        mock_host_interface,
+        monkeypatch,
+    ):
+        # Confidence check that ManagerFactory works with
+        # CppPluginSystemManagerImplementationFactory.
+
+        monkeypatch.setenv(
+            CppPluginSystemManagerImplementationFactory.kPluginEnvVar,
+            a_cpp_manager_plugin_path,
+        )
+
+        manager_factory = ManagerFactory(
+            mock_host_interface,
+            CppPluginSystemManagerImplementationFactory(mock_logger),
+            mock_logger,
+        )
+
+        manager = manager_factory.createManager(plugin_a_identifier)
+
+        assert manager.identifier() == plugin_a_identifier
+
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_if_no_test_plugins_available(the_cpp_plugins_root_path):
+    """
+    Skip tests in this module if there are no plugins to test against.
+
+    Some test runs may genuinely not have access to the plugins, e.g.
+    when building/testing Python wheels, since the test plugins are
+    created by CMake when test targets are enabled. In this case, skip
+    the tests in this module.
+
+    If we know we are running via CTest (i.e.
+    OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR is defined), then the test
+    plugins should definitely exist. So in this case, ensure we do _not_
+    disable these tests.
+    """
+    if (
+        not os.path.isdir(the_cpp_plugins_root_path)
+        and os.environ.get("OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR") is None
+    ):
+        pytest.skip("Skipping C++ plugin system tests as no test plugins are available")

--- a/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystemmanagerimplementationfactory.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystemmanagerimplementationfactory.py
@@ -93,33 +93,35 @@ class Test_PythonPluginSystemManagerImplementationFactory_init:
 
     def test_when_no_args_and_path_env_then_path_plugins_loaded(
         self,
-        a_module_plugin_path,
-        module_plugin_identifier,
+        a_python_module_plugin_path,
+        plugin_a_identifier,
         monkeypatch,
     ):
         monkeypatch.setenv(
-            PythonPluginSystemManagerImplementationFactory.kPluginEnvVar, a_module_plugin_path
+            PythonPluginSystemManagerImplementationFactory.kPluginEnvVar,
+            a_python_module_plugin_path,
         )
         factory = PythonPluginSystemManagerImplementationFactory(ConsoleLogger())
-        assert factory.identifiers() == [module_plugin_identifier]
+        assert factory.identifiers() == [plugin_a_identifier]
 
     def test_when_path_arg_set_then_overrides_path_env(
         self,
-        a_module_plugin_path,
-        a_package_plugin_path,
-        package_plugin_identifier,
+        a_python_module_plugin_path,
+        a_python_package_plugin_path,
+        plugin_b_identifier,
         mock_logger,
         monkeypatch,
     ):
         monkeypatch.setenv(
-            PythonPluginSystemManagerImplementationFactory.kPluginEnvVar, a_module_plugin_path
+            PythonPluginSystemManagerImplementationFactory.kPluginEnvVar,
+            a_python_module_plugin_path,
         )
 
         factory = PythonPluginSystemManagerImplementationFactory(
-            paths=a_package_plugin_path, logger=mock_logger
+            paths=a_python_package_plugin_path, logger=mock_logger
         )
         assert factory.identifiers() == [
-            package_plugin_identifier,
+            plugin_b_identifier,
         ]
 
     def test_when_entry_points_disable_arg_set_then_overrides_entry_points_disable_env(
@@ -150,18 +152,18 @@ class Test_PythonPluginSystemManagerImplementationFactory_init:
     def test_when_duplicate_identifiers_path_selected_over_entry_point(
         self,
         prepended_sys_path_with_entry_point_plugin,
-        a_package_plugin_path,
-        package_plugin_identifier,
+        a_python_package_plugin_path,
+        plugin_b_identifier,
         mock_logger,
     ):
         factory = PythonPluginSystemManagerImplementationFactory(
-            mock_logger, paths=a_package_plugin_path, disableEntryPointsPlugins=False
+            mock_logger, paths=a_python_package_plugin_path, disableEntryPointsPlugins=False
         )
 
         assert factory.identifiers() == [
-            package_plugin_identifier,
+            plugin_b_identifier,
         ]
-        assert a_package_plugin_path in factory.instantiate(package_plugin_identifier)["file"]
+        assert a_python_package_plugin_path in factory.instantiate(plugin_b_identifier)["file"]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

Closes #1268.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.

## Reviewer Notes

Consistency with the Python plugin system has been prioritised over a neater, and perhaps more idiomatic, C++ implementation. Future work to improve the plugin system should be done for both Python and C++.

## Test Instructions

If testing via `pytest` directly, a build/install with test targets enabled (`OPENASSETIO_ENABLE_TESTS`) is required and (on POSIX) the env var `OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR=lib/OpenAssetIO/plugins`.
