### PR TITLE
[Test] Load C++ plugins in test harness

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,11 @@ v1.0.0-beta.x.y
   a `CppPluginSystemManagerPlugin` object.
   [#1115](https://github.com/OpenAssetIO/OpenAssetIO/issues/1115)
 
+- `openassetio.test.manager`, notably used for Api Compliance tests,
+  updated to automatically load C++ plugins if a python plugin of the
+  requested identifier cannot be found.
+  [#1294](https://github.com/OpenAssetIO/OpenAssetIO/issues/1294)
+
 - Added `LoggerInterface.isSeverityLogged` to allow users to
   short-circuit log message construction if the logger indicates the
   intended severity will be filtered. Updated `SeverityFilter` to use


### PR DESCRIPTION
## Description
When a python plugin of the provided identifier cannot be found when loading a test plugin, fallback to attempting to load a c++ plugin.

As specified during refinement, testing only that the initialisation of the factory is provided the correct type of implementation factory, via mocks, as the functionality for the `ManagerFactory` to load plugins once provided a correct implementation factory is tested elsewhere

Closes #1294

- [x] I have updated the release notes.

