### PR TITLE
GetWithRelationship(s) conveniences

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,13 @@ v1.0.0-beta.x.y
 
 ### Improvements
 
+- Added `getRelationship(s)` overloads for convenience, providing
+  alternatives to the core callback-based workflow. Includes a more
+  direct method for resolving relationships for single entity
+  references, or single relationships, as well exception vs. result
+  object workflows.
+  [#973](https://github.com/OpenAssetIO/OpenAssetIO/issues/973)
+
 - Added `.pyi` stub files to the Python package to aid IDE code
   completion for Python bindings of C++ types.
   [#1252](https://github.com/OpenAssetIO/OpenAssetIO/issues/1252)

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -1414,12 +1414,15 @@ class OPENASSETIO_CORE_EXPORT Manager final {
       std::function<void(std::size_t, EntityReferencePagerPtr)>;
 
   /**
-   * Query entity references that are related to the input
+   * Query for entity references that are related to the input
    * references by the relationship defined by a set of traits and
    * their properties.
    *
    * This is an essential function in this API - as it is widely used
    * to query other entities or organisational structure.
+   *
+   * When calling this method, you can expect to receive one result
+   * per @ref entity_reference provided.
    *
    * @note Consult the documentation for the relevant relationship
    * traits to determine if the order of entities in the inner lists
@@ -1482,8 +1485,264 @@ class OPENASSETIO_CORE_EXPORT Manager final {
                            const trait::TraitSet& resultTraitSet = {});
 
   /**
-   * Queries entity references that are related to the input reference
-   * by the relationships defined by a set of traits and their
+   * Query for entity references that are related to the input
+   * reference by the relationship defined by a set of traits and
+   * their properties.
+   *
+   * See documentation for the <!--
+   * --> @ref getWithRelationship(const EntityReferences&, <!--
+   * --> const trait::TraitsDataPtr&, size_t, <!--
+   * --> access::RelationsAccess, const ContextConstPtr&, <!--
+   * --> const RelationshipQuerySuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback, <!--
+   * --> const trait::TraitSet&)
+   * "callback variation" for more details on relationship behaviour.
+   *
+   * Any errors that occur during the query will be immediately thrown
+   * as an exception, either from the @ref manager plugin (for errors
+   * not specific to the entity relationship) or as a
+   * @fqref{errors.BatchElementException}
+   * "BatchElementException"-derived error.
+   *
+   * @param entityReference An @ref entity_reference to query
+   * the specified relationship for.
+   *
+   * @param relationshipTraitsData The traits of the relationship to
+   * query.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param relationsAccess The intended usage of the returned
+   * references.
+   *
+   * @param context The calling context.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Exception.
+   *
+   * @return @ref EntityReferencePager pointer. Pages over
+   * an unbounded set of entity references related to the input
+   * entity reference.
+   *
+   * @throws errors.InputValidationException if @p pageSize is zero.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kRelationshipQueries.
+   *
+   * @see @ref Capability.kRelationshipQueries
+   */
+  EntityReferencePagerPtr getWithRelationship(
+      const EntityReference& entityReference, const trait::TraitsDataPtr& relationshipTraitsData,
+      size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+      const trait::TraitSet& resultTraitSet,
+      const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
+
+  /**
+   * Query for entity references that are related to the input
+   * reference by the relationship defined by a set of traits and
+   * their properties.
+   *
+   * See documentation for the <!--
+   * --> @ref getWithRelationship(const EntityReferences&, <!--
+   * --> const trait::TraitsDataPtr&, size_t, <!--
+   * --> access::RelationsAccess, const ContextConstPtr&, <!--
+   * --> const RelationshipQuerySuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback, <!--
+   * --> const trait::TraitSet&)
+   * "callback variation" for more details on relationship behaviour.
+   *
+   * If successful, the result is populated with an
+   * EntityReferencePager, which pages over an unbounded set of entity
+   * references related to the input entity reference, or an error.
+   *
+   * Otherwise, the result is populated with an error object detailing
+   * the reason for the failure to fetch the related entities.
+   *
+   * Errors that are not specific to the entity relationship will be
+   * thrown as an exception.
+   *
+   * @param entityReference An @ref entity_reference to query
+   * the specified relationship for.
+   *
+   * @param relationshipTraitsData The traits of the relationship to
+   * query.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param relationsAccess The intended usage of the returned
+   * references.
+   *
+   * @param context The calling context.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Variant.
+   *
+   * @return Object containing either the EntityReferencePager pointer,
+   * which pages over an unbounded set of entity references related to
+   * the input entity reference, or an error.
+   *
+   * @throws errors.InputValidationException if @p pageSize is zero.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kRelationshipQueries.
+   *
+   * @see @ref Capability.kRelationshipQueries
+   */
+  std::variant<errors::BatchElementError, EntityReferencePagerPtr> getWithRelationship(
+      const EntityReference& entityReference, const trait::TraitsDataPtr& relationshipTraitsData,
+      size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+      const trait::TraitSet& resultTraitSet,
+      const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
+
+  /**
+   * Query for entity references that are related to the input
+   * references by the relationship defined by a set of traits and
+   * their properties.
+   *
+   * See documentation for the <!--
+   * --> @ref getWithRelationship(const EntityReferences&, <!--
+   * --> const trait::TraitsDataPtr&, size_t, <!--
+   * --> access::RelationsAccess, const ContextConstPtr&, <!--
+   * --> const RelationshipQuerySuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback, <!--
+   * --> const trait::TraitSet&)
+   * "callback variation" for more details on relationship behaviour.
+   *
+   * Any errors that occur during the query will be immediately thrown
+   * as an exception, either from the @ref manager plugin (for errors
+   * not specific to the entity relationship) or as a
+   * @fqref{errors.BatchElementException}
+   * "BatchElementException"-derived error.
+   *
+   * @param entityReferences A list of @ref entity_reference to query
+   * the specified relationship for.
+   *
+   * @param relationshipTraitsData The traits of the relationship to
+   * query.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param relationsAccess The intended usage of the returned
+   * references.
+   *
+   * @param context The calling context.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Exception.
+   *
+   * @return List of @ref EntityReferencePager pointers. These page over
+   * unbounded sets of entity references related to the input
+   * entity references.
+   *
+   * @throws errors.InputValidationException if @p pageSize is zero.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kRelationshipQueries.
+   *
+   * @see @ref Capability.kRelationshipQueries
+   */
+  std::vector<EntityReferencePagerPtr> getWithRelationship(
+      const EntityReferences& entityReferences, const trait::TraitsDataPtr& relationshipTraitsData,
+      size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+      const trait::TraitSet& resultTraitSet,
+      const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
+
+  /**
+   * Query for entity references that are related to the input
+   * references by the relationship defined by a set of traits and
+   * their properties.
+   *
+   * See documentation for the <!--
+   * --> @ref getWithRelationship(const EntityReferences&, <!--
+   * --> const trait::TraitsDataPtr&, size_t, <!--
+   * --> access::RelationsAccess, const ContextConstPtr&, <!--
+   * --> const RelationshipQuerySuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback, <!--
+   * --> const trait::TraitSet&)
+   * "callback variation" for more details on relationship behaviour.
+   *
+   * For successful relationships, the corresponding element of the
+   * result is populated with an EntityReferencePager, which pages over
+   * an unbounded set of entity references related to the corresponding
+   * input entity reference.
+   *
+   * Otherwise, the corresponding element of the result is populated
+   * with an error object detailing the reason for the failure to
+   * fetch the related entities for that particular relationship.
+   *
+   * Errors that are not specific to an entity relationship will be
+   * thrown as an exception, failing the whole batch.
+   *
+   * @param entityReferences A list of @ref entity_reference to query
+   * the specified relationship for.
+   *
+   * @param relationshipTraitsData The traits of the relationship to
+   * query.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param relationsAccess The intended usage of the returned
+   * references.
+   *
+   * @param context The calling context.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Variant.
+   *
+   * @return List of objects, each containing either the
+   * EntityReferencePager pointer, which pages over an unbounded set of
+   * entity references related to the input entity reference, or an
+   * error.
+   *
+   * @throws errors.InputValidationException if @p pageSize is zero.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kRelationshipQueries.
+   *
+   * @see @ref Capability.kRelationshipQueries
+   */
+  std::vector<std::variant<errors::BatchElementError, EntityReferencePagerPtr>>
+  getWithRelationship(const EntityReferences& entityReferences,
+                      const trait::TraitsDataPtr& relationshipTraitsData, size_t pageSize,
+                      access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+                      const trait::TraitSet& resultTraitSet,
+                      const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
+
+  /**
+   * Query for entity references that are related to the input reference
+   * by the relationships defined by sets of traits and their
    * properties.
    *
    * This is an essential function in this API - as it is widely used to
@@ -1492,6 +1751,9 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * @note Consult the documentation for the relevant relationship
    * traits to determine if the order of entities in the inner lists of
    * matching references is considered meaningful.
+   *
+   * When calling this method, you can expect to receive one result
+   * per relationship provided in @p relationshipTraitsDatas.
    *
    * If any relationship definition is unknown, then an empty list will
    * be returned for that relationship, and no errors will be raised.
@@ -1552,6 +1814,136 @@ class OPENASSETIO_CORE_EXPORT Manager final {
                             const RelationshipQuerySuccessCallback& successCallback,
                             const BatchElementErrorCallback& errorCallback,
                             const trait::TraitSet& resultTraitSet = {});
+
+  /**
+   * Query for entity references that are related to the input
+   * reference by the relationships defined by sets of traits and
+   * their properties.
+   *
+   * See documentation for the <!--
+   * --> @ref getWithRelationships(const EntityReference&, <!--
+   * --> const trait::TraitsDatas&, size_t, <!--
+   * --> access::RelationsAccess, const ContextConstPtr&, <!--
+   * --> const RelationshipQuerySuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback, <!--
+   * --> const trait::TraitSet&)
+   * "callback variation" for more details on relationship behaviour.
+   *
+   * Any errors that occur during the query will be immediately thrown
+   * as an exception, either from the @ref manager plugin (for errors
+   * not specific to the entity relationship) or as a
+   * @fqref{errors.BatchElementException}
+   * "BatchElementException"-derived error.
+   *
+   * @param entityReference The @ref entity_reference to query the
+   * specified relationships for.
+   *
+   * @param relationshipTraitsDatas The traits of the relationships to
+   * query.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param relationsAccess The intended usage of the returned
+   * references.
+   *
+   * @param context The calling context.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Exception.
+   *
+   * @return List of @ref EntityReferencePager pointers. These page over
+   * unbounded sets of entity references related to the input
+   * entity reference.
+   *
+   * @throws errors.InputValidationException if @p pageSize is zero.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kRelationshipQueries.
+   *
+   * @see @ref Capability.kRelationshipQueries
+   */
+  std::vector<EntityReferencePagerPtr> getWithRelationships(
+      const EntityReference& entityReference, const trait::TraitsDatas& relationshipTraitsDatas,
+      size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+      const trait::TraitSet& resultTraitSet,
+      const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
+
+  /**
+   * Query for entity references that are related to the input
+   * reference by the relationships defined by sets of traits and
+   * their properties.
+   *
+   * See documentation for the <!--
+   * --> @ref getWithRelationships(const EntityReference&, <!--
+   * --> const trait::TraitsDatas&, size_t, <!--
+   * --> access::RelationsAccess, const ContextConstPtr&, <!--
+   * --> const RelationshipQuerySuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback, <!--
+   * --> const trait::TraitSet&)
+   * "callback variation" for more details on relationship behaviour.
+   *
+   * For successful relationships, the corresponding element of the
+   * result is populated with an EntityReferencePager, which pages over
+   * an unbounded set of entity references related to the corresponding
+   * input entity reference
+   *
+   * Otherwise, the corresponding element of the result is populated
+   * with an error object detailing the reason for the failure to
+   * fetch the related entities for that particular relationship.
+   *
+   * Errors that are not specific to an entity relationship will be
+   * thrown as an exception, failing the whole batch.
+   *
+   * @param entityReference The @ref entity_reference to query the
+   * specified relationships for.
+   *
+   * @param relationshipTraitsDatas The traits of the relationships to
+   * query.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param relationsAccess The intended usage of the returned
+   * references.
+   *
+   * @param context The calling context.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Variant.
+   *
+   * @return List of objects, each containing either the
+   * EntityReferencePager pointer, which pages over an unbounded set of
+   * entity references related to the input entity reference, or an error.
+   *
+   * @throws errors.InputValidationException if @p pageSize is zero.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kRelationshipQueries.
+   *
+   * @see @ref Capability.kRelationshipQueries
+   */
+  std::vector<std::variant<errors::BatchElementError, EntityReferencePagerPtr>>
+  getWithRelationships(const EntityReference& entityReference,
+                       const trait::TraitsDatas& relationshipTraitsDatas, size_t pageSize,
+                       access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+                       const trait::TraitSet& resultTraitSet,
+                       const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
+
   /// @}
 
   /**

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -235,10 +235,84 @@ void registerManager(const py::module& mod) {
            py::arg("defaultEntityAccess"), py::arg("context").none(false),
            py::arg("successCallback"), py::arg("errorCallback"),
            py::call_guard<py::gil_scoped_release>{})
-      .def("getWithRelationship", &Manager::getWithRelationship, py::arg("entityReferences"),
-           py::arg("relationshipTraitsData").none(false), py::arg("pageSize"),
-           py::arg("relationsAccess"), py::arg("context").none(false), py::arg("successCallback"),
-           py::arg("errorCallback"), py::arg("resultTraitSet") = trait::TraitSet{},
+      .def("getWithRelationship",
+           py::overload_cast<const EntityReferences&, const trait::TraitsDataPtr&, size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const Manager::RelationshipQuerySuccessCallback&,
+                             const Manager::BatchElementErrorCallback&, const trait::TraitSet&>(
+               &Manager::getWithRelationship),
+           py::arg("entityReferences"), py::arg("relationshipTraitsData").none(false),
+           py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
+           py::arg("successCallback"), py::arg("errorCallback"),
+           py::arg("resultTraitSet") = trait::TraitSet{}, py::call_guard<py::gil_scoped_release>{})
+      // TODO(DF): Technically we shouldn't need this overload,
+      // since we can use a similar trick to C++ to default the
+      // appropriate overload's tag parameter, e.g.
+      // `py::arg("errorPolicyTag") = {}`. However, this causes a
+      // memory leak in pybind11.
+      .def(
+          "getWithRelationship",
+          [](Manager& self, const EntityReference& entityReference,
+             const trait::TraitsDataPtr& relationshipTraitsData, size_t pageSize,
+             const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+             const trait::TraitSet& resultTraitSet) {
+            return self.getWithRelationship(entityReference, relationshipTraitsData, pageSize,
+                                            relationsAccess, context, resultTraitSet);
+          },
+          py::arg("entityReference"), py::arg("relationshipTraitsData").none(false),
+          py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
+          py::arg("resultTraitSet"), py::call_guard<py::gil_scoped_release>{})
+      .def(
+          "getWithRelationship",
+          [](Manager& self, const EntityReferences& entityReferences,
+             const trait::TraitsDataPtr& relationshipTraitsData, size_t pageSize,
+             const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+             const trait::TraitSet& resultTraitSet) {
+            return self.getWithRelationship(entityReferences, relationshipTraitsData, pageSize,
+                                            relationsAccess, context, resultTraitSet);
+          },
+          py::arg("entityReferences"), py::arg("relationshipTraitsData").none(false),
+          py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
+          py::arg("resultTraitSet"), py::call_guard<py::gil_scoped_release>{})
+      .def("getWithRelationship",
+           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&, size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const trait::TraitSet&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::getWithRelationship),
+           py::arg("entityReference"), py::arg("relationshipTraitsData").none(false),
+           py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
+           py::arg("resultTraitSet"), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("getWithRelationship",
+           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&, size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const trait::TraitSet&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::getWithRelationship),
+           py::arg("entityReference"), py::arg("relationshipTraitsData").none(false),
+           py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
+           py::arg("resultTraitSet"), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("getWithRelationship",
+           py::overload_cast<const EntityReferences&, const trait::TraitsDataPtr&, size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const trait::TraitSet&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::getWithRelationship),
+           py::arg("entityReferences"), py::arg("relationshipTraitsData").none(false),
+           py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
+           py::arg("resultTraitSet"), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("getWithRelationship",
+           py::overload_cast<const EntityReferences&, const trait::TraitsDataPtr&, size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const trait::TraitSet&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::getWithRelationship),
+           py::arg("entityReferences"), py::arg("relationshipTraitsData").none(false),
+           py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
+           py::arg("resultTraitSet"), py::arg("errorPolicyTag"),
            py::call_guard<py::gil_scoped_release>{})
       .def(
           "getWithRelationships",
@@ -249,14 +323,62 @@ void registerManager(const py::module& mod) {
              const Manager::BatchElementErrorCallback& errorCallback,
              const trait::TraitSet& resultTraitSet) {
             validateTraitsDatas(relationshipTraitsDatas);
-            self.getWithRelationships(entityReference, relationshipTraitsDatas, pageSize,
-                                      relationsAccess, context, successCallback, errorCallback,
-                                      resultTraitSet);
+            return self.getWithRelationships(entityReference, relationshipTraitsDatas, pageSize,
+                                             relationsAccess, context, successCallback,
+                                             errorCallback, resultTraitSet);
           },
           py::arg("entityReference"), py::arg("relationshipTraitsDatas"), py::arg("pageSize"),
           py::arg("relationsAccess"), py::arg("context").none(false), py::arg("successCallback"),
           py::arg("errorCallback"), py::arg("resultTraitSet") = trait::TraitSet{},
           py::call_guard<py::gil_scoped_release>{})
+      // TODO(DF): Technically we shouldn't need this overload,
+      // since we can use a similar trick to C++ to default the
+      // appropriate overload's tag parameter, e.g.
+      // `py::arg("errorPolicyTag") = {}`. However, this causes a
+      // memory leak in pybind11.
+      .def(
+          "getWithRelationships",
+          [](Manager& self, const EntityReference& entityReference,
+             const trait::TraitsDatas& relationshipTraitsDatas, size_t pageSize,
+             const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+             const trait::TraitSet& resultTraitSet) {
+            validateTraitsDatas(relationshipTraitsDatas);
+            return self.getWithRelationships(entityReference, relationshipTraitsDatas, pageSize,
+                                             relationsAccess, context, resultTraitSet);
+          },
+          py::arg("entityReference"), py::arg("relationshipTraitsDatas"), py::arg("pageSize"),
+          py::arg("relationsAccess"), py::arg("context").none(false), py::arg("resultTraitSet"),
+          py::call_guard<py::gil_scoped_release>{})
+      .def(
+          "getWithRelationships",
+          [](Manager& self, const EntityReference& entityReference,
+             const trait::TraitsDatas& relationshipTraitsDatas, size_t pageSize,
+             access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+             const trait::TraitSet& resultTraitSet,
+             const Manager::BatchElementErrorPolicyTag::Exception& errorPolicyTag) {
+            validateTraitsDatas(relationshipTraitsDatas);
+            return self.getWithRelationships(entityReference, relationshipTraitsDatas, pageSize,
+                                             relationsAccess, context, resultTraitSet,
+                                             errorPolicyTag);
+          },
+          py::arg("entityReference"), py::arg("relationshipTraitsDatas"), py::arg("pageSize"),
+          py::arg("relationsAccess"), py::arg("context").none(false), py::arg("resultTraitSet"),
+          py::arg("errorPolicyTag"), py::call_guard<py::gil_scoped_release>{})
+      .def(
+          "getWithRelationships",
+          [](Manager& self, const EntityReference& entityReference,
+             const trait::TraitsDatas& relationshipTraitsDatas, size_t pageSize,
+             access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+             const trait::TraitSet& resultTraitSet,
+             const Manager::BatchElementErrorPolicyTag::Variant& errorPolicyTag) {
+            validateTraitsDatas(relationshipTraitsDatas);
+            return self.getWithRelationships(entityReference, relationshipTraitsDatas, pageSize,
+                                             relationsAccess, context, resultTraitSet,
+                                             errorPolicyTag);
+          },
+          py::arg("entityReference"), py::arg("relationshipTraitsDatas"), py::arg("pageSize"),
+          py::arg("relationsAccess"), py::arg("context").none(false), py::arg("resultTraitSet"),
+          py::arg("errorPolicyTag"), py::call_guard<py::gil_scoped_release>{})
       .def(
           "preflight",
           [](Manager& self, const EntityReferences& entityReferences,

--- a/src/openassetio-python/tests/cmodule/gil/test_manager_gil.py
+++ b/src/openassetio-python/tests/cmodule/gil/test_manager_gil.py
@@ -127,11 +127,9 @@ class Test_Manager_gil:
     def test_flushCaches(self, a_threaded_manager):
         a_threaded_manager.flushCaches()
 
-    def test_getWithRelationship(self, a_threaded_manager, a_traits_data, a_context):
-        # Defend against forgetting to include convenience signatures in
-        # this test, once added.
-        assert "Overloaded" not in a_threaded_manager.getWithRelationship.__doc__
-
+    def test_getWithRelationship(
+        self, a_threaded_manager, an_entity_reference, a_traits_data, a_context
+    ):
         a_threaded_manager.getWithRelationship(
             [],
             a_traits_data,
@@ -142,11 +140,37 @@ class Test_Manager_gil:
             fail,
         )
 
-    def test_getWithRelationships(self, a_threaded_manager, an_entity_reference, a_context):
-        # Defend against forgetting to include convenience signatures in
-        # this test, once added.
-        assert "Overloaded" not in a_threaded_manager.getWithRelationships.__doc__
+        tag = Manager.BatchElementErrorPolicyTag
 
+        a_threaded_manager.getWithRelationship(
+            an_entity_reference,
+            a_traits_data,
+            1,
+            access.RelationsAccess.kRead,
+            a_context,
+            set(),
+            tag.kVariant,
+        )
+
+        a_threaded_manager.getWithRelationship(
+            an_entity_reference,
+            a_traits_data,
+            1,
+            access.RelationsAccess.kRead,
+            a_context,
+            set(),
+            tag.kException,
+        )
+
+        a_threaded_manager.getWithRelationship(
+            [], a_traits_data, 1, access.RelationsAccess.kRead, a_context, set(), tag.kVariant
+        )
+
+        a_threaded_manager.getWithRelationship(
+            [], a_traits_data, 1, access.RelationsAccess.kRead, a_context, set(), tag.kException
+        )
+
+    def test_getWithRelationships(self, a_threaded_manager, an_entity_reference, a_context):
         a_threaded_manager.getWithRelationships(
             an_entity_reference,
             [],
@@ -155,6 +179,30 @@ class Test_Manager_gil:
             a_context,
             fail,
             fail,
+        )
+
+        tag = Manager.BatchElementErrorPolicyTag
+
+        # No singular getWithRelationships conveniences.
+
+        a_threaded_manager.getWithRelationships(
+            an_entity_reference,
+            [],
+            1,
+            access.RelationsAccess.kRead,
+            a_context,
+            set(),
+            tag.kVariant,
+        )
+
+        a_threaded_manager.getWithRelationships(
+            an_entity_reference,
+            [],
+            1,
+            access.RelationsAccess.kRead,
+            a_context,
+            set(),
+            tag.kException,
         )
 
     def test_hasCapability(self, a_threaded_manager):

--- a/src/openassetio-python/tests/conftest.py
+++ b/src/openassetio-python/tests/conftest.py
@@ -115,6 +115,15 @@ def mock_entity_reference_pager_interface():
 
 
 @pytest.fixture
+def mock_entity_reference_pager_interface_2():
+    """
+    Fixture for an `EntityReferencePagerInterface` that forwards method
+    calls to an internal public `mock.Mock` instance.
+    """
+    return MockEntityReferencePagerInterface()
+
+
+@pytest.fixture
 def mock_manager_interface(create_mock_manager_interface):
     """
     Fixture for a `ManagerInterface` that asserts parameter types and


### PR DESCRIPTION
## Description

Closes #973

Adds standard set of singular/batch conveniences for getWithRelationship(s), for both exceptional and variant error modalities.

Due to the inability to use the test framework for conveniences, it's all a bit rough & ready. I'm hoping just a happy path and a failure case are enough considering the scope of duplication involved.

## Reviewer Notes

Docs are in another commit. Just sort of worked out this way but I thought it's probably a better reviewer experience so left it like that. Will squash after.

Good luck trying to keep all the variations strait in your head when looking at docs & bindings ... I really struggled.
