### PR TITLE
[Python] Deprecate `plugin` hook.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,6 +33,13 @@ v1.0.0-beta.x.y
   completion for Python bindings of C++ types.
   [#1252](https://github.com/OpenAssetIO/OpenAssetIO/issues/1252)
 
+### Deprecated
+
+- Deprecated top level `plugin` variable for python plugins in favour of
+  `openassetioPlugin`, in order to reduce risk of conflict with other
+  plugin systems, and maintain consistency with the C++ plugin system.
+  [#1290](https://github.com/OpenAssetIO/OpenAssetIO/issues/1290)
+
 v1.0.0-beta.2.1
 ---------------
 

--- a/examples/host/simpleResolver/test_simpleResolver.py
+++ b/examples/host/simpleResolver/test_simpleResolver.py
@@ -49,11 +49,13 @@ class Test_simpleResolver_errors:
         self, test_config_env  # pylint: disable=unused-argument
     ):
         result = execute_cli()
-        expected_message = [
-            "usage: simpleResolver.py [-h] traitset entityref",
-            "simpleResolver.py: error: the following arguments are required: traitset, entityref",
-        ]
-        assert result.stderr.splitlines() == expected_message
+        expected_message = (
+            "usage: simpleResolver.py [-h] traitset entityref\n"
+            "simpleResolver.py: error: the following arguments are required: traitset, entityref"
+        )
+
+        # TODO E.M, Revert this to being an exact check once BAL no longer prints "plugin" deprecation warning.
+        assert expected_message in result.stderr
         assert result.returncode == 2
 
     def test_when_entity_ref_and_trait_set_valid_then_expected_data_output_and_return_code_zero(
@@ -81,7 +83,8 @@ class Test_simpleResolver_errors:
     ):
         result = execute_cli("named", "bal:///doesNotExist")
         # Don't test the specific message as it couples to BAL specifics
-        assert result.stderr.startswith("ERROR:")
+        # TODO E.M, Revert this to being a startswith check once BAL no longer prints "plugin" deprecation warning.
+        assert "ERROR:" in result.stderr
         assert result.returncode == int(BatchElementError.ErrorCode.kEntityResolutionError)
 
 

--- a/src/openassetio-python/tests/bridge/resources/modulePlugin.py
+++ b/src/openassetio-python/tests/bridge/resources/modulePlugin.py
@@ -15,4 +15,4 @@ class ModulePlugin(PythonPluginSystemPlugin):
 
 
 # pylint: disable=invalid-name
-plugin = ModulePlugin
+openassetioPlugin = ModulePlugin

--- a/src/openassetio-python/tests/package/pluginSystem/conftest.py
+++ b/src/openassetio-python/tests/package/pluginSystem/conftest.py
@@ -37,6 +37,11 @@ def plugin_b_identifier():
 
 
 @pytest.fixture
+def deprecated_plugin_identifier():
+    return "org.openassetio.test.pluginSystem.resources.deprecated"
+
+
+@pytest.fixture
 def entry_point_plugin_identifier(plugin_b_identifier):
     return plugin_b_identifier
 
@@ -74,6 +79,11 @@ def a_cpp_manager_plugin_path(the_cpp_plugins_root_path):
 @pytest.fixture
 def a_python_package_plugin_path(the_python_resources_directory_path):
     return os.path.join(the_python_resources_directory_path, "pathB")
+
+
+@pytest.fixture
+def a_deprecated_plugin_path(the_python_resources_directory_path):
+    return os.path.join(the_python_resources_directory_path, "deprecated")
 
 
 @pytest.fixture

--- a/src/openassetio-python/tests/package/pluginSystem/resources/deprecated/deprecatedPlugin.py
+++ b/src/openassetio-python/tests/package/pluginSystem/resources/deprecated/deprecatedPlugin.py
@@ -1,0 +1,19 @@
+"""
+Provides a test PythonPluginSystemPlugin using the deprecated `plugin`
+hook
+"""
+
+from openassetio.pluginSystem import PythonPluginSystemManagerPlugin
+
+
+class DeprecatedPlugin(PythonPluginSystemManagerPlugin):
+    # pylint: disable=missing-class-docstring
+
+    @classmethod
+    def identifier(cls):
+        return "org.openassetio.test.pluginSystem.resources.deprecated"
+
+
+# The `plugin` hook is deprecated in favour of `openassetioPlugin`
+# pylint: disable=invalid-name
+plugin = DeprecatedPlugin

--- a/src/openassetio-python/tests/package/pluginSystem/resources/entryPoint/src/packaged_plugin/__init__.py
+++ b/src/openassetio-python/tests/package/pluginSystem/resources/entryPoint/src/packaged_plugin/__init__.py
@@ -9,4 +9,4 @@ from .PackagePlugin import PackagePlugin
 
 
 # pylint: disable=invalid-name
-plugin = PackagePlugin
+openassetioPlugin = PackagePlugin

--- a/src/openassetio-python/tests/package/pluginSystem/resources/pathA/modulePlugin.py
+++ b/src/openassetio-python/tests/package/pluginSystem/resources/pathA/modulePlugin.py
@@ -21,4 +21,4 @@ class ModulePlugin(PythonPluginSystemManagerPlugin):
 
 
 # pylint: disable=invalid-name
-plugin = ModulePlugin
+openassetioPlugin = ModulePlugin

--- a/src/openassetio-python/tests/package/pluginSystem/resources/pathB/packagedPlugin/__init__.py
+++ b/src/openassetio-python/tests/package/pluginSystem/resources/pathB/packagedPlugin/__init__.py
@@ -9,4 +9,4 @@ from .PackagePlugin import PackagePlugin
 
 
 # pylint: disable=invalid-name
-plugin = PackagePlugin
+openassetioPlugin = PackagePlugin

--- a/src/openassetio-python/tests/package/pluginSystem/resources/pathC/modulePlugin.py
+++ b/src/openassetio-python/tests/package/pluginSystem/resources/pathC/modulePlugin.py
@@ -25,4 +25,4 @@ class ModulePlugin(PythonPluginSystemManagerPlugin):
 
 
 # pylint: disable=invalid-name
-plugin = ModulePlugin
+openassetioPlugin = ModulePlugin

--- a/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystem.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystem.py
@@ -69,6 +69,26 @@ class Test_PythonPluginSystem_scan:
         expected_identifiers = set([plugin_b_identifier, plugin_a_identifier])
         assert set(a_plugin_system.identifiers()) == expected_identifiers
 
+    def test_when_path_contains_deprecated_plugin_hook_then_it_is_loaded(
+        self, a_plugin_system, a_deprecated_plugin_path, deprecated_plugin_identifier
+    ):
+        a_plugin_system.scan(a_deprecated_plugin_path)
+        assert a_plugin_system.identifiers() == [
+            deprecated_plugin_identifier,
+        ]
+
+    def test_when_path_contains_deprecated_plugin_hook_then_deprecation_warning_is_logged(
+        self, a_deprecated_plugin_path, mock_logger
+    ):
+        deprecated_plugin_path = os.path.join(a_deprecated_plugin_path, "deprecatedPlugin.py")
+        plugin_system = PythonPluginSystem(mock_logger)
+        plugin_system.scan(a_deprecated_plugin_path)
+        mock_logger.mock.log.assert_any_call(
+            mock_logger.Severity.kWarning,
+            "PythonPluginSystem: Use of top-level 'plugin' variable is deprecated, "
+            f"use `openassetioPlugin` instead. {deprecated_plugin_path}",
+        )
+
     def test_when_multiple_plugins_share_identifiers_then_leftmost_is_used(
         self, a_plugin_system, the_python_resources_directory_path, plugin_a_identifier
     ):
@@ -120,7 +140,7 @@ class Test_PythonPluginSystem_scan:
         missing_plugin_path = os.path.join(broken_python_plugins_path, "missing_plugin.py")
         mock_logger.mock.log.assert_any_call(
             mock_logger.Severity.kError,
-            f"PythonPluginSystem: No top-level 'plugin' variable {missing_plugin_path}",
+            f"PythonPluginSystem: No top-level 'openassetioPlugin' variable {missing_plugin_path}",
         )
         raises_exception_path = os.path.join(broken_python_plugins_path, "raises_exception.py")
         mock_logger.mock.log.assert_any_call(
@@ -185,7 +205,7 @@ class Test_PythonPluginSystem_scan_entry_points:
         missing_plugin_path = os.path.join(broken_python_plugins_path, "missing_plugin.py")
         mock_logger.mock.log.assert_any_call(
             mock_logger.Severity.kError,
-            f"PythonPluginSystem: No top-level 'plugin' variable {missing_plugin_path}",
+            f"PythonPluginSystem: No top-level 'openassetioPlugin' variable {missing_plugin_path}",
         )
         raises_exception_path = os.path.join(broken_python_plugins_path, "raises_exception.py")
         mock_logger.mock.log.assert_any_call(

--- a/src/openassetio-python/tests/package/test/manager/resources/plugins/StubManager.py
+++ b/src/openassetio-python/tests/package/test/manager/resources/plugins/StubManager.py
@@ -89,4 +89,4 @@ class StubManagerPlugin(PythonPluginSystemManagerPlugin):
 
 
 # pylint: disable=invalid-name
-plugin = StubManagerPlugin
+openassetioPlugin = StubManagerPlugin


### PR DESCRIPTION
## Description
Deprecate the top level `plugin` variable for the python plugin system in favour of the `openassetioPlugin` variable.

Closes #1290

- [x] I have updated the release notes.