### PR TITLE
[Docs] Consider dependent projects in release process

### DIFF
--- a/doc/contributing/PROCESS.md
+++ b/doc/contributing/PROCESS.md
@@ -145,7 +145,11 @@ To make a new OpenAssetIO release, follow this procedure.
 - Commit changes using the title: `[Release] Bump version to <version>`.
 - Have a final scan over the release notes to check for typos. If any
   are spotted, add a commit *before* the version bump to fix them.
-- Create a PR into the primary repo, review and merge as normal.
+- Create a PR into the primary repo and await review.
+- Check if this release must occur simultaneously with a release of
+  another project in the OpenAssetIO ecosystem, and if so ensure they
+  are also ready to release before continuing.
+- Merge the release PR to `main` as normal.
 
 > **Warning**
 >


### PR DESCRIPTION
This came out of a team retrospective action to address an issue whereby OpenAssetIO core was released with a breaking change, but the corresponding update to BAL (Basic Asset Library) was not yet ready. This meant there was a non-trivial period where the latest published version of BAL was incompatible with the latest published version of OpenAssetIO core. This then had a knock-on effect to host integrators, who could not use BAL to test conformance with the latest OpenAssetIO core API.

So update our release process so that we always consider if other projects in the ecosystem must be released simultaneously, and if so ensure they are ready for release, before finalising the OpenAssetIO core release.

- [ ] ~~I have updated the release notes.~~
- [x] I have updated all relevant user documentation.
