### PR TITLE
`entityExists` conveniences

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,12 +33,12 @@ v1.0.0-beta.x.y
 
 ### Improvements
 
-- Added `getRelationship(s)` overloads for convenience, providing
-  alternatives to the core callback-based workflow. Includes a more
-  direct method for resolving relationships for single entity
-  references, or single relationships, as well exception vs. result
-  object workflows.
+- Added `getRelationship(s)` and `entityExists` overloads for
+  convenience, providing alternatives to the core callback-based
+  workflow. Includes more direct methods for singular queries, as
+  well as exception vs. result object workflows.
   [#973](https://github.com/OpenAssetIO/OpenAssetIO/issues/973)
+  [#1169](https://github.com/OpenAssetIO/OpenAssetIO/issues/1169)
 
 - Added `.pyi` stub files to the Python package to aid IDE code
   completion for Python bindings of C++ types.

--- a/src/openassetio-core/include/openassetio/errors/BatchElementError.hpp
+++ b/src/openassetio-core/include/openassetio/errors/BatchElementError.hpp
@@ -146,7 +146,7 @@ class BatchElementError final {
   constexpr bool operator!=(const BatchElementError& other) const { return !(*this == other); }
 
   /// Error code indicating the class of error.
-  ErrorCode code;
+  ErrorCode code{ErrorCode::kUnknown};
   /// Human-readable error message.
   Str message;
 };

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -940,10 +940,6 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * @throws errors.BatchElementException Converted exception thrown
    * when the manager emits a @fqref{errors.BatchElementError}
    * "BatchElementError".
-   * @throws errors.NotImplementedException Thrown when this method is
-   * not implemented by the manager. Check that this method is
-   * implemented before use by calling @ref hasCapability with @ref
-   * Capability.kResolution.
    */
   std::vector<trait::TraitSet> entityTraits(
       const EntityReferences& entityReferences, access::EntityTraitsAccess entityTraitsAccess,
@@ -1136,6 +1132,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * @throws errors.BatchElementException Converted exception thrown
    * when the manager emits a @fqref{errors.BatchElementError}
    * "BatchElementError".
+   *
    * @throws errors.NotImplementedException Thrown when this method is
    * not implemented by the manager. Check that this method is
    * implemented before use by calling @ref hasCapability with @ref

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -772,6 +772,183 @@ class OPENASSETIO_CORE_EXPORT Manager final {
                     const BatchElementErrorCallback& errorCallback);
 
   /**
+   * Determines if the supplied @ref entity_reference points to an
+   * entity that exists in the @ref asset_management_system.
+   *
+   * See the documentation for the @ref
+   * entityExists(const EntityReferences&, <!--
+   * --> const ContextConstPtr&, const ExistsSuccessCallback&, <!--
+   * --> const BatchElementErrorCallback&) "callback overload" for more
+   * details.
+   *
+   * Errors that occur will be thrown as an exception, either from the
+   * @ref manager plugin (for errors not specific to the entity
+   * reference) or as a @fqref{errors.BatchElementException}
+   * "BatchElementException"-derived error.
+   *
+   * @param entityReference Entity reference to query.
+   *
+   * @param context The calling context.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Exception.
+   *
+   * @return Boolean indicating existence of the entity.
+   *
+   * @throws errors.BatchElementException Converted exception thrown
+   * when the manager emits a @fqref{errors.BatchElementError}
+   * "BatchElementError".
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kExistenceQueries.
+   *
+   * @see @ref Capability.kExistenceQueries
+   */
+  bool entityExists(const EntityReference& entityReference, const ContextConstPtr& context,
+                    const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
+
+  /**
+   * Determines if the supplied @ref entity_reference points to an
+   * entity that exists in the @ref asset_management_system.
+   *
+   * See the documentation for the @ref
+   * entityExists(const EntityReferences&, <!--
+   * --> const ContextConstPtr&, const ExistsSuccessCallback&, <!--
+   * --> const BatchElementErrorCallback&) "callback overload" for more
+   * details.
+   *
+   * If successful, the result is a boolean indicating the existence of
+   * the @ref entity.
+   *
+   * Otherwise, the result is populated with an error object detailing
+   * the reason for the failure to check the existence of this
+   * particular entity.
+   *
+   * Errors that are not specific to the entity being queried will be
+   * thrown as an exception.
+   *
+   * @param entityReference Entity reference to query.
+   *
+   * @param context The calling context.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Variant.
+   *
+   * @return Object containing either a boolean indicating the existence
+   * of the entity or an error object.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kExistenceQueries.
+   *
+   * @see @ref Capability.kExistenceQueries
+   */
+  std::variant<errors::BatchElementError, bool> entityExists(
+      const EntityReference& entityReference, const ContextConstPtr& context,
+      const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
+
+  /**
+   * Type to use in place of bool in `vector<bool>` so that the "dynamic
+   * bitset" specialisation of std::vector is not used.
+   *
+   * `std::vector<bool>` is a specialisation that uses a single bit per
+   * element, which is more memory efficient but limits the use of
+   * the vector for certain operations.
+   *
+   * As a workaround, we can use an integral type as the vector element,
+   * such that zero represents false and non-zero represents true.
+   */
+  using BoolAsUint = std::uint_fast8_t;
+
+  /**
+   * Determines if each supplied @ref entity_reference points to an
+   * entity that exists in the @ref asset_management_system.
+   *
+   * See documentation for the <!--
+   * --> @ref entityExists(const EntityReferences&, <!--
+   * --> const ContextConstPtr&, const ExistsSuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback)
+   * "callback overload" for more details on existence check behaviour.
+   *
+   * Any errors that occur will be immediately thrown as an exception,
+   * either from the @ref manager plugin (for errors not specific to the
+   * entity reference) or as a @fqref{errors.BatchElementException}
+   * "BatchElementException"-derived error.
+   *
+   * @param entityReferences Entity references to query.
+   *
+   * @param context The calling context.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Exception.
+   *
+   * @return List of boolean values indicating the existence of each
+   * entity.
+   *
+   * @throws errors.BatchElementException Converted exception thrown
+   * when the manager emits a @fqref{errors.BatchElementError}
+   * "BatchElementError".
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kExistenceQueries.
+   *
+   * @see @ref Capability.kExistenceQueries
+   */
+  std::vector<BoolAsUint> entityExists(
+      const EntityReferences& entityReferences, const ContextConstPtr& context,
+      const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
+
+  /**
+   * Determines if each supplied @ref entity_reference points to an
+   * entity that exists in the @ref asset_management_system.
+   *
+   * For successful references, the corresponding element of the result
+   * is populated with a boolean indicating the existence of the entity.
+   *
+   * Otherwise, the corresponding element of the result is populated
+   * with an error object detailing the reason for the failure to check
+   * the existence of that particular entity.
+   *
+   * Errors that are not specific to an entity will be thrown as an
+   * exception, failing the whole batch.
+   *
+   * See documentation for the <!--
+   * --> @ref entityExists(const EntityReferences&, <!--
+   * --> const ContextConstPtr&, const ExistsSuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback)
+   * "callback overload" for more details on existence check behaviour.
+   *
+   * @param entityReferences Entity references to query.
+   *
+   * @param context The calling context.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tag dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Variant.
+   *
+   * @return List of objects, each containing either a boolean indicating
+   * the existence of the entity or an error.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kExistenceQueries.
+   *
+   * @see @ref Capability.kExistenceQueries
+   */
+  std::vector<std::variant<errors::BatchElementError, bool>> entityExists(
+      const EntityReferences& entityReferences, const ContextConstPtr& context,
+      const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
+
+  /**
    * Callback signature used for a successful entity trait set query.
    */
   using EntityTraitsSuccessCallback = std::function<void(std::size_t, trait::TraitSet)>;

--- a/src/openassetio-core/src/errors/exceptionMessages.cpp
+++ b/src/openassetio-core/src/errors/exceptionMessages.cpp
@@ -33,9 +33,9 @@ Str errorCodeName(BatchElementError::ErrorCode code) {
   return "Unknown ErrorCode";
 }
 
-std::string createBatchElementExceptionMessage(const BatchElementError& err, size_t index,
-                                               const EntityReference& entityReference,
-                                               internal::access::Access access) {
+std::string createBatchElementExceptionMessage(
+    const BatchElementError& err, size_t index, const EntityReference& entityReference,
+    const std::optional<internal::access::Access> access) {
   /*
    * BatchElementException messages consist of five parts.
    * 1. The name of the error code.
@@ -47,16 +47,24 @@ std::string createBatchElementExceptionMessage(const BatchElementError& err, siz
    * Ends up looking something like : "entityAccessError: Could not
    * access Entity [index=2] [access=read] [entity=bal:///entityRef]"
    */
-  const auto errorCodeStr = fmt::format("{}:", errorCodeName(err.code));
-  const auto errorMessageStr = err.message.empty() ? "" : fmt::format(" {}", err.message);
+  std::string result;
 
-  // Data elements
-  const auto indexStr = fmt::format(" [index={}]", index);
-  const auto accessStr = fmt::format(" [access={}]", access::kAccessNames[access]);
-  const auto entityReferenceStr = fmt::format(" [entity={}]", entityReference.toString());
+  result += fmt::format("{}:", errorCodeName(err.code));
 
-  return fmt::format("{}{}{}{}{}", errorCodeStr, errorMessageStr, indexStr, accessStr,
-                     entityReferenceStr);
+  if (!err.message.empty()) {
+    result += " ";
+    result += err.message;
+  }
+
+  result += fmt::format(" [index={}]", index);
+
+  if (access) {
+    result += fmt::format(" [access={}]", access::kAccessNames[*access]);
+  }
+
+  result += fmt::format(" [entity={}]", entityReference.toString());
+
+  return result;
 }
 }  // namespace errors
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-core/src/errors/exceptionMessages.hpp
+++ b/src/openassetio-core/src/errors/exceptionMessages.hpp
@@ -19,7 +19,7 @@ Str errorCodeName(BatchElementError::ErrorCode code);
 /**Construct a full message to place into a convenience exception.*/
 std::string createBatchElementExceptionMessage(const BatchElementError& err, size_t index,
                                                const EntityReference& entityReference,
-                                               internal::access::Access access);
+                                               std::optional<internal::access::Access> access);
 }  // namespace errors
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/tests/.clang-tidy
+++ b/src/openassetio-core/tests/.clang-tidy
@@ -3,6 +3,10 @@
 
 InheritParentConfig: true
 
-# Disable "cognitive complexity" check: Catch2 test macros trigger this.
+# - -readability-function-cognitive-complexity: Catch2 test macros
+#    trigger this.
+# - -bugprone-chained-comparison: (Clang-Tidy 18+) Catch2 CHECK macro
+#    triggers this.
 Checks: >
-    -readability-function-cognitive-complexity
+    -readability-function-cognitive-complexity,
+    -bugprone-chained-comparison

--- a/src/openassetio-core/tests/BatchElementErrorTest.cpp
+++ b/src/openassetio-core/tests/BatchElementErrorTest.cpp
@@ -14,6 +14,15 @@ SCENARIO("BatchElementError usage") {
     STATIC_REQUIRE(std::is_copy_assignable_v<BatchElementError>);
   }
 
+  GIVEN("a default-constructed BatchElementError") {
+    const BatchElementError error{};
+
+    THEN("code is kUnknown and message is empty") {
+      CHECK(error.code == BatchElementError::ErrorCode::kUnknown);
+      CHECK(error.message.empty());
+    }
+  }
+
   GIVEN("an error code and message") {
     const auto code = BatchElementError::ErrorCode::kUnknown;
     const openassetio::Str message = "some message";

--- a/src/openassetio-python/tests/cmodule/gil/test_manager_gil.py
+++ b/src/openassetio-python/tests/cmodule/gil/test_manager_gil.py
@@ -104,12 +104,17 @@ class Test_Manager_gil:
         mock_manager_interface.mock.displayName.return_value = "My Name"
         assert a_threaded_manager.displayName() == "My Name"
 
-    def test_entityExists(self, a_threaded_manager, a_context):
-        # Defend against forgetting to include convenience signatures in
-        # this test, once added.
-        assert "Overloaded" not in a_threaded_manager.entityExists.__doc__
+    def test_entityExists(self, a_threaded_manager, a_context, an_entity_reference):
+        ref = an_entity_reference
+        tag = Manager.BatchElementErrorPolicyTag
 
         a_threaded_manager.entityExists([], a_context, fail, fail)
+        a_threaded_manager.entityExists(ref, a_context)
+        a_threaded_manager.entityExists(ref, a_context, tag.kException)
+        a_threaded_manager.entityExists(ref, a_context, tag.kVariant)
+        a_threaded_manager.entityExists([], a_context)
+        a_threaded_manager.entityExists([], a_context, tag.kException)
+        a_threaded_manager.entityExists([], a_context, tag.kVariant)
 
     def test_entityTraits(self, a_threaded_manager, a_context, an_entity_reference):
         ref = an_entity_reference

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -1012,7 +1012,7 @@ class Test_Manager_entityExists(BatchFirstMethodTest):
     def test_batch_overload_default_response(self, two_refs):
         self.assert_batch_overload_default_response(
             method_specific_args_for_batch_of_two=(two_refs,),
-            expected_default_results=[True, True],
+            expected_default_results=[False, False],
         )
 
     def test_singular_overload_success(self, a_ref):
@@ -1061,7 +1061,7 @@ class Test_Manager_entityExists(BatchFirstMethodTest):
     @pytest.mark.parametrize("error_code", BatchFirstMethodTest.batch_element_error_codes)
     def test_when_singular_throwing_overload_errors_then_raises(self, a_ref, error_code):
         batch_element_error = BatchElementError(error_code, "some error")
-        expected_error_message = self._make_expected_err_msg(
+        expected_error_message = self._make_expected_existence_err_msg(
             batch_element_error,
             a_ref,
         )
@@ -1076,7 +1076,7 @@ class Test_Manager_entityExists(BatchFirstMethodTest):
     @pytest.mark.parametrize("error_code", BatchFirstMethodTest.batch_element_error_codes)
     def test_when_batched_throwing_overload_errors_then_raises(self, two_refs, error_code):
         batch_element_error = BatchElementError(error_code, "some error")
-        expected_error_message = self._make_expected_err_msg(
+        expected_error_message = self._make_expected_existence_err_msg(
             batch_element_error,
             two_refs[0],
         )
@@ -1087,7 +1087,7 @@ class Test_Manager_entityExists(BatchFirstMethodTest):
             expected_error_message=expected_error_message,
         )
 
-    def _make_expected_err_msg(self, batch_element_error, entityRef):
+    def _make_expected_existence_err_msg(self, batch_element_error, entityRef):
         error_type_name = self.batch_element_error_codes_names[
             self.batch_element_error_codes.index(batch_element_error.code)
         ]

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -159,6 +159,107 @@ class BatchFirstMethodTest:
                 mock.Mock(),
             )
 
+    def assert_singular_overload_default_response(
+        self,
+        method_specific_args,
+        batched_method_specific_args,
+        expected_default_result,
+        assert_result_identity=True,
+    ):
+        """
+        Check the default response when the manager doesn't call a
+        callback.
+        """
+        for tag in (
+            [],
+            [Manager.BatchElementErrorPolicyTag.kException],
+        ):
+            with self.subtests.test(tag=tag):
+
+                actual_result = self.method(*method_specific_args, self.a_context, *tag)
+
+                self.mock_interface_method.assert_called_once_with(
+                    *batched_method_specific_args,
+                    self.a_context,
+                    self.a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+                self.mock_interface_method.reset_mock()
+
+                assert actual_result == expected_default_result
+                if assert_result_identity:
+                    assert actual_result is expected_default_result
+
+        with self.subtests.test(tag=Manager.BatchElementErrorPolicyTag.kVariant):
+
+            actual_result = self.method(
+                *method_specific_args, self.a_context, Manager.BatchElementErrorPolicyTag.kVariant
+            )
+
+            self.mock_interface_method.assert_called_once_with(
+                *batched_method_specific_args,
+                self.a_context,
+                self.a_host_session,
+                mock.ANY,
+                mock.ANY,
+            )
+
+            assert actual_result == BatchElementError(BatchElementError.ErrorCode.kUnknown, "")
+
+    def assert_batch_overload_default_response(
+        self,
+        method_specific_args_for_batch_of_two,
+        expected_default_results,
+        assert_result_identity=True,
+    ):
+        """
+        Check the default response when the manager doesn't call a
+        callback.
+        """
+        for tag in (
+            [],
+            [Manager.BatchElementErrorPolicyTag.kException],
+        ):
+            with self.subtests.test(tag=tag):
+                actual_results = self.method(
+                    *method_specific_args_for_batch_of_two, self.a_context, *tag
+                )
+
+                self.mock_interface_method.assert_called_once_with(
+                    *method_specific_args_for_batch_of_two,
+                    self.a_context,
+                    self.a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+                self.mock_interface_method.reset_mock()
+
+                assert actual_results == expected_default_results
+
+                if assert_result_identity:
+                    for actual, expected in zip(actual_results, expected_default_results):
+                        assert actual is expected
+
+        with self.subtests.test(tag=Manager.BatchElementErrorPolicyTag.kVariant):
+            actual_results = self.method(
+                *method_specific_args_for_batch_of_two,
+                self.a_context,
+                Manager.BatchElementErrorPolicyTag.kVariant,
+            )
+
+            self.mock_interface_method.assert_called_once_with(
+                *method_specific_args_for_batch_of_two,
+                self.a_context,
+                self.a_host_session,
+                mock.ANY,
+                mock.ANY,
+            )
+
+            assert (
+                actual_results == [BatchElementError(BatchElementError.ErrorCode.kUnknown, "")] * 2
+            )
+
     def assert_singular_overload_success(
         self,
         method_specific_args,
@@ -870,39 +971,129 @@ class Test_Manager_createEntityReferenceIfValid:
         assert entity_reference.toString() == a_ref_string
 
 
-class Test_Manager_entityExists:
-    def test_method_defined_in_cpp(self, method_introspector):
-        assert not method_introspector.is_defined_in_python(Manager.entityExists)
-        assert method_introspector.is_implemented_once(Manager, "entityExists")
-
-    def test_wraps_the_corresponding_method_of_the_held_interface(
+class Test_Manager_entityExists(BatchFirstMethodTest):
+    @pytest.fixture(autouse=True)
+    def constructor(
         self,
-        manager,
-        mock_manager_interface,
-        a_host_session,
-        some_refs,
-        a_context,
-        a_batch_element_error,
+        subtests,
         invoke_entityExists_success_cb,
         invoke_entityExists_error_cb,
+        a_batch_element_error,
+        a_context,
+        a_host_session,
+        manager,
+        mock_manager_interface,
     ):
-        success_callback = mock.Mock()
-        error_callback = mock.Mock()
+        self.subtests = subtests
+        self.invoke_success_cb = invoke_entityExists_success_cb
+        self.invoke_error_cb = invoke_entityExists_error_cb
+        self.a_batch_element_error = a_batch_element_error
+        self.a_context = a_context
+        self.a_host_session = a_host_session
 
-        method = mock_manager_interface.mock.entityExists
+        self.method = manager.entityExists
+        self.mock_interface_method = mock_manager_interface.mock.entityExists
 
-        def call_callbacks(*_args):
-            invoke_entityExists_success_cb(123, False)
-            invoke_entityExists_error_cb(456, a_batch_element_error)
+    def test_callback_overload_wraps_the_corresponding_method_of_the_held_interface(
+        self, two_refs
+    ):
+        self.assert_callback_overload_wraps_the_corresponding_method_of_the_held_interface(
+            method_specific_args_for_batch_of_two=(two_refs,),
+            one_success_result=True,
+        )
 
-        method.side_effect = call_callbacks
+    def test_singular_overload_default_response(self, a_ref):
+        self.assert_singular_overload_default_response(
+            method_specific_args=(a_ref,),
+            batched_method_specific_args=([a_ref],),
+            expected_default_result=False,
+        )
 
-        manager.entityExists(some_refs, a_context, success_callback, error_callback)
+    def test_batch_overload_default_response(self, two_refs):
+        self.assert_batch_overload_default_response(
+            method_specific_args_for_batch_of_two=(two_refs,),
+            expected_default_results=[True, True],
+        )
 
-        method.assert_called_once_with(some_refs, a_context, a_host_session, mock.ANY, mock.ANY)
+    def test_singular_overload_success(self, a_ref):
+        self.assert_singular_overload_success(
+            method_specific_args=(a_ref,),
+            batched_method_specific_args=([a_ref],),
+            expected_result=True,
+        )
 
-        success_callback.assert_called_once_with(123, False)
-        error_callback.assert_called_once_with(456, a_batch_element_error)
+    def test_batch_overload_success(self, two_refs):
+        self.assert_batch_overload_success(
+            method_specific_args_for_batch_of_two=(two_refs,),
+            expected_results=[False, True],
+        )
+
+    def test_when_batch_overload_receives_output_out_of_order_then_results_reordered(
+        self, two_refs
+    ):
+        self.assert_batch_overload_success_out_of_order(
+            method_specific_args_for_batch_of_two=(two_refs,),
+            expected_results=[True, False],
+        )
+
+    def test_when_singular_variant_overload_errors_then_error_returned(self, a_ref):
+        self.assert_singular_variant_overload_error(
+            method_specific_args=(a_ref,),
+            batched_method_specific_args=([a_ref],),
+        )
+
+    def test_when_batch_variant_overload_receives_mixed_output_then_mixed_results_returned(
+        self, two_refs
+    ):
+        self.assert_batch_variant_overload_mixed_output(
+            method_specific_args_for_batch_of_two=(two_refs,),
+            one_success_result=True,
+        )
+
+    def test_when_batch_variant_overload_receives_mixed_output_out_of_order_then_results_reordered(
+        self, four_refs
+    ):
+        self.assert_batch_variant_overload_mixed_output_out_of_order(
+            method_specific_args_for_batch_of_four=(four_refs,),
+            two_success_results=[True, False],
+        )
+
+    @pytest.mark.parametrize("error_code", BatchFirstMethodTest.batch_element_error_codes)
+    def test_when_singular_throwing_overload_errors_then_raises(self, a_ref, error_code):
+        batch_element_error = BatchElementError(error_code, "some error")
+        expected_error_message = self._make_expected_err_msg(
+            batch_element_error,
+            a_ref,
+        )
+
+        self.assert_singular_throwing_overload_raises(
+            method_specific_args=(a_ref,),
+            batched_method_specific_args=([a_ref],),
+            batch_element_error=batch_element_error,
+            expected_error_message=expected_error_message,
+        )
+
+    @pytest.mark.parametrize("error_code", BatchFirstMethodTest.batch_element_error_codes)
+    def test_when_batched_throwing_overload_errors_then_raises(self, two_refs, error_code):
+        batch_element_error = BatchElementError(error_code, "some error")
+        expected_error_message = self._make_expected_err_msg(
+            batch_element_error,
+            two_refs[0],
+        )
+
+        self.assert_batched_throwing_overload_raises(
+            method_specific_args_for_batch_of_two=(two_refs,),
+            batch_element_error=batch_element_error,
+            expected_error_message=expected_error_message,
+        )
+
+    def _make_expected_err_msg(self, batch_element_error, entityRef):
+        error_type_name = self.batch_element_error_codes_names[
+            self.batch_element_error_codes.index(batch_element_error.code)
+        ]
+        return (
+            f"{error_type_name}: {batch_element_error.message} [index=0]" f" [entity={entityRef}]"
+        )
 
 
 class Test_Manager_defaultEntityReference:
@@ -981,7 +1172,7 @@ class FakeEntityReferencePagerInterface(EntityReferencePagerInterface):
 # the arguments for getWithRelationship are not in the standard format.
 
 
-class Test_Manager_getWithRelationship_with_callback_signiature:
+class Test_Manager_getWithRelationship_with_callback_signature:
     def test_wraps_the_corresponding_method_of_the_held_interface(
         self,
         manager,
@@ -1149,6 +1340,61 @@ class Test_Manager_getWithRelationship_singular_convenience:
             Manager.BatchElementErrorPolicyTag.kVariant,
         ],
     )
+    def test_when_no_response_then_None_returned(
+        self,
+        manager,
+        a_ref,
+        mock_manager_interface,
+        a_host_session,
+        an_empty_traitsdata,
+        an_entity_trait_set,
+        a_context,
+        mock_entity_reference_pager_interface,
+        invoke_getWithRelationship_success_cb,
+        error_mode,
+    ):
+        page_size = 3
+        method = mock_manager_interface.mock.getWithRelationship
+
+        args = {
+            "entityReference": a_ref,
+            "relationshipTraitsData": an_empty_traitsdata,
+            "pageSize": page_size,
+            "relationsAccess": access.RelationsAccess.kRead,
+            "context": a_context,
+            "resultTraitSet": an_entity_trait_set,
+        }
+
+        if error_mode is not None:
+            args["errorPolicyTag"] = error_mode
+
+        actual_pager = manager.getWithRelationship(**args)
+
+        method.assert_called_once_with(
+            [a_ref],
+            an_empty_traitsdata,
+            an_entity_trait_set,
+            page_size,
+            access.RelationsAccess.kRead,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        if error_mode is Manager.BatchElementErrorPolicyTag.kVariant:
+            assert actual_pager == BatchElementError(BatchElementError.ErrorCode.kUnknown, "")
+        else:
+            assert actual_pager is None
+
+    @pytest.mark.parametrize(
+        "error_mode",
+        [
+            None,
+            Manager.BatchElementErrorPolicyTag.kException,
+            Manager.BatchElementErrorPolicyTag.kVariant,
+        ],
+    )
     def test_when_success_then_entityReferencePager_returned(
         self,
         manager,
@@ -1254,6 +1500,65 @@ class Test_Manager_getWithRelationship_singular_convenience:
 
 
 class Test_Manager_getWithRelationship_batch_convenience:
+    @pytest.mark.parametrize(
+        "error_mode",
+        [
+            None,
+            Manager.BatchElementErrorPolicyTag.kException,
+            Manager.BatchElementErrorPolicyTag.kVariant,
+        ],
+    )
+    def test_when_no_response_then_None_returned(
+        self,
+        manager,
+        a_ref,
+        mock_manager_interface,
+        a_host_session,
+        an_empty_traitsdata,
+        an_entity_trait_set,
+        a_context,
+        mock_entity_reference_pager_interface,
+        mock_entity_reference_pager_interface_2,
+        invoke_getWithRelationship_success_cb,
+        error_mode,
+    ):
+
+        two_refs = [a_ref, a_ref]
+        page_size = 3
+        method = mock_manager_interface.mock.getWithRelationship
+
+        args = {
+            "entityReferences": two_refs,
+            "relationshipTraitsData": an_empty_traitsdata,
+            "pageSize": page_size,
+            "relationsAccess": access.RelationsAccess.kRead,
+            "context": a_context,
+            "resultTraitSet": an_entity_trait_set,
+        }
+
+        if error_mode is not None:
+            args["errorPolicyTag"] = error_mode
+
+        actual_pagers = manager.getWithRelationship(**args)
+
+        method.assert_called_once_with(
+            two_refs,
+            an_empty_traitsdata,
+            an_entity_trait_set,
+            page_size,
+            access.RelationsAccess.kRead,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        if error_mode is Manager.BatchElementErrorPolicyTag.kVariant:
+            assert (
+                actual_pagers == [BatchElementError(BatchElementError.ErrorCode.kUnknown, "")] * 2
+            )
+        else:
+            assert actual_pagers == [None, None]
 
     @pytest.mark.parametrize(
         "error_mode",
@@ -1546,6 +1851,66 @@ class Test_Manager_getWithRelationships_with_batch_convenience:
             Manager.BatchElementErrorPolicyTag.kVariant,
         ],
     )
+    def test_when_no_response_then_Nones_returned(
+        self,
+        manager,
+        a_ref,
+        mock_manager_interface,
+        a_host_session,
+        an_empty_traitsdata,
+        an_entity_trait_set,
+        a_context,
+        mock_entity_reference_pager_interface,
+        mock_entity_reference_pager_interface_2,
+        invoke_getWithRelationships_success_cb,
+        error_mode,
+    ):
+
+        two_traitsdatas = [an_empty_traitsdata, an_empty_traitsdata]
+        page_size = 3
+        method = mock_manager_interface.mock.getWithRelationships
+
+        args = {
+            "entityReference": a_ref,
+            "relationshipTraitsDatas": two_traitsdatas,
+            "pageSize": page_size,
+            "relationsAccess": access.RelationsAccess.kRead,
+            "context": a_context,
+            "resultTraitSet": an_entity_trait_set,
+        }
+
+        if error_mode is not None:
+            args["errorPolicyTag"] = error_mode
+
+        actual_pagers = manager.getWithRelationships(**args)
+
+        method.assert_called_once_with(
+            a_ref,
+            two_traitsdatas,
+            an_entity_trait_set,
+            page_size,
+            access.RelationsAccess.kRead,
+            a_context,
+            a_host_session,
+            mock.ANY,
+            mock.ANY,
+        )
+
+        if error_mode is Manager.BatchElementErrorPolicyTag.kVariant:
+            assert (
+                actual_pagers == [BatchElementError(BatchElementError.ErrorCode.kUnknown, "")] * 2
+            )
+        else:
+            assert actual_pagers == [None, None]
+
+    @pytest.mark.parametrize(
+        "error_mode",
+        [
+            None,
+            Manager.BatchElementErrorPolicyTag.kException,
+            Manager.BatchElementErrorPolicyTag.kVariant,
+        ],
+    )
     def test_when_success_then_entityReferencePagers_returned(
         self,
         manager,
@@ -1702,6 +2067,31 @@ class Test_Manager_resolve(BatchFirstMethodTest):
                 access.ResolveAccess.kRead,
             ),
             one_success_result=a_traitsdata,
+        )
+
+    def test_singular_overload_default_response(self, a_ref, an_entity_trait_set):
+        self.assert_singular_overload_default_response(
+            method_specific_args=(
+                a_ref,
+                an_entity_trait_set,
+                access.ResolveAccess.kRead,
+            ),
+            batched_method_specific_args=(
+                [a_ref],
+                an_entity_trait_set,
+                access.ResolveAccess.kRead,
+            ),
+            expected_default_result=None,
+        )
+
+    def test_batch_overload_default_response(self, two_refs, an_entity_trait_set):
+        self.assert_batch_overload_default_response(
+            method_specific_args_for_batch_of_two=(
+                two_refs,
+                an_entity_trait_set,
+                access.ResolveAccess.kRead,
+            ),
+            expected_default_results=[None, None],
         )
 
     def test_singular_overload_success(self, a_ref, an_entity_trait_set, a_traitsdata):
@@ -1869,6 +2259,30 @@ class Test_Manager_entityTraits(BatchFirstMethodTest):
             one_success_result=an_entity_trait_set,
         )
 
+    def test_singular_overload_default_response(self, a_ref):
+        self.assert_singular_overload_default_response(
+            method_specific_args=(
+                a_ref,
+                access.EntityTraitsAccess.kRead,
+            ),
+            batched_method_specific_args=(
+                [a_ref],
+                access.EntityTraitsAccess.kRead,
+            ),
+            expected_default_result=set(),
+            assert_result_identity=False,
+        )
+
+    def test_batch_overload_default_response(self, two_refs):
+        self.assert_batch_overload_default_response(
+            method_specific_args_for_batch_of_two=(
+                two_refs,
+                access.EntityTraitsAccess.kRead,
+            ),
+            expected_default_results=[set(), set()],
+            assert_result_identity=False,
+        )
+
     def test_singular_overload_success(self, a_ref, an_entity_trait_set):
         self.assert_singular_overload_success(
             method_specific_args=(
@@ -1892,8 +2306,6 @@ class Test_Manager_entityTraits(BatchFirstMethodTest):
             expected_results=two_entity_trait_sets,
             assert_result_identity=False,
         )
-
-    assert_result_identity = (False,)
 
     def test_when_batch_overload_receives_output_out_of_order_then_results_reordered(
         self, two_refs, two_entity_trait_sets
@@ -2074,6 +2486,33 @@ class Test_Manager_preflight(BatchFirstMethodTest):
                 [a_traitsdata, None],
                 access.PublishingAccess.kWrite,
             )
+        )
+
+    def test_singular_overload_default_response(self, a_ref, a_different_ref, a_traitsdata):
+        self.assert_singular_overload_default_response(
+            method_specific_args=(
+                a_ref,
+                a_traitsdata,
+                access.PublishingAccess.kWrite,
+            ),
+            batched_method_specific_args=(
+                [a_ref],
+                [a_traitsdata],
+                access.PublishingAccess.kWrite,
+            ),
+            expected_default_result=EntityReference(""),
+            assert_result_identity=False,
+        )
+
+    def test_batch_overload_default_response(self, two_refs, two_entity_traitsdatas):
+        self.assert_batch_overload_default_response(
+            method_specific_args_for_batch_of_two=(
+                two_refs,
+                two_entity_traitsdatas,
+                access.PublishingAccess.kWrite,
+            ),
+            expected_default_results=[EntityReference(""), EntityReference("")],
+            assert_result_identity=False,
         )
 
     def test_singular_overload_success(self, a_ref, a_different_ref, a_traitsdata):
@@ -2264,6 +2703,33 @@ class Test_Manager_register(BatchFirstMethodTest):
                 [a_traitsdata, None],
                 access.PublishingAccess.kWrite,
             )
+        )
+
+    def test_singular_overload_default_response(self, a_ref, a_different_ref, a_traitsdata):
+        self.assert_singular_overload_default_response(
+            method_specific_args=(
+                a_ref,
+                a_traitsdata,
+                access.PublishingAccess.kWrite,
+            ),
+            batched_method_specific_args=(
+                [a_ref],
+                [a_traitsdata],
+                access.PublishingAccess.kWrite,
+            ),
+            expected_default_result=EntityReference(""),
+            assert_result_identity=False,
+        )
+
+    def test_batch_overload_default_response(self, two_refs, two_entity_traitsdatas):
+        self.assert_batch_overload_default_response(
+            method_specific_args_for_batch_of_two=(
+                two_refs,
+                two_entity_traitsdatas,
+                access.PublishingAccess.kWrite,
+            ),
+            expected_default_results=[EntityReference(""), EntityReference("")],
+            assert_result_identity=False,
         )
 
     def test_singular_overload_success(self, a_ref, a_different_ref, a_traitsdata):


### PR DESCRIPTION
## Description

Closes #1169. Add overloads for `entityExists`, similar to other API methods. I.e. singular vs. batch, exception vs. result (variant).

Also fix a few sundry issues found along the way. 

In particular, for convenience overloads of various methods, add test cases for the default response when the manager is naughty and doesn't call any callback.

Hence set the default `code` of `BatchElementError` to `kUnknown` - this closes #1298.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.

## Reviewer Notes

<!--- Provide any notes to the reviewer that might help them more easily
      understand the changeset. --->

## Test Instructions

<!--- Provide instructions to the reviewer on how to explicitly test
      these changes. --->
