### PR TITLE
Printable TraitsData + other types.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,16 @@ _The addition of a new virtual method,
 
 ### New Features
 
+- Many types are now printable, with `<<` operators available in C++, and `str`
+  and `repr` functions available in python.
+  Notably, this includes `TraitsData`, which when printed now displays all the
+  properties contained within the traits, rather than simply a list of trait
+  ids.
+  
+  Note: Due to this, some runtime string output may have slightly changed, and
+  tests may need to be adjusted.
+  [#1307](https://github.com/OpenAssetIO/OpenAssetIO/issues/1307)
+
 - Added a C++ plugin system. In particular, hosts can use the
   `CppPluginSystemManagerImplementationFactory` class (as a drop-in
   replacement for `PythonPluginSystemManagerImplementationFactory`) in

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -85,6 +85,8 @@ target_sources(
     src/pluginSystem/CppPluginSystemManagerPlugin.cpp
     src/pluginSystem/CppPluginSystemPlugin.cpp
     src/trait/TraitsData.cpp
+    src/utils/formatter.cpp
+    src/utils/ostream.cpp
     src/utils/Regex.cpp
     src/utils/path.cpp
     src/utils/path/common.cpp

--- a/src/openassetio-core/include/openassetio/utils/ostream.hpp
+++ b/src/openassetio-core/include/openassetio/utils/ostream.hpp
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#pragma once
+
+#include <memory>
+#include <ostream>
+#include <unordered_map>
+#include <vector>
+
+#include <openassetio/InfoDictionary.hpp>
+#include <openassetio/errors/BatchElementError.hpp>
+#include <openassetio/hostApi/Manager.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/trait/collection.hpp>
+#include <openassetio/trait/property.hpp>
+#include <openassetio/typedefs.hpp>
+
+OPENASSETIO_FWD_DECLARE(Context)
+OPENASSETIO_FWD_DECLARE(managerApi, HostSession)
+OPENASSETIO_FWD_DECLARE(trait, TraitsData)
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+class EntityReference;
+using EntityReferences = std::vector<EntityReference>;
+
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "an_entity_reference".
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(std::ostream& out,
+                                                 const EntityReference& formattable);
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "['an_entity_reference_1', 'an_entity_reference_2']".
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(std::ostream& out,
+                                                 const EntityReferences& formattable);
+
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "{'locale': {'aTrait': {'aProperty': propertyVal}}, 'managerState': memoryAddress}".
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(std::ostream& out, const ContextPtr& formattable);
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "{'locale': {'aTrait': {'aProperty': propertyVal}}, 'managerState': memoryAddress}".
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(std::ostream& out,
+                                                 const ContextConstPtr& formattable);
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "{'locale': {'aTrait': {'aProperty': propertyVal}}, 'managerState': memoryAddress}".
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(std::ostream& out, const Context& formattable);
+
+namespace managerApi {
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "humanReadableCapabilityName".
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(std::ostream& out,
+                                                 const ManagerInterface::Capability& formattable);
+}  // namespace managerApi
+
+namespace hostApi {
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "humanReadableCapabilityName".
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(std::ostream& out,
+                                                 const Manager::Capability& formattable);
+}  // namespace hostApi
+
+namespace errors {
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "humanReadableErrorCodeName".
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(std::ostream& out,
+                                                 const BatchElementError::ErrorCode& formattable);
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "humanReadableErrorCodeName: Error message.".
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(std::ostream& out,
+                                                 const BatchElementError& formattable);
+}  // namespace errors
+
+namespace trait {
+
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "{'aTrait': {'aTraitProperty': traitValue, 'anotherTraitProperty':
+ * anotherTraitValue}, 'anotherTrait': {aTraitProperty: traitValue}}".
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(std::ostream& out,
+                                                 const TraitsDataPtr& formattable);
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "{'aTrait': {'aTraitProperty': traitValue, 'anotherTraitProperty':
+ * anotherTraitValue}, 'anotherTrait': {aTraitProperty: traitValue}}".
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(std::ostream& out,
+                                                 const TraitsDataConstPtr& formattable);
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "{'aTrait': {'aTraitProperty': traitValue, 'anotherTraitProperty':
+ * anotherTraitValue}, 'anotherTrait': {aTraitProperty: traitValue}}".
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(std::ostream& out, const TraitsData& formattable);
+
+namespace property {
+
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "Value", (or "'Value'" if formattable is a string)
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(std::ostream& out, const Value& formattable);
+}  // namespace property
+}  // namespace trait
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio
+
+/* The types here are just typedefs to standard types, and thus must be defined
+ * in the standard namespace. */
+namespace std {
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "{'key1': 'value1', 'key2': 'value2'}"
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(
+    std::ostream& out, const openassetio::OPENASSETIO_CORE_ABI_VERSION::StrMap& formattable);
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "{'key1': value1, 'key2': value2}"
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(
+    std::ostream& out,
+    const openassetio::OPENASSETIO_CORE_ABI_VERSION::InfoDictionary& formattable);
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "{'trait1', 'trait2'}"
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(
+    std::ostream& out,
+    const openassetio::OPENASSETIO_CORE_ABI_VERSION::trait::TraitSet& formattable);
+/**
+ * Insertion operator for use with ostreams.
+ * Formats as "[{'trait1', 'trait2'}, {'trait3', 'trait4'}]"
+ */
+OPENASSETIO_CORE_EXPORT std::ostream& operator<<(
+    std::ostream& out,
+    const openassetio::OPENASSETIO_CORE_ABI_VERSION::trait::TraitSets& formattable);
+}  // namespace std

--- a/src/openassetio-core/src/utils/formatter.cpp
+++ b/src/openassetio-core/src/utils/formatter.cpp
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+
+#include "formatter.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <openassetio/Context.hpp>
+#include <openassetio/EntityReference.hpp>
+#include <openassetio/errors/BatchElementError.hpp>
+#include <openassetio/hostApi/Manager.hpp>
+#include <openassetio/managerApi/HostSession.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
+#include "../errors/exceptionMessages.hpp"
+
+auto fmt::formatter<openassetio::EntityReference>::format(
+    const openassetio::EntityReference& entityRef, format_context& ctx) const
+    -> decltype(ctx.out()) {
+  return fmt::formatter<string_view>::format(fmt::format("{}", entityRef.toString()), ctx);
+}
+
+auto fmt::formatter<openassetio::EntityReferences>::format(
+    const openassetio::EntityReferences& entityRefs, format_context& ctx) const
+    -> decltype(ctx.out()) {
+  std::string result;
+
+  if (entityRefs.empty()) {
+    result = "[]";
+  } else {
+    result += "['";
+    result += fmt::format("{}", fmt::join(entityRefs, "', '"));
+    result += "']";
+  }
+
+  return fmt::formatter<string_view>::format(result, ctx);
+}
+
+auto fmt::formatter<openassetio::StrMap>::format(const openassetio::StrMap& strMap,
+                                                 format_context& ctx) const
+    -> decltype(ctx.out()) {
+  std::vector<std::string> flattenedStrMap;
+  flattenedStrMap.reserve(
+      strMap.size());  // Reserve space for the elements to avoid multiple allocations
+
+  for (const auto& kv : strMap) {
+    // Format each key-value pair into a single string
+    flattenedStrMap.push_back(fmt::format("'{}': '{}'", kv.first, kv.second));
+  }
+
+  return formatter<string_view>::format(fmt::format("{{{}}}", fmt::join(flattenedStrMap, ", ")),
+                                        ctx);
+}
+
+auto fmt::formatter<openassetio::managerApi::ManagerInterface::Capability>::format(
+    openassetio::managerApi::ManagerInterface::Capability capability, format_context& ctx) const
+    -> decltype(ctx.out()) {
+  return formatter<string_view>::format(
+      openassetio::managerApi::ManagerInterface::kCapabilityNames[static_cast<std::size_t>(
+          capability)],
+      ctx);
+}
+
+auto fmt::formatter<openassetio::hostApi::Manager::Capability>::format(
+    openassetio::hostApi::Manager::Capability capability, format_context& ctx) const
+    -> decltype(ctx.out()) {
+  return formatter<string_view>::format(
+      openassetio::managerApi::ManagerInterface::kCapabilityNames[static_cast<std::size_t>(
+          capability)],
+      ctx);
+}
+
+auto fmt::formatter<openassetio::errors::BatchElementError::ErrorCode>::format(
+    openassetio::errors::BatchElementError::ErrorCode errorCode, format_context& ctx) const
+    -> decltype(ctx.out()) {
+  return formatter<string_view>::format(openassetio::errors::errorCodeName(errorCode), ctx);
+}
+
+auto fmt::formatter<openassetio::errors::BatchElementError>::format(
+    const openassetio::errors::BatchElementError& ber, format_context& ctx) const
+    -> decltype(ctx.out()) {
+  openassetio::Str out = fmt::format("{}: {}", ber.code, ber.message);
+  return formatter<string_view>::format(out, ctx);
+}
+
+auto fmt::formatter<openassetio::trait::TraitSet>::format(
+    const openassetio::trait::TraitSet& traitSet, format_context& ctx) const
+    -> decltype(ctx.out()) {
+  std::vector<std::string> quotedTraitSet;
+  quotedTraitSet.reserve(traitSet.size());
+  std::transform(traitSet.cbegin(), traitSet.cend(), std::back_inserter(quotedTraitSet),
+                 [](const std::string& trait) { return fmt::format("'{}'", trait); });
+
+  return fmt::formatter<string_view>::format(
+      fmt::format("{{{}}}", fmt::join(quotedTraitSet, ", ")), ctx);
+}
+
+auto fmt::formatter<openassetio::trait::TraitSets>::format(
+    const openassetio::trait::TraitSets& traitSets, format_context& ctx) const
+    -> decltype(ctx.out()) {
+  return fmt::formatter<string_view>::format(fmt::format("[{}]", fmt::join(traitSets, ", ")), ctx);
+}
+
+namespace {
+struct ToStringVisitor {
+  std::string operator()(openassetio::Str arg) const { return fmt::format("'{}'", arg); }
+  std::string operator()(openassetio::Float arg) const { return std::to_string(arg); }
+  std::string operator()(openassetio::Int arg) const { return std::to_string(arg); }
+  std::string operator()(openassetio::Bool arg) const { return arg ? "True" : "False"; }
+};
+}  // namespace
+auto fmt::formatter<openassetio::trait::property::Value>::format(
+    const openassetio::trait::property::Value& val, format_context& ctx) const
+    -> decltype(ctx.out()) {
+  return fmt::formatter<string_view>::format(std::visit(ToStringVisitor(), val), ctx);
+}
+
+auto fmt::formatter<openassetio::InfoDictionary>::format(
+    const openassetio::InfoDictionary& infoDict, format_context& ctx) const
+    -> decltype(ctx.out()) {
+  std::vector<std::string> flattenedStrMap;
+  flattenedStrMap.reserve(
+      infoDict.size());  // Reserve space for the elements to avoid multiple allocations
+
+  for (const auto& kv : infoDict) {
+    // Format each key-value pair into a single string
+    flattenedStrMap.push_back(
+        fmt::format("'{}': {}", kv.first, std::visit(ToStringVisitor(), kv.second)));
+  }
+
+  return formatter<string_view>::format(fmt::format("{{{}}}", fmt::join(flattenedStrMap, ", ")),
+                                        ctx);
+}
+
+auto fmt::formatter<openassetio::ContextPtr>::format(const openassetio::ContextPtr& context,
+                                                     format_context& ctx) const
+    -> decltype(ctx.out()) {
+  if (context == nullptr) {
+    return fmt::formatter<string_view>::format("null", ctx);
+  }
+  fmt::formatter<openassetio::Context> valueFormatter;
+  return valueFormatter.format(*context, ctx);
+}
+
+auto fmt::formatter<openassetio::ContextConstPtr>::format(
+    const openassetio::ContextConstPtr& context, format_context& ctx) const
+    -> decltype(ctx.out()) {
+  if (context == nullptr) {
+    return fmt::formatter<string_view>::format("null", ctx);
+  }
+  fmt::formatter<openassetio::Context> valueFormatter;
+  return valueFormatter.format(*context, ctx);
+}
+
+auto fmt::formatter<openassetio::Context>::format(const openassetio::Context& context,
+                                                  format_context& ctx) const
+    -> decltype(ctx.out()) {
+  openassetio::Str out = fmt::format("{{'locale': {}, 'managerState': {}}}", context.locale,
+                                     static_cast<void*>(context.managerState.get()));
+
+  return fmt::formatter<string_view>::format(out, ctx);
+}
+
+auto fmt::formatter<openassetio::trait::TraitsDataPtr>::format(
+    const openassetio::trait::TraitsDataPtr& traitsData, format_context& ctx) const
+    -> decltype(ctx.out()) {
+  if (traitsData == nullptr) {
+    return fmt::formatter<string_view>::format("null", ctx);
+  }
+  fmt::formatter<openassetio::trait::TraitsData> valueFormatter;
+  return valueFormatter.format(*traitsData, ctx);
+}
+
+auto fmt::formatter<openassetio::trait::TraitsDataConstPtr>::format(
+    const openassetio::trait::TraitsDataConstPtr& traitsData, format_context& ctx) const
+    -> decltype(ctx.out()) {
+  if (traitsData == nullptr) {
+    return fmt::formatter<string_view>::format("null", ctx);
+  }
+  fmt::formatter<openassetio::trait::TraitsData> valueFormatter;
+  return valueFormatter.format(*traitsData, ctx);
+}
+
+auto fmt::formatter<openassetio::trait::TraitsData>::format(
+    const openassetio::trait::TraitsData& traitsData, format_context& ctx) const
+    -> decltype(ctx.out()) {
+  const auto traitSet = traitsData.traitSet();
+  std::vector<openassetio::Str> traitStrings;
+  traitStrings.reserve(traitSet.size());
+
+  for (const auto& traitId : traitSet) {
+    std::vector<std::string> propertyStrings;
+    const auto keys = traitsData.traitPropertyKeys(traitId);
+    std::transform(std::cbegin(keys), std::cend(keys), std::back_inserter(propertyStrings),
+                   [&traitsData, &traitId](const std::string& propertyKey) {
+                     openassetio::trait::property::Value out;
+                     traitsData.getTraitProperty(&out, traitId, propertyKey);
+                     return fmt::format(R"('{}': {})", propertyKey, out);
+                   });
+
+    // Add the string that makes up the trait, which is the dict section for the traitId,
+    // followed by all the property key value pairs.
+    traitStrings.push_back(fmt::format("'{}': {{{}}}", traitId, fmt::join(propertyStrings, ", ")));
+  }
+
+  // The idea here being that this is a valid python dict, hence all the extra brace formatting
+  return fmt::formatter<string_view>::format(fmt::format("{{{}}}", fmt::join(traitStrings, ", ")),
+                                             ctx);
+}

--- a/src/openassetio-core/src/utils/formatter.hpp
+++ b/src/openassetio-core/src/utils/formatter.hpp
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#pragma once
+
+#include <fmt/format.h>
+#include <openassetio/hostApi/Manager.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/trait/collection.hpp>
+#include <openassetio/typedefs.hpp>
+
+OPENASSETIO_FWD_DECLARE(errors, BatchElementError)
+OPENASSETIO_FWD_DECLARE(EntityReference)
+OPENASSETIO_FWD_DECLARE(Context)
+OPENASSETIO_FWD_DECLARE(hostApi, Manager)
+OPENASSETIO_FWD_DECLARE(managerApi, HostSession)
+OPENASSETIO_FWD_DECLARE(trait, TraitsData)
+
+// Provide fmt formatters for most OpenAssetIO types.
+// Whilst this is internal, it is implementation for public behaviour, such
+// as << operators and python `str` and `repr`
+
+template <>
+struct fmt::formatter<openassetio::EntityReference> : fmt::formatter<string_view> {
+  auto format(const openassetio::EntityReference& entityRef, format_context& ctx) const
+      -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::EntityReferences> : fmt::formatter<string_view> {
+  auto format(const openassetio::EntityReferences& entityRefs, format_context& ctx) const
+      -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::StrMap> : fmt::formatter<string_view> {
+  auto format(const openassetio::StrMap& strMap, format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::managerApi::ManagerInterface::Capability>
+    : fmt::formatter<string_view> {
+  auto format(openassetio::managerApi::ManagerInterface::Capability capability,
+              format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::hostApi::Manager::Capability> : fmt::formatter<string_view> {
+  auto format(openassetio::hostApi::Manager::Capability capability, format_context& ctx) const
+      -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::errors::BatchElementError::ErrorCode>
+    : fmt::formatter<string_view> {
+  auto format(openassetio::errors::BatchElementError::ErrorCode errorCode,
+              format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::errors::BatchElementError> : fmt::formatter<string_view> {
+  auto format(const openassetio::errors::BatchElementError& ber, format_context& ctx) const
+      -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::trait::TraitSet> : fmt::formatter<string_view> {
+  auto format(const openassetio::trait::TraitSet& traitSet, format_context& ctx) const
+      -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::trait::TraitSets> : fmt::formatter<string_view> {
+  auto format(const openassetio::trait::TraitSets& traitSets, format_context& ctx) const
+      -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::InfoDictionary> : fmt::formatter<string_view> {
+  auto format(const openassetio::InfoDictionary& infoDict, format_context& ctx) const
+      -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::trait::property::Value> : fmt::formatter<string_view> {
+  auto format(const openassetio::trait::property::Value& val, format_context& ctx) const
+      -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::ContextPtr> : fmt::formatter<string_view> {
+  auto format(const openassetio::ContextPtr& context, format_context& ctx) const
+      -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::ContextConstPtr> : fmt::formatter<string_view> {
+  auto format(const openassetio::ContextConstPtr& context, format_context& ctx) const
+      -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::Context> : fmt::formatter<string_view> {
+  auto format(const openassetio::Context& context, format_context& ctx) const
+      -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::trait::TraitsDataPtr> : fmt::formatter<string_view> {
+  auto format(const openassetio::trait::TraitsDataPtr& traitsData, format_context& ctx) const
+      -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::trait::TraitsDataConstPtr> : fmt::formatter<string_view> {
+  auto format(const openassetio::trait::TraitsDataConstPtr& traitsData, format_context& ctx) const
+      -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<openassetio::trait::TraitsData> : fmt::formatter<string_view> {
+  auto format(const openassetio::trait::TraitsData& traitsData, format_context& ctx) const
+      -> decltype(ctx.out());
+};

--- a/src/openassetio-core/src/utils/ostream.cpp
+++ b/src/openassetio-core/src/utils/ostream.cpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <openassetio/Context.hpp>
+#include <openassetio/EntityReference.hpp>
+#include <openassetio/managerApi/HostSession.hpp>
+#include <openassetio/utils/ostream.hpp>
+
+#include "formatter.hpp"
+
+#define OSTREAM_FMT_DEFINITION(Type)                                     \
+  std::ostream &operator<<(std::ostream &out, const Type &formattable) { \
+    out << fmt::format("{}", formattable);                               \
+    return out;                                                          \
+  }
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+OSTREAM_FMT_DEFINITION(EntityReference)
+OSTREAM_FMT_DEFINITION(EntityReferences)
+OSTREAM_FMT_DEFINITION(ContextPtr)
+OSTREAM_FMT_DEFINITION(ContextConstPtr)
+OSTREAM_FMT_DEFINITION(Context)
+
+namespace managerApi {
+OSTREAM_FMT_DEFINITION(ManagerInterface::Capability)
+}  // namespace managerApi
+
+namespace hostApi {
+OSTREAM_FMT_DEFINITION(Manager::Capability)
+}
+
+namespace errors {
+OSTREAM_FMT_DEFINITION(BatchElementError)
+OSTREAM_FMT_DEFINITION(BatchElementError::ErrorCode)
+}  // namespace errors
+
+namespace trait {
+OSTREAM_FMT_DEFINITION(TraitsDataPtr)
+
+OSTREAM_FMT_DEFINITION(TraitsDataConstPtr)
+
+OSTREAM_FMT_DEFINITION(TraitsData)
+
+namespace property {
+OSTREAM_FMT_DEFINITION(Value)
+}
+}  // namespace trait
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio
+
+namespace std {
+OSTREAM_FMT_DEFINITION(openassetio::StrMap)
+OSTREAM_FMT_DEFINITION(openassetio::InfoDictionary)
+OSTREAM_FMT_DEFINITION(openassetio::trait::TraitSet)
+OSTREAM_FMT_DEFINITION(openassetio::trait::TraitSets)
+}  // namespace std

--- a/src/openassetio-core/tests/CMakeLists.txt
+++ b/src/openassetio-core/tests/CMakeLists.txt
@@ -84,10 +84,13 @@ target_sources(openassetio-core-cpp-internal-test-exe
     PRIVATE
     # Implementation dependencies.
     ${PROJECT_SOURCE_DIR}/src/openassetio-core/src/utils/Regex.cpp
+    ${PROJECT_SOURCE_DIR}/src/openassetio-core/src/utils/formatter.cpp
+    ${PROJECT_SOURCE_DIR}/src/openassetio-core/src/errors/exceptionMessages.cpp
 
     # Tests.
     main.cpp
     utils/RegexTest.cpp
+    utils/PrintableTest.cpp
 )
 
 target_include_directories(

--- a/src/openassetio-core/tests/utils/PrintableTest.cpp
+++ b/src/openassetio-core/tests/utils/PrintableTest.cpp
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <sstream>
+
+#include <fmt/format.h>
+#include <catch2/catch.hpp>
+
+#include <openassetio/Context.hpp>
+#include <openassetio/errors/exceptions.hpp>
+#include <openassetio/hostApi/HostInterface.hpp>
+#include <openassetio/hostApi/Manager.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/managerApi/ManagerStateBase.hpp>
+#include <openassetio/trait/TraitsData.hpp>
+#include <openassetio/utils/ostream.hpp>
+#include "utils/formatter.hpp"
+
+namespace {
+
+template <typename T>
+void checkBasicPrintable(T&& value, const std::string& expected) {
+  // Check fmt::format
+  REQUIRE(fmt::format("{}", std::forward<T>(value)) == expected);
+
+  // Check stream operator
+  std::ostringstream oss;
+  oss << value;
+  REQUIRE(oss.str() == expected);
+}
+
+template <typename T>
+void checkBasicPrintableContains(T&& value, const std::string& expected) {
+  // Check fmt::format
+  REQUIRE_THAT(fmt::format("{}", std::forward<T>(value)), Catch::Matchers::Contains(expected));
+
+  // Check stream operator
+  std::ostringstream oss;
+  oss << value;
+  REQUIRE_THAT(oss.str(), Catch::Matchers::Contains(expected));
+}
+
+// This function is here because we can't assume order of set and map types.
+// Doing this characterwise check is _almost_ just as good.
+template <typename T>
+void checkBasicPrintableByCharacters(T&& value, const std::string& expected) {
+  auto sortedExpected = expected;
+  std::sort(sortedExpected.begin(), sortedExpected.end());
+
+  // Check fmt::format
+  auto sortedValueFromFmt = fmt::format("{}", std::forward<T>(value));
+  std::sort(sortedValueFromFmt.begin(), sortedValueFromFmt.end());
+  REQUIRE(sortedValueFromFmt == sortedExpected);
+
+  // Check stream operator
+  std::ostringstream oss;
+  oss << value;
+  auto sortedValueFromOstream = oss.str();
+  std::sort(sortedValueFromOstream.begin(), sortedValueFromOstream.end());
+  REQUIRE(sortedValueFromOstream == sortedExpected);
+}
+
+}  // namespace
+
+SCENARIO("Printing api types") {
+  GIVEN("Printable OpenAssetIO Types") {
+    openassetio::errors::BatchElementError batchElementError;
+    batchElementError.code = openassetio::errors::BatchElementError::ErrorCode::kInvalidTraitSet;
+    batchElementError.message = "Invalid trait set";
+
+    openassetio::EntityReference entityReference("test:///an_entity_reference");
+
+    openassetio::EntityReferences entityReferences;
+    entityReferences.emplace_back("test:///an_entity_reference_1");
+    entityReferences.emplace_back("test:///an_entity_reference_2");
+
+    openassetio::EntityReferences emptyEntityReferences;
+
+    openassetio::trait::TraitSet traitSet = {"trait1", "trait2"};
+    openassetio::trait::TraitSets traitSets = {{"trait1", "trait2"}, {"trait3", "trait4"}};
+
+    openassetio::Identifier identifier = "an identifier";
+
+    openassetio::Str str = "example string";
+
+    openassetio::StrMap strMap = {{"key1", "value1"}, {"key2", "value2"}};
+
+    openassetio::InfoDictionary infoDictionary = {{"key1", openassetio::Str("value1")},
+                                                  {"key2", false}};
+
+    openassetio::managerApi::ManagerInterface::Capability managerInterfaceCapability =
+        openassetio::managerApi::ManagerInterface::Capability::kPublishing;
+
+    openassetio::hostApi::Manager::Capability managerCapability =
+        openassetio::hostApi::Manager::Capability::kPublishing;
+
+    auto context = openassetio::Context::make();
+
+    context->locale->setTraitProperty("aTrait", "aIntTraitProperty", std::int64_t(2));
+    context->managerState = std::make_shared<openassetio::managerApi::ManagerStateBase>();
+
+    openassetio::trait::TraitsDataPtr traitsData = openassetio::trait::TraitsData::make();
+    traitsData->setTraitProperty("aTrait", "aIntTraitProperty", std::int64_t(2));
+    traitsData->setTraitProperty("aTrait", "aBoolTraitProperty", false);
+    traitsData->setTraitProperty("a.long.namespaced.trait.that.goes.on.and.on.and.on",
+                                 "aIntTraitProperty", std::int64_t(2));
+    traitsData->setTraitProperty("a.long.namespaced.trait.that.goes.on.and.on.and.on",
+                                 "aStringTraitProperty", openassetio::Str("a string"));
+    traitsData->setTraitProperty("a.long.namespaced.trait.that.goes.on.and.on.and.on",
+                                 "aBoolTraitProperty", true);
+    traitsData->addTrait("a.trait.with.no.properties");
+
+    WHEN("An InfoDictionary is printed") {
+      THEN("It can be printed via fmt and <<") {
+        checkBasicPrintableByCharacters(infoDictionary, "{'key2': False, 'key1': 'value1'}");
+      }
+    }
+
+    WHEN("A TraitSet is printed") {
+      THEN("It can be printed via fmt and <<") {
+        checkBasicPrintableByCharacters(traitSet, "{'trait2', 'trait1'}");
+      }
+    }
+
+    WHEN("TraitSets are printed") {
+      THEN("They can be printed via fmt and <<") {
+        checkBasicPrintableByCharacters(traitSets, "[{'trait2', 'trait1'}, {'trait4', 'trait3'}]");
+      }
+    }
+
+    WHEN("A BatchElementError is printed") {
+      THEN("It can be printed via fmt and <<") {
+        checkBasicPrintable(batchElementError, "invalidTraitSet: Invalid trait set");
+      }
+    }
+
+    WHEN("An EntityReference is printed") {
+      THEN("It can be printed via fmt and <<") {
+        checkBasicPrintable(entityReference, "test:///an_entity_reference");
+      }
+    }
+
+    WHEN("EntityReferences are printed") {
+      THEN("They can be printed via fmt and <<") {
+        checkBasicPrintable(entityReferences,
+                            "['test:///an_entity_reference_1', 'test:///an_entity_reference_2']");
+        checkBasicPrintable(emptyEntityReferences, "[]");
+      }
+    }
+
+    WHEN("An Identifier is printed") {
+      THEN("It can be printed via fmt and <<") {
+        checkBasicPrintable(identifier, "an identifier");
+      }
+    }
+
+    WHEN("A Str is printed") {
+      THEN("It can be printed via fmt and <<") { checkBasicPrintable(str, "example string"); }
+    }
+
+    WHEN("A StrMap is printed") {
+      THEN("It can be printed via fmt and <<") {
+        checkBasicPrintableByCharacters(strMap, "{'key2': 'value2', 'key1': 'value1'}");
+      }
+    }
+
+    WHEN("A ManagerInterface Capability is printed") {
+      THEN("It can be printed via fmt and <<") {
+        checkBasicPrintable(managerInterfaceCapability, "publishing");
+      }
+    }
+
+    WHEN("A Manager Capability is printed") {
+      THEN("It can be printed via fmt and <<") {
+        checkBasicPrintable(managerCapability, "publishing");
+      }
+    }
+
+    WHEN("A Context is printed") {
+      THEN("It can be printed via fmt and <<") {
+        // No closing brace on purpose, to account for variant managerState memory address
+        checkBasicPrintableContains(*context,
+                                    R"({'locale': {'aTrait': {'aIntTraitProperty': 2}}, )"
+                                    R"('managerState': 0x)");
+        checkBasicPrintableContains(context, R"('locale': {'aTrait': {'aIntTraitProperty': 2}}, )"
+                                             R"('managerState': 0x)");
+
+        context = nullptr;
+        checkBasicPrintable(context, "null");
+      }
+    }
+
+    WHEN("A TraitsData is printed") {
+      THEN("It can be printed via fmt and <<") {
+        checkBasicPrintableByCharacters(
+            *traitsData,
+            R"({'aTrait': {'aIntTraitProperty': 2, 'aBoolTraitProperty': False}, )"
+            R"('a.long.namespaced.trait.that.goes.on.and.on.and.on': {'aIntTraitProperty': 2, )"
+            R"('aStringTraitProperty': 'a string', 'aBoolTraitProperty': True}, 'a.trait.with.no.properties': {}})");
+        checkBasicPrintableByCharacters(
+            traitsData,
+            R"({'aTrait': {'aIntTraitProperty': 2, 'aBoolTraitProperty': False}, )"
+            R"('a.long.namespaced.trait.that.goes.on.and.on.and.on': {'aIntTraitProperty': 2, )"
+            R"('aStringTraitProperty': 'a string', 'aBoolTraitProperty': True}, 'a.trait.with.no.properties': {}})");
+
+        traitsData = nullptr;
+        checkBasicPrintable(traitsData, "null");
+      }
+    }
+  }
+}

--- a/src/openassetio-python/cmodule/src/ContextBinding.cpp
+++ b/src/openassetio-python/cmodule/src/ContextBinding.cpp
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2024 The Foundry Visionmongers Ltd
+#include <sstream>
+
+#include <fmt/format.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include <openassetio/Context.hpp>
 #include <openassetio/managerApi/ManagerStateBase.hpp>
 #include <openassetio/trait/TraitsData.hpp>
+#include <openassetio/utils/ostream.hpp>
 
 #include "PyRetainingSharedPtr.hpp"
 #include "_openassetio.hpp"
@@ -34,6 +38,12 @@ void registerContext(const py::module& mod) {
       // same default `TraitsData` instance, where any mutations will
       // persist in the default.
       .def(py::init([]() { return Context::make(TraitsData::make(), ManagerStateBasePtr{}); }))
+      .def("__str__",
+           [](const Context& self) {
+             std::ostringstream stringStream;
+             stringStream << self;
+             return stringStream.str();
+           })
       .def_readwrite("locale", &Context::locale)
       .def_property(
           "managerState", [](const Context& self) { return self.managerState; },

--- a/src/openassetio-python/cmodule/src/EntityReferenceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/EntityReferenceBinding.cpp
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2024 The Foundry Visionmongers Ltd
+#include <sstream>
+
 #include <fmt/format.h>
+
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 
 #include <openassetio/EntityReference.hpp>
+#include <openassetio/utils/ostream.hpp>
 
 #include "_openassetio.hpp"
 
@@ -14,10 +18,17 @@ void registerEntityReference(const py::module& mod) {
   py::class_<EntityReference>{mod, "EntityReference", py::is_final()}
       .def(py::init<openassetio::Str>(), py::arg("entityReferenceString"))
       .def("toString", &EntityReference::toString)
-      .def("__str__", &EntityReference::toString)
+      .def("__str__",
+           [](const EntityReference& self) {
+             std::ostringstream stringStream;
+             stringStream << self;
+             return stringStream.str();
+           })
       .def("__repr__",
            [](const EntityReference& self) {
-             return fmt::format("<openassetio.EntityReference {}>", self.toString());
+             std::ostringstream stringStream;
+             stringStream << self;
+             return fmt::format("EntityReference('{}')", stringStream.str());
            })
       .def(py::self == py::self);  // NOLINT(misc-redundant-expression)
 }

--- a/src/openassetio-python/cmodule/src/errors/BatchElementErrorBinding.cpp
+++ b/src/openassetio-python/cmodule/src/errors/BatchElementErrorBinding.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2024 The Foundry Visionmongers Ltd
+#include <sstream>
 #include <string_view>
 
 #include <fmt/format.h>
@@ -8,6 +9,7 @@
 
 #include <openassetio/errors/BatchElementError.hpp>
 #include <openassetio/typedefs.hpp>
+#include <openassetio/utils/ostream.hpp>
 
 #include "../_openassetio.hpp"
 
@@ -31,8 +33,9 @@ void registerBatchElementError(const py::module& mod) {
       .def(py::self == py::self)  // NOLINT(misc-redundant-expression)
       .def_readonly("code", &BatchElementError::code)
       .def_readonly("message", &BatchElementError::message)
-      .def("__repr__", [](const BatchElementError& self) {
-        return fmt::format("BatchElementError({}, '{}')",
-                           py::str(py::cast(self.code)).cast<std::string_view>(), self.message);
+      .def("__str__", [](const BatchElementError& self) {
+        std::ostringstream stringStream;
+        stringStream << self;
+        return stringStream.str();
       });
 }

--- a/src/openassetio-python/cmodule/src/trait/TraitsDataBinding.cpp
+++ b/src/openassetio-python/cmodule/src/trait/TraitsDataBinding.cpp
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2024 The Foundry Visionmongers Ltd
 #include <optional>
+#include <sstream>
 
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
 #include <fmt/format.h>
-#include <fmt/ranges.h>
 
 #include <openassetio/trait/TraitsData.hpp>
 #include <openassetio/trait/collection.hpp>
+#include <openassetio/utils/ostream.hpp>
 
 #include "../_openassetio.hpp"
 
@@ -45,6 +46,15 @@ void registerTraitsData(const py::module& mod) {
           py::arg("traitId"), py::arg("propertyKey"))
       .def("traitPropertyKeys", &TraitsData::traitPropertyKeys, py::arg("traitId"))
       .def(py::self == py::self)  // NOLINT(misc-redundant-expression)
-      .def("__repr__",
-           [](const TraitsData& self) { return fmt::format("TraitsData({})", self.traitSet()); });
+      .def("__str__",
+           [](const TraitsData& self) {
+             std::ostringstream stringStream;
+             stringStream << self;
+             return stringStream.str();
+           })
+      .def("__repr__", [](const TraitsData& self) {
+        std::ostringstream stringStream;
+        stringStream << "TraitsData(" << self << ")";
+        return stringStream.str();
+      });
 }

--- a/src/openassetio-python/tests/package/test_batchelementerror.py
+++ b/src/openassetio-python/tests/package/test_batchelementerror.py
@@ -108,20 +108,6 @@ class Test_BatchElementError_equality:
         assert a_batch_element_error != b_batch_element_error
 
 
-class Test_BatchElementError_repr:
-    def test(self):
-        batch_element_error = BatchElementError(
-            BatchElementError.ErrorCode.kEntityResolutionError, "some error happened"
-        )
-
-        assert str(batch_element_error) == repr(batch_element_error)
-
-        assert (
-            str(batch_element_error)
-            == "BatchElementError(ErrorCode.kEntityResolutionError, 'some error happened')"
-        )
-
-
 class Test_BatchElementException:
     @pytest.mark.parametrize(
         "exception_code",

--- a/src/openassetio-python/tests/package/test_entityreference.py
+++ b/src/openassetio-python/tests/package/test_entityreference.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2022 The Foundry Visionmongers Ltd
+#   Copyright 2024 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -39,14 +39,6 @@ class Test_EntityReference_toString:
         expected = "ref://some/entity/🐈"
         an_entity_reference = EntityReference(expected)
         assert an_entity_reference.toString() == expected
-
-
-class Test_EntityReferenve_repr:
-    def test_returns_angle_bracket_string_with_class_and_value(self):
-        for ref_str in ("a://ref", "a 🦆 v1"):
-            expected = f"<openassetio.EntityReference {ref_str}>"
-            a_ref = EntityReference(ref_str)
-            assert repr(a_ref) == expected
 
 
 class Test_EntityReference_equality:

--- a/src/openassetio-python/tests/package/test_traitsdata.py
+++ b/src/openassetio-python/tests/package/test_traitsdata.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 The Foundry Visionmongers Ltd
+
 """
 Tests for the traits data container
 """
@@ -182,15 +185,6 @@ class Test_TraitsData_equality:
         data_b = TraitsData({"another_trait"})
         assert data_a != data_b
         assert data_a != data_b
-
-
-class Test_TraitsData_repr:
-    def test(self, a_traitsdata):
-        assert repr(a_traitsdata) == str(a_traitsdata)
-        assert (
-            str(a_traitsdata) == 'TraitsData({"first_trait", "second_trait"})'
-            or str(a_traitsdata) == 'TraitsData({"second_trait", "first_trait"})'
-        )
 
 
 @pytest.fixture

--- a/src/openassetio-python/tests/package/utils/test_printable.py
+++ b/src/openassetio-python/tests/package/utils/test_printable.py
@@ -1,0 +1,230 @@
+#
+# Copyright 2024 The Foundry Visionmongers Ltd
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Tests that cover the printing and formatting openassetio types
+"""
+
+# pylint: disable=invalid-name,redefined-outer-name
+# pylint: disable=too-few-public-methods
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+from ast import literal_eval
+import pytest
+
+from openassetio import EntityReference
+from openassetio.errors import BatchElementError
+from openassetio.managerApi import ManagerInterface
+from openassetio.managerApi import ManagerStateBase
+from openassetio.hostApi import Manager
+from openassetio import Context
+from openassetio.trait import TraitsData
+
+
+def checkBasicPrintable(value, expected_str, expected_repr=None):
+    if expected_repr is None:
+        expected_repr = expected_str
+
+    assert str(value) == expected_str
+    assert repr(value) == expected_repr
+
+
+def checkBasicPrintableContains(value, expected_str, expected_repr=None):
+    if expected_repr is None:
+        expected_repr = expected_str
+
+    assert expected_str in str(value)
+    assert expected_repr in repr(value)
+
+
+# This function is here because we can't assume order of set and map types.
+# Doing this characterwise check is _almost_ just as good.
+def checkBasicPrintableByCharacters(value, expected_str, expected_repr=None):
+    if expected_repr is None:
+        expected_repr = expected_str
+
+    assert sorted(expected_str) == sorted(str(value))
+    assert sorted(expected_repr) == sorted(repr(value))
+
+
+class Test_Printable:
+    def test_print_infoDictionary(self, an_info_dictionary):
+        checkBasicPrintableByCharacters(
+            an_info_dictionary, "{'key1': 'value1', 'key2': False, 'key3': 1, 'key4': 1.23}"
+        )
+
+    def test_print_traitSet(self, a_trait_set):
+        checkBasicPrintableByCharacters(a_trait_set, "{'trait2', 'trait1'}")
+
+    def test_print_traitSets(self, a_trait_sets):
+        checkBasicPrintableByCharacters(
+            a_trait_sets, "[{'trait2', 'trait1'}, {'trait4', 'trait3'}]"
+        )
+
+    def test_print_batchElementError(self, a_batch_element_error):
+        checkBasicPrintableContains(
+            a_batch_element_error,
+            "invalidTraitSet: Invalid trait set",
+            "<openassetio._openassetio.errors.BatchElementError object at 0x",
+        )
+
+    def test_print_entityReference(self, an_entity_reference):
+        checkBasicPrintable(
+            an_entity_reference,
+            "test:///an_entity_reference",
+            "EntityReference('test:///an_entity_reference')",
+        )
+
+    def test_print_entityReferences(self, an_entity_references):
+        checkBasicPrintable(
+            an_entity_references,
+            (
+                "[EntityReference('test:///an_entity_reference_1'), "
+                "EntityReference('test:///an_entity_reference_2')]"
+            ),
+        )
+
+    def test_print_identifier(self, an_identifier):
+        checkBasicPrintable(an_identifier, "an identifier", "'an identifier'")
+
+    def test_print_str(self, a_str):
+        checkBasicPrintable(a_str, "example string", "'example string'")
+
+    def test_print_stringMap(self, a_string_map):
+        checkBasicPrintableByCharacters(a_string_map, "{'key1': 'value1', 'key2': 'value2'}")
+
+    def test_print_managerInterface_capability(self, a_managerInterface_capability):
+        checkBasicPrintable(
+            a_managerInterface_capability, "Capability.kPublishing", "<Capability.kPublishing: 5>"
+        )
+
+    def test_print_managercapability(self, a_manager_capability):
+        checkBasicPrintable(
+            a_manager_capability, "Capability.kPublishing", "<Capability.kPublishing: 5>"
+        )
+
+    def test_print_context(self, a_context):
+        # No closing brace on purpose, to account for variant managerState memory address
+        checkBasicPrintableContains(
+            a_context,
+            r"{'locale': {'aTrait': {'aIntTraitProperty': 2}}, 'managerState': 0x",
+            "<openassetio._openassetio.Context object at 0x",
+        )
+
+    def test_print_traitsData(self, a_traitsData):
+
+        expected = {
+            "aTrait": {"aIntTraitProperty": 2, "aBoolTraitProperty": False},
+            "a.long.namespaced.trait.that.goes.on.and.on.and.on": {
+                "aIntTraitProperty": 2,
+                "aStringTraitProperty": "a string",
+                "aBoolTraitProperty": True,
+            },
+            "a.trait.with.no.properties": {},
+        }
+
+        # Traitsdata output should literally be a python dict.
+        traitsData_out_dict = literal_eval(str(a_traitsData))
+
+        assert traitsData_out_dict == expected
+
+
+@pytest.fixture
+def an_info_dictionary():
+    return {"key1": "value1", "key2": False, "key3": 1, "key4": 1.23}
+
+
+@pytest.fixture
+def a_trait_set():
+    return set({"trait1", "trait2"})
+
+
+@pytest.fixture
+def a_trait_sets():
+    return [{"trait1", "trait2"}, {"trait3", "trait4"}]
+
+
+@pytest.fixture
+def a_batch_element_error():
+    return BatchElementError(BatchElementError.ErrorCode.kInvalidTraitSet, "Invalid trait set")
+
+
+@pytest.fixture
+def an_entity_reference():
+    return EntityReference("test:///an_entity_reference")
+
+
+@pytest.fixture
+def an_entity_references():
+    return [
+        EntityReference("test:///an_entity_reference_1"),
+        EntityReference("test:///an_entity_reference_2"),
+    ]
+
+
+@pytest.fixture
+def an_identifier():
+    return "an identifier"
+
+
+@pytest.fixture
+def a_str():
+    return "example string"
+
+
+@pytest.fixture
+def a_string_map():
+    return {"key1": "value1", "key2": "value2"}
+
+
+@pytest.fixture
+def a_managerInterface_capability():
+    return ManagerInterface.Capability.kPublishing
+
+
+@pytest.fixture
+def a_manager_capability():
+    return Manager.Capability.kPublishing
+
+
+@pytest.fixture
+def a_context():
+    context = Context()
+    context.locale.setTraitProperty("aTrait", "aIntTraitProperty", 2)
+    context.managerState = ManagerStateBase()
+    return context
+
+
+@pytest.fixture
+def a_traitsData():
+    traitsData = TraitsData()
+    traitsData.setTraitProperty("aTrait", "aIntTraitProperty", 2)
+    traitsData.setTraitProperty("aTrait", "aBoolTraitProperty", False)
+    traitsData.setTraitProperty(
+        "a.long.namespaced.trait.that.goes.on.and.on.and.on", "aIntTraitProperty", 2
+    )
+    traitsData.setTraitProperty(
+        "a.long.namespaced.trait.that.goes.on.and.on.and.on", "aStringTraitProperty", "a string"
+    )
+    traitsData.setTraitProperty(
+        "a.long.namespaced.trait.that.goes.on.and.on.and.on", "aBoolTraitProperty", True
+    )
+    traitsData.addTrait("a.trait.with.no.properties")
+    return traitsData
+
+
+@pytest.fixture
+def a_manager(mock_manager_interface, a_host_session):
+    return Manager(mock_manager_interface, a_host_session)


### PR DESCRIPTION
## Description

Add fmt formatters for most useful OpenAssetIO types.
Wrap this internal formatting behaviour to implement public <<
operators for logging and printing.

Not totally consistent, and not totally all-encompasing either. Lots of decisions were made in a pairing context.

Closes #1307

- [x] I have updated the release notes.

Kept a bit split between python and C++ just for review convenience.
