### PR TITLE
[Build] Pin tomlplusplus recipe

### DIFF
--- a/resources/build/conanfile.py
+++ b/resources/build/conanfile.py
@@ -35,7 +35,11 @@ class OpenAssetIOConan(ConanFile):
         # CY2022
         self.requires("pybind11/2.10.1")
         # TOML library
-        self.requires("tomlplusplus/3.2.0")
+        # TODO (EM) Unpin this. This is only pinned because a recipe update
+        # seemed to remove all exceptions no matter how the configuration
+        # is set.
+        # https://github.com/conan-io/conan-center-index/pull/24336#issuecomment-2175846302
+        self.requires("tomlplusplus/3.2.0#e2e85cfd0746ace46d77657fa1103045")
         # URL processing
         self.requires("ada/2.7.4")
         # Regex

--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -148,4 +148,4 @@ environment-pass = ["PIP_VERBOSE", "OPENASSETIO_TEST_ENABLE_PYTHON_STUBGEN"]
 [tool.cibuildwheel.linux]
 # Linux runs in a docker container, with the project at top level
 before-build = "resources/build/bootstrap-cibuildwheel-manylinux-2014.sh"
-environment = { CMAKE_TOOLCHAIN_FILE=".conan/conan_paths.cmake" }
+environment = { CMAKE_TOOLCHAIN_FILE=".conan/conan_paths.cmake", CONAN_REVISIONS_ENABLED=1 }


### PR DESCRIPTION
The tomlplusplus recipe got updated to include support for setting exceptions enabled explicitly.

Unfortunately, this seemed to disable exceptions no matter what. Pinning until this is resolved.

https://github.com/conan-io/conan-center-index/pull/24336

This was found by our `cibuildwheel` tests. As that runs in a fresh container each time. It dosen't have a conancache to depend on, so got the new recipe strait away. https://github.com/OpenAssetIO/OpenAssetIO/actions/runs/9560287692/job/26352138550
