### PR TITLE
Revert tomlplusplus recipe revision pin

### DIFF
--- a/resources/build/conanfile.py
+++ b/resources/build/conanfile.py
@@ -39,7 +39,7 @@ class OpenAssetIOConan(ConanFile):
         # seemed to remove all exceptions no matter how the configuration
         # is set.
         # https://github.com/conan-io/conan-center-index/pull/24336#issuecomment-2175846302
-        self.requires("tomlplusplus/3.2.0#e2e85cfd0746ace46d77657fa1103045")
+        self.requires("tomlplusplus/3.2.0")
         # URL processing
         self.requires("ada/2.7.4")
         # Regex

--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -148,4 +148,4 @@ environment-pass = ["PIP_VERBOSE", "OPENASSETIO_TEST_ENABLE_PYTHON_STUBGEN"]
 [tool.cibuildwheel.linux]
 # Linux runs in a docker container, with the project at top level
 before-build = "resources/build/bootstrap-cibuildwheel-manylinux-2014.sh"
-environment = { CMAKE_TOOLCHAIN_FILE=".conan/conan_paths.cmake", CONAN_REVISIONS_ENABLED=1 }
+environment = { CMAKE_TOOLCHAIN_FILE=".conan/conan_paths.cmake" }


### PR DESCRIPTION
## Description

An update to the Conan recipe for tomlplusplus meant that exceptions were disabled and there was no way to re-enable them, so we had to pin the recipe to the previous revision.

An upstream fix has now been pushed (conan-io/conan-center-index#24385), so we can revert the recipe revision pin.
