### PR TITLE
Disable internal BatchElementError deprecation warnings

### DIFF
--- a/src/openassetio-core/src/BatchElementError.cpp
+++ b/src/openassetio-core/src/BatchElementError.cpp
@@ -1,5 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 The Foundry Visionmongers Ltd
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <openassetio/BatchElementError.hpp>
 
 // This file exists soley to ensure the symbol is used to


### PR DESCRIPTION
## Description

Discovered whilst working on OpenAssetIO/usdOpenAssetIOResolver#39, which required use of VFX Reference Platform CY23, i.e. GCC 11. We currently work on CY22, i.e. GCC 9.3.

When bumping to GCC 11 `-Werror` causes the build to fail with `-Werror=deprecated-declarations` because we deliberately include the deprecated `BatchElementException` types in the binary, to satisfy symbol discovery on Windows.

The fact this isn't flagged as an error when compiling with GCC 9.3 is probably a deficiency in that compiler version.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~
