### PR TITLE
[CI] Allow use of Node 16

### DIFF
--- a/.github/workflows/build-vfx-reference-platform.yml
+++ b/.github/workflows/build-vfx-reference-platform.yml
@@ -17,6 +17,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Buy some more time to use the deprecated Node 16 (needed for GLIBC
+  # version - also see comment re. pinning to actions/checkout@v3).
+  # Upgrading to the CY23 Docker images will solve this longer term. See
+  # https://github.com/OpenAssetIO/OpenAssetIO/issues/984#issuecomment-2210792734
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   build:
     name: Build and test

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -5,6 +5,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Buy some more time to use the deprecated Node 16 (needed for GLIBC
+  # version - also see comment re. pinning to actions/checkout@v3).
+  # Upgrading to the CY23 Docker images will solve this longer term. See
+  # https://github.com/OpenAssetIO/OpenAssetIO/issues/984#issuecomment-2210792734
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   pylint:
     runs-on: ${{ matrix.config.os }}


### PR DESCRIPTION
## Description

We have CI tests that use our Docker image, which is based on the ASWF VFX Reference Platform 2022 image, whose glibc version is rather old. This makes it incompatible with Node 20. We have been holding back the
version of `actions/checkout` to ensure Node 16 was still used. However, GitHub have started forcing Node 20 regardless. 

See
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

Example failure [here](https://github.com/OpenAssetIO/OpenAssetIO/actions/runs/9807282377/job/27080742052?pr=1342)

That link gives a way to buy more time on Node 16 via a `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` env var, which we can use for now.

The real fix will be to upgrade our Docker image, which will be done in https://github.com/OpenAssetIO/OpenAssetIO/issues/984.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~
