### PR TITLE
Fix C++ plugin loading from Python

### DIFF
--- a/.github/workflows/build-instructions.yml
+++ b/.github/workflows/build-instructions.yml
@@ -78,45 +78,6 @@ jobs:
     - name: Run Python tests
       run: pytest src/openassetio-python/tests/package
 
-  editable_pip_install:
-    name: Editable pip install on  ${{ matrix.config.os }}
-    runs-on: ${{ matrix.config.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - os: windows-2019
-            preamble: call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64
-            shell: cmd
-          - os: ubuntu-20.04
-            shell: bash
-          - os: macos-12
-            shell: bash
-    defaults:
-      run:
-        # Annoyingly required here since `matrix` isn't available in
-        # the `shell` property of individual steps.
-        shell: ${{ matrix.config.shell }}
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Bootstrap
-      uses: ./.github/bootstrap_platform
-
-    - name: Install using pip
-      run: |
-        ${{ matrix.config.preamble }}
-        python -m pip install --editable src/openassetio-python
-      env:
-        CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/.conan/conan_paths.cmake
-
-    - name: Install test dependencies
-      run: pip install -r src/openassetio-python/tests/requirements.txt
-
-    - name: Run Python tests
-      run: pytest src/openassetio-python/tests/package
-
   disallowed_pip_install:
     name: Disallowed pip install on  ${{ matrix.config.os }}
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -166,6 +166,8 @@ jobs:
           # warnings, sanitizers. Will need additional CMake preset(s).
           OPENASSETIO_TRAITGENTEST_CMAKE_PRESET: test
           CONAN_USER_HOME: ~/conan
+          # For Windows:
+          OPENASSETIO_DLL_PATH: ${{ github.workspace }}/dist/bin
 
       - name: Checkout OpenAssetIO-Test-CMake
         uses: actions/checkout@v4
@@ -193,6 +195,8 @@ jobs:
         env:
           CMAKE_PREFIX_PATH: ${{ github.workspace }}/dist
           CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/.conan/conan_paths.cmake
+          # For Windows:
+          OPENASSETIO_DLL_PATH: ${{ github.workspace }}/dist/bin
 
       # TODO(DF): SimpleCppManager should (also) be tested as part of
       # Python e2e tests, once we fix loading C++ plugins from Python.
@@ -226,3 +230,5 @@ jobs:
           OPENASSETIO_LOGGING_SEVERITY: 1
           OPENASSETIO_PLUGIN_PATH: ${{ github.workspace }}/dist/plugins
           OPENASSETIO_DEFAULT_CONFIG: ${{ github.workspace }}/examples/manager/SimpleCppManager/tests/resources/openassetio_config.toml
+          # For Windows:
+          OPENASSETIO_DLL_PATH: ${{ github.workspace }}/dist/bin

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -198,8 +198,49 @@ jobs:
           # For Windows:
           OPENASSETIO_DLL_PATH: ${{ github.workspace }}/dist/bin
 
-      # TODO(DF): SimpleCppManager should (also) be tested as part of
-      # Python e2e tests, once we fix loading C++ plugins from Python.
+  cpp-manager-plugin:
+    name: C++ manager plugin on ${{ matrix.config.os }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - os: windows-2019
+            preamble: call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64
+            site-packages: Lib/site-packages
+            shell: cmd
+          - os: ubuntu-20.04
+            site-packages: lib/python3.9/site-packages
+            shell: bash
+          - os: macos-12
+            site-packages: lib/python3.9/site-packages
+            shell: bash
+    defaults:
+      run:
+        shell: ${{ matrix.config.shell }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bootstrap
+        uses: ./.github/bootstrap_platform
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install pytest
+
+      - name: Build/install OpenAssetIO (CMake)
+        run: >
+          ${{ matrix.config.preamble }}
+
+          cmake -S . -B build --install-prefix ${{ github.workspace }}/dist
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+          cmake --build build --parallel --config RelWithDebInfo
+
+          cmake --install build --config RelWithDebInfo
+        env:
+          CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/.conan/conan_paths.cmake
 
       - name: Build/install SimpleCppManager
         run: >
@@ -219,9 +260,9 @@ jobs:
         env:
           CMAKE_PREFIX_PATH: ${{ github.workspace }}/dist
 
-      - name: Test SimpleCppManager with simpleResolver
+      - name: Test SimpleCppManager with simpleResolver (via CMake install tree)
         run: >
-          python '${{ github.workspace }}/examples/host/simpleResolver/simpleResolver.py'
+          python ${{ github.workspace }}/examples/host/simpleResolver/simpleResolver.py
           openassetio-mediacreation:identity.DisplayName simplecpp://test/entity/1
           | grep 'Test Entity 1'
 
@@ -232,3 +273,21 @@ jobs:
           OPENASSETIO_DEFAULT_CONFIG: ${{ github.workspace }}/examples/manager/SimpleCppManager/tests/resources/openassetio_config.toml
           # For Windows:
           OPENASSETIO_DLL_PATH: ${{ github.workspace }}/dist/bin
+
+      - name: Build/install OpenAssetIO (setup.py)
+        run: |
+          ${{ matrix.config.preamble }}
+          python -m pip install src/openassetio-python
+        env:
+          CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/.conan/conan_paths.cmake
+
+      - name: Test SimpleCppManager with simpleResolver (via Python distribution)
+        run: >
+          python ${{ github.workspace }}/examples/host/simpleResolver/simpleResolver.py
+          openassetio-mediacreation:identity.DisplayName simplecpp://test/entity/1
+          | grep 'Test Entity 1'
+
+        env:
+          OPENASSETIO_LOGGING_SEVERITY: 1
+          OPENASSETIO_PLUGIN_PATH: ${{ github.workspace }}/dist/plugins
+          OPENASSETIO_DEFAULT_CONFIG: ${{ github.workspace }}/examples/manager/SimpleCppManager/tests/resources/openassetio_config.toml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2013-2022 The Foundry Visionmongers Ltd
+# Copyright 2013-2024 The Foundry Visionmongers Ltd
 
 #-----------------------------------------------------------------------
 # CMake preamble.
@@ -110,7 +110,8 @@ include(CMakeDependentOption)
 # TODO(DF): We may end up needing to support building of both shared
 #   and static libs simultaneously. Also, using this means we inherit
 #   the option if openassetio is used as a CMake subproject.
-option(BUILD_SHARED_LIBS "Set to OFF to build static libraries" ON)
+option(BUILD_SHARED_LIBS
+    "Set to OFF to build static libraries. Static libaries are not recommended." ON)
 
 # Enable Python bindings build by default.
 option(OPENASSETIO_ENABLE_PYTHON "Build Python bindings" ON)
@@ -218,6 +219,20 @@ option(OPENASSETIO_ENABLE_CPPLINT "Enable cpplint linter during build" OFF)
 
 # Enable cmake-lint linter.
 option(OPENASSETIO_ENABLE_CMAKE_LINT "Enable cmake-lint linter during build" OFF)
+
+
+#-----------------------------------------------------------------------
+# Warn against static library builds
+
+if (NOT BUILD_SHARED_LIBS)
+    message(WARNING [[
+Building OpenAssetIO as a static library is not recommended. For C++
+plugins to load, the necessary symbols must be exported and be available
+to link against. In addition, C++ plugins will generally have a
+dependency on the OpenAssetIO core C++ shared library file, and if that
+file is not available (because it has been statically linked into a
+larger binary), then the plugin will fail to load.]])
+endif()
 
 
 #-----------------------------------------------------------------------

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,7 +68,8 @@
       "description": "Settings for building Python extension module consumed by setuptools",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "BUILD_SHARED_LIBS": "OFF",
+        "CMAKE_INSTALL_BINDIR": "openassetio",
+        "CMAKE_INSTALL_LIBDIR": "openassetio",
         "OPENASSETIO_PYTHON_SITEDIR": "."
       }
     },

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,11 @@ v1.0.0-beta.x.x
   should still be preferred as a test manager when Python is available.
   [#1324](https://github.com/OpenAssetIO/OpenAssetIO/issues/1324)
 
+- For Windows users, added `OPENASSETIO_DLL_PATH` environment variable
+  to allow non-standard Python installations to locate
+  `openassetio.dll`, if required.
+  [#1340](https://github.com/OpenAssetIO/OpenAssetIO/issues/1340)
+
 ### Improvements
 
 - Added singular overload of `managementPolicy` for convenience.
@@ -29,6 +34,13 @@ v1.0.0-beta.x.x
 - Added a type hint for the `Manager` instance injected into the
   `openassetio.test.manager` API Compliance test harness, to aid in
   IDE code completion when writing test cases for manager plugins.
+
+### Bug fixes
+
+- Modified OpenAssetIO Python distributions (e.g. installed with `pip
+  install`) to allow C++ plugins to load. OpenAssetIO is now bundled as
+  multiple shared libraries, allowing external libraries to link.
+  [#1340](https://github.com/OpenAssetIO/OpenAssetIO/issues/1340)
 
 v1.0.0-beta.2.2
 ---------------

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -160,6 +160,18 @@ if (OPENASSETIO_ENABLE_PYTHON)
         OPENASSETIO_TEST_ENABLE_PYTHON_STUBGEN=$<BOOL:${OPENASSETIO_ENABLE_PYTHON_STUBGEN}>
     )
 
+    if (WIN32)
+        file(RELATIVE_PATH
+            _install_dir_rel_to_bin
+            "${CMAKE_INSTALL_PREFIX}/${OPENASSETIO_PYTHON_SITEDIR}/openassetio"
+            "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}")
+        # On Windows the _openassetio Python extension module may not be
+        # installed alongside the openassetio.dll core library, and
+        # loading the Python extension module will fail in that case
+        # unless we augment the DLL search path.
+        set(_pytest_env OPENASSETIO_DLL_PATH=${_install_dir_rel_to_bin} ${_pytest_env})
+    endif()
+
     #-------------------------------------------------------------------
     # Gather ASan-specific environment variables to prepend to the
     # `pytest` invocations.

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -108,8 +108,14 @@ cmake --install build
 The artifacts are installed to `/build/dist`. This default location can
 be overridden by setting `CMAKE_INSTALL_PREFIX` prior to build.
 
-By default, OpenAssetIO builds as a shared library. This can be
-overridden by setting `BUILD_SHARED_LIBS` prior to build.
+By default, OpenAssetIO builds as a shared library.
+
+> **Warning**
+>
+> It is strongly recommended that OpenAssetIO is built as a shared
+> library, to ensure that OpenAssetIO C++ manager plugins can load
+> correctly.
+
 If shared library builds are disabled, then the core library will
 be built and installed as a static library, and statically linked into
 the Python module.
@@ -168,7 +174,6 @@ behaviour of the build.
 
 | Option                                            | Description                                                           | Default |
 |---------------------------------------------------|-----------------------------------------------------------------------|---------|
-| `BUILD_SHARED_LIBS`                               | `ON` to build shared libraries. `OFF` to build static libraries.      | `ON`    |
 | `OPENASSETIO_ENABLE_PYTHON`                       | Additionally build python bindings                                    | `ON`    |
 | `OPENASSETIO_ENABLE_PYTHON_INSTALL_DIST_INFO`     | Create a dist-info metadata directory alongside Python installation   | `ON`    |
 | `OPENASSETIO_ENABLE_C`                            | Additionally build C bindings                                         | `OFF`   |

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -124,13 +124,6 @@ In installing the Python module, OpenAssetIO creates a valid Python
 package, placed at
 `build/dist/lib/{python-version}/site-packages/openassetio`.
 
-> **Note**
->
-> When built this way, the `openassetio` Python package will not
-> function unless the binary artifacts are also made available to your
-> Python environment.
->
-
 ### Building via pip
 
 OpenAssetIO can alternately be built and installed via `pip`, which may
@@ -144,22 +137,6 @@ python -m pip install src/openassetio-python
 This will automatically build and install the Python extension module
 into your python environment, along with the Python sources. After this,
 you should be able to simply `import openassetio` from your python shell.
-
-> **Note**
->
-> `pip install src/openassetio-python` is not a substantially different
-> operation to calling CMake directly as described above (and as such,
-> all the same dependency requirements apply).
->
-> However, be aware that once the C++
-> library is built, it is statically, rather than dynamically, linked
-> into the python libraries, and is not usable as a standalone
-> OpenAssetIO C++ library.
->
-> This means that this method of building is only appropriate for the
-> exclusively python focused developer. Anyone wishing to write
-> non-python hosts or managers should build via the CMake method
-> described above.
 
 ### Sandboxed builds
 

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -155,14 +155,6 @@ you should be able to simply `import openassetio` from your python shell.
 > non-python hosts or managers should build via the CMake method
 > described above.
 
-For users that wish to modify the Python sources and test their changes
-without reinstalling, [editable installs](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs)
-are also supported
-
-```shell
-python -m pip install --editable src/openassetio-python
-```
-
 ### Sandboxed builds
 
 For a more convenient "out of the box" build environments, OpenAssetIO

--- a/doc/doxygen/src/Glossary.dox
+++ b/doc/doxygen/src/Glossary.dox
@@ -282,6 +282,17 @@
  * is then controlled by the host's own configuration mechanism(s).
  *
  *
+ * @section dll_path_var $OPENASSETIO_DLL_PATH
+ *
+ * When using OpenAssetIO via Python on Windows, this environment
+ * variable can be set to the directory containing openassetio.dll, to
+ * ensure importing `openassetio` succeeds. This is useful if the
+ * particular OpenAssetIO deployment places the openassetio.dll core
+ * library outside the standard Python search path. If a relative path
+ * is given, it is assumed to be relative to the `openassetio` package
+ * directory.
+ *
+ *
  * @section manager_state Manager State
  *
  * The @ref ManagerInterface is a reentrant API by design, and its

--- a/examples/manager/SimpleCppManager/CMakeLists.txt
+++ b/examples/manager/SimpleCppManager/CMakeLists.txt
@@ -115,15 +115,12 @@ if (NOT TARGET OpenAssetIO::openassetio-core)
 endif ()
 
 # Link to the OpenAssetIO core library.
-# TODO(DF): ideally we'd use CMake's `$<COMPILE_ONLY:` here, to avoid
-# baking in a dependency on the OpenAssetIO core library. In theory, the
-# OpenAssetIO symbols should already be available in the process
-# environment by the time the plugin is loaded (its loaded by
-# OpenAssetIO!). However, Python (and any other process that loads
+# Note that we cannot reliably avoid baking in a dependency on the
+# OpenAssetIO core library. Python (and any other process that loads
 # OpenAssetIO with RTLD_LOCAL or equivalent) will not expose the
-# OpenAssetIO symbols to the plugin. So we need to link the plugin to
-# the OpenAssetIO library explicitly. This means the plugin will not
-# load if the OpenAssetIO core C++ shared library is not found, e.g. if
+# OpenAssetIO symbols publicly. So we need to link the plugin to the
+# OpenAssetIO library explicitly. This means the plugin will not load if
+# the OpenAssetIO core C++ shared library is not found, e.g. if
 # OpenAssetIO is statically linked into a larger third-party binary.
 target_link_libraries(${_target_name} PRIVATE OpenAssetIO::openassetio-core)
 

--- a/examples/manager/SimpleCppManager/tests/CMakeLists.txt
+++ b/examples/manager/SimpleCppManager/tests/CMakeLists.txt
@@ -25,6 +25,21 @@ list(APPEND _envmod
 
 list(APPEND _envmod "OPENASSETIO_LOGGING_SEVERITY=1")
 
+# On Windows we (might) need to augment the DLL search path.
+if (WIN32)
+    # The dll will be in OPENASSETIO_BINARY_DIR, which is set in the
+    # OpenAssetIO CMake config file, and so is only available if we used
+    # `find_package(OpenAssetIO)`.
+    # If the variable is not available, then we must be building as a
+    # subproject of the parent OpenAssetIO project.
+    if (NOT DEFINED OPENASSETIO_BINARY_DIR)
+        # If building as part of OpenAssetIO, then we know where the
+        # OpenAssetIO DLLs are installed.
+        set(OPENASSETIO_BINARY_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}")
+    endif ()
+    list(APPEND _envmod "OPENASSETIO_DLL_PATH=${OPENASSETIO_BINARY_DIR}")
+endif ()
+
 # Add pytest test
 add_test(
     NAME openassetio.example.${PROJECT_NAME}.pytest

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -43,8 +43,6 @@ set_target_properties(openassetio-core PROPERTIES OUTPUT_NAME openassetio)
 install(TARGETS openassetio-core EXPORT ${PROJECT_NAME}_EXPORTED_TARGETS)
 
 if (WIN32)
-    install(TARGETS openassetio-core
-        DESTINATION "${OPENASSETIO_PYTHON_SITEDIR}/openassetio")
     # "TARGET_PDB_FILE is allowed only for targets with linker created
     # artifacts"
     if (BUILD_SHARED_LIBS)

--- a/src/openassetio-python/bridge/CMakeLists.txt
+++ b/src/openassetio-python/bridge/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2013-2022 The Foundry Visionmongers Ltd
+# Copyright 2013-2024 The Foundry Visionmongers Ltd
 
 #----------------------------------------------------------------------
 # Public headers
@@ -35,8 +35,6 @@ install(TARGETS openassetio-python-bridge EXPORT ${PROJECT_NAME}_EXPORTED_TARGET
 
 # TODO(DF): This needs some thought to get right - see #538.
 if (WIN32 AND OPENASSETIO_ENABLE_PYTHON)
-    install(TARGETS openassetio-python-bridge
-        DESTINATION "${OPENASSETIO_PYTHON_SITEDIR}/openassetio")
     # "TARGET_PDB_FILE is allowed only for targets with linker created
     # artifacts"
     if (BUILD_SHARED_LIBS)

--- a/src/openassetio-python/cmodule/CMakeLists.txt
+++ b/src/openassetio-python/cmodule/CMakeLists.txt
@@ -30,8 +30,21 @@ install(
     TARGETS openassetio-python-module
     EXPORT ${PROJECT_NAME}_EXPORTED_TARGETS
     DESTINATION ${_install_subdir}
-    COMPONENT openassetio-python-module
+    COMPONENT openassetio-python-distribution
 )
+if (BUILD_SHARED_LIBS)
+    # For a shared library build, we must ensure the core C++ library
+    # dependency is installed when the Python extension module component
+    # is installed. The openassetio-python-distribution component is
+    # targeted for install when building Python wheels - see setup.py.
+    # In addition, ensure the Python bridge library is also available,
+    # to enable (the albeit rare case of) C++ plugin direct interaction
+    # with Python objects.
+    install(
+        TARGETS openassetio-core openassetio-python-bridge
+        COMPONENT openassetio-python-distribution
+    )
+endif ()
 
 
 #-----------------------------------------------------------------------
@@ -151,7 +164,7 @@ if (OPENASSETIO_ENABLE_PYTHON_STUBGEN)
             " pybind11-stubgen not found: status=${_pybind11_stubgen_exit_code}:"
             " ${_pybind11_stubgen_output}"
         )
-    endif()
+    endif ()
 
     # Create temporary pseudo-package directory.
     add_custom_command(
@@ -167,6 +180,10 @@ if (OPENASSETIO_ENABLE_PYTHON_STUBGEN)
         # Note that this must be done _after_ the build, otherwise
         # Windows (Visual Studio CMake generator) complains that the
         # build directory already exists.
+        # Also note OPENASSETIO_DLL_PATH does not work here, since that
+        # requires the top-level `openassetio.__init__.py` to be
+        # importable, but it lives in a different directory (at build
+        # time).
         add_custom_command(
             TARGET openassetio-python-module POST_BUILD
             COMMAND
@@ -174,7 +191,7 @@ if (OPENASSETIO_ENABLE_PYTHON_STUBGEN)
             "$<TARGET_FILE:openassetio-core>"
             "${CMAKE_CURRENT_BINARY_DIR}/openassetio/"
         )
-    endif()
+    endif ()
 
     # Execute commands to generate .pyi stubs.
     add_custom_command(
@@ -208,18 +225,18 @@ if (OPENASSETIO_ENABLE_PYTHON_STUBGEN)
 
     # Add stub files to the Python extension module installation
     # component, so that
-    # `cmake --install --component openassetio-python-module` will
+    # `cmake --install --component openassetio-python-distribution` will
     # include the stubs.
     install(
         # pybind11-stubgen generates stubs for openassetio._openassetio
         # under an `openassetio/_openassetio` directory structure.
         DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/openassetio/_openassetio"
         DESTINATION "${_install_subdir}"
-        COMPONENT openassetio-python-module
+        COMPONENT openassetio-python-distribution
     )
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/openassetio/py.typed"
         DESTINATION "${_install_subdir}"
-        COMPONENT openassetio-python-module
+        COMPONENT openassetio-python-distribution
     )
 endif ()

--- a/src/openassetio-python/package/openassetio/__init__.py
+++ b/src/openassetio-python/package/openassetio/__init__.py
@@ -67,6 +67,14 @@ API documentation
 The documentation for OpenAssetIO can be found here:
    https://openassetio.github.io/OpenAssetIO.
 """
+import os
+
+# If Windows, we may need to wrangle DLL search paths.
+if os.name == "nt":
+    from . import _windows
+
+    _windows.addDllDirectoryFromEnvVar()
+
 
 # pylint: disable=wrong-import-position,import-error,no-name-in-module
 from ._openassetio import (

--- a/src/openassetio-python/package/openassetio/_windows.py
+++ b/src/openassetio-python/package/openassetio/_windows.py
@@ -1,0 +1,82 @@
+#
+#   Copyright 2024 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Utility module to handle Windows dll loading idiosyncrasies.
+
+The _openassetio Python C extension module has a dependency on the core
+OpenAssetIO library. We cannot, in general, predict where this library
+will be installed. On Linux/macOS, the rpath mechanism can be used by
+installers. In Python 3.8+ on Windows, the best we can do is add to the
+search paths here, allowing the user (or wrapper application) to control
+the additional search path with an environment variable.
+"""
+import os
+import warnings
+import importlib
+import pathlib
+
+
+def addDllDirectoryFromEnvVar():
+    """
+    Add a DLL search path from the OPENASSETIO_DLL_PATH environment
+    variable, if provided, and check if the openassetio Python C
+    extension module can be imported.
+
+    A relative path will be interpreted as relative to the openassetio
+    package directory.
+
+    Use the warnings module to provide helpful output if the import
+    fails and/or the search path is invalid. Using the warnings module
+    means that users can filter them if desired for a particular
+    installation.
+
+    An ImportWarning might seem more appropriate than the default
+    (UserWarning), but Python will not print ImportWarnings unless the
+    user explicitly enables them.
+    """
+
+    searchPath = os.environ.get("OPENASSETIO_DLL_PATH")
+    if searchPath is not None:
+        searchPath = pathlib.Path(searchPath)
+        # Join path to directory of package if it is relative, else use
+        # verbatim.
+        if searchPath.is_absolute():
+            fullSearchPath = searchPath
+        else:
+            fullSearchPath = (pathlib.Path(__file__).parent / searchPath).resolve(strict=False)
+
+        # Warn if openassetio.dll is not found in the configured search
+        # path.
+        if not (fullSearchPath / "openassetio.dll").is_file():
+            warning = f"OPENASSETIO_DLL_PATH given as '{searchPath}'"
+            if not searchPath.is_absolute():
+                warning += f" and resolved to '{fullSearchPath}'"
+            warning += " does not contain openassetio.dll."
+            warnings.warn(warning)
+
+        # Add DLL search path.
+        os.add_dll_directory(str(fullSearchPath))
+
+    # Try to import the extension module and print a useful error if it
+    # fails.
+    try:
+        importlib.import_module("openassetio._openassetio")
+    except ImportError:
+        warnings.warn(
+            "Failed to load _openassetio extension module. Try"
+            " setting the OPENASSETIO_DLL_PATH environment"
+            " variable to the directory containing openassetio.dll"
+        )

--- a/src/openassetio-python/setup.py
+++ b/src/openassetio-python/setup.py
@@ -40,6 +40,9 @@ class build_ext(setuptools.command.build_ext.build_ext):
 
         @param _ext: Extension to build (we only have one, so ignored).
         """
+        if self.editable_mode:
+            raise NotImplementedError("OpenAssetIO does not support editable installs")
+
         cmake_project_path = pathlib.Path("../..")
 
         if not os.path.isfile(cmake_project_path / "CMakeLists.txt"):

--- a/src/openassetio-python/setup.py
+++ b/src/openassetio-python/setup.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2013-2022 The Foundry Visionmongers Ltd
+#   Copyright 2013-2024 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -74,14 +74,14 @@ class build_ext(setuptools.command.build_ext.build_ext):
             ]
         )
 
-        self.__cmake(["--build", self.build_temp, "--target", "openassetio-python-module"])
+        self.__cmake(["--build", self.build_temp, "--parallel"])
 
         self.__cmake(
             [
                 "--install",
                 self.build_temp,
                 "--component",
-                "openassetio-python-module",
+                "openassetio-python-distribution",
             ]
         )
 

--- a/src/openassetio-python/tests/package/test__windows.py
+++ b/src/openassetio-python/tests/package/test__windows.py
@@ -1,0 +1,164 @@
+#
+#   Copyright 2024 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Tests that cover the openassetio._windows module, for augmenting dll
+search paths.
+"""
+# pylint: disable=invalid-name,redefined-outer-name
+# pylint: disable=missing-class-docstring,missing-function-docstring
+import os
+import pathlib
+import re
+import importlib
+from unittest import mock
+
+import pytest
+
+import openassetio
+from openassetio import _windows
+
+
+if os.name != "nt":
+    pytest.skip("Windows specific tests", allow_module_level=True)
+
+
+class Test_addDllDirectoryFromEnvVar:
+    def test_when_openassetio_extension_successfully_imports_then_no_warning(self, recwarn):
+        _windows.addDllDirectoryFromEnvVar()
+
+        assert len(recwarn) == 0
+
+    def test_when_openassetio_extension_fails_to_import_then_warns(self, monkeypatch):
+        mock_import = mock.Mock(spec=importlib.import_module)
+        mock_import.side_effect = ImportError
+
+        monkeypatch.setattr(importlib, "import_module", mock_import)
+
+        expected_warning = re.escape(
+            "Failed to load _openassetio extension module. Try setting"
+            " the OPENASSETIO_DLL_PATH environment variable to the"
+            " directory containing openassetio.dll"
+        )
+
+        with pytest.warns(UserWarning, match=expected_warning):
+            _windows.addDllDirectoryFromEnvVar()
+
+        mock_import.assert_called_once_with("openassetio._openassetio")
+
+    def test_when_no_env_var_then_does_not_add_dll_directory(
+        self, monkeypatch, mock_add_dll_directory
+    ):
+        monkeypatch.delenv("OPENASSETIO_DLL_PATH", raising=False)
+
+        _windows.addDllDirectoryFromEnvVar()
+
+        mock_add_dll_directory.assert_not_called()
+
+    def test_when_env_var_is_absolute_path_then_adds_dll_directory_verbatim(
+        self, monkeypatch, mock_add_dll_directory, path_with_openassetio_dll
+    ):
+        monkeypatch.setenv("OPENASSETIO_DLL_PATH", str(path_with_openassetio_dll))
+
+        _windows.addDllDirectoryFromEnvVar()
+
+        mock_add_dll_directory.assert_called_once_with(str(path_with_openassetio_dll))
+
+    def test_when_env_var_is_relative_path_then_adds_absolute_dll_directory(
+        self, monkeypatch, mock_add_dll_directory
+    ):
+        relative_path = pathlib.Path("..", "something")
+        expected_path = (pathlib.Path(openassetio.__file__).parent / relative_path).resolve(
+            strict=False
+        )
+
+        monkeypatch.setenv("OPENASSETIO_DLL_PATH", str(relative_path))
+
+        with pytest.warns(UserWarning):
+            _windows.addDllDirectoryFromEnvVar()
+
+        mock_add_dll_directory.assert_called_once_with(str(expected_path))
+
+    def test_when_dll_path_contains_openassetio_dll_then_does_not_warn(
+        self, monkeypatch, path_with_openassetio_dll, recwarn
+    ):
+        monkeypatch.setenv("OPENASSETIO_DLL_PATH", str(path_with_openassetio_dll))
+
+        _windows.addDllDirectoryFromEnvVar()
+
+        assert len(recwarn) == 0
+
+    def test_when_absolute_dll_path_does_not_contain_openassetio_dll_then_warns_about_path(
+        self, monkeypatch, path_without_openassetio_dll
+    ):
+        monkeypatch.setenv("OPENASSETIO_DLL_PATH", str(path_without_openassetio_dll))
+
+        expected_warning = re.escape(
+            f"OPENASSETIO_DLL_PATH given as '{path_without_openassetio_dll}' does"
+            " not contain openassetio.dll."
+        )
+
+        with pytest.warns(UserWarning, match=expected_warning):
+            _windows.addDllDirectoryFromEnvVar()
+
+    def test_when_relative_dll_path_does_not_contain_openassetio_dll_then_warns_about_path(
+        self, monkeypatch, path_without_openassetio_dll
+    ):
+        rel_path = os.path.relpath(
+            path_without_openassetio_dll, os.path.dirname(openassetio.__file__)
+        )
+        monkeypatch.setenv("OPENASSETIO_DLL_PATH", rel_path)
+        expected_warning = re.escape(
+            f"OPENASSETIO_DLL_PATH given as '{rel_path}' and resolved to"
+            f" '{path_without_openassetio_dll.resolve(strict=False)}' does not contain"
+            f" openassetio.dll."
+        )
+
+        with pytest.warns(UserWarning, match=expected_warning):
+            _windows.addDllDirectoryFromEnvVar()
+
+
+@pytest.fixture()
+def mock_add_dll_directory(monkeypatch):
+    """
+    Patches the _windows.addDllDirectoryFromEnvVar function with a mock
+    and returns the mock.
+    """
+    mocked = mock.Mock()
+    monkeypatch.setattr(os, "add_dll_directory", mocked)
+    return mocked
+
+
+@pytest.fixture()
+def path_with_openassetio_dll(tmp_path):
+    """
+    Provides a temporary path containing an openassetio.dll file.
+    """
+    dll_path = tmp_path / "openassetio.dll"
+    dll_path.touch()
+    return tmp_path
+
+
+@pytest.fixture
+def path_without_openassetio_dll():
+    """
+    Provides an arbitrary path that does not contain an openassetio.dll
+    file.
+    """
+    # Note: this must be a real path, or os.add_dll_directory will
+    # raise. It must also be a path on the same drive as the
+    # `openassetio` module, or computing a relative path from it will
+    # raise.
+    return pathlib.Path(openassetio.__file__).parent / "pluginSystem"


### PR DESCRIPTION
## Description

Closes #1340. 

Building OpenAssetIO as a static library almost certainly precludes loading C++ manager plugins.  This is due to plugins depending explicitly on the OpenAssetIO core C++ shared library and/or depending on the symbols of that library being exported and public, in order to link properly at runtime.

The most straightforward and universal fix to this is to ensure OpenAssetIO is only ever built as a bunch of shared libraries.

So update the Python distribution to bundle OpenAssetIO as several shared libraries, rather than a single extension module.

When building/installing as a CMake package on Windows, we must unfortunately duplicate the dlls, with one copy in the `lib` subdirectory, for use by C++ consumers, and one copy in the `site-packages/openassetio` directory, for use by Python consumers. This was already being done, though as a slightly hacky fix early in the project to get Windows builds working (#244 - related follow-up to give Windows more love #538). So consolidate that logic with code comments explaining why.

With these changes, `pip install --editable` no longer works. Rather than fix it, disable `--editable` installs, for now. They're not very useful since the vast majority of code is in C++, so not worth the effort to support at the moment. Support will be re-visited in #1309.

Update BUILDING instructions to reflect the new structure of Python distributions. Plus fix some historic inaccuracies in that doc.

Also, ninja commit some fixes to running `ctest` with multi-config generators that were discovered whilst investigating this issue.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.
