### PR TITLE
Add type hint to API Compliance cases for Manager

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,10 @@ v1.0.0-beta.x.x
 - Updated the `simpleResolver` example host to support C++ plugins.
   [#1324](https://github.com/OpenAssetIO/OpenAssetIO/issues/1324)
 
+- Added a type hint for the `Manager` instance injected into the
+  `openassetio.test.manager` API Compliance test harness, to aid in
+  IDE code completion when writing test cases for manager plugins.
+
 v1.0.0-beta.2.2
 ---------------
 

--- a/src/openassetio-python/package/openassetio/test/manager/harness.py
+++ b/src/openassetio-python/package/openassetio/test/manager/harness.py
@@ -32,6 +32,8 @@ import unittest
 
 from . import _implementation
 from ...errors import ConfigurationException, InputValidationException
+from ... import hostApi
+from ... import trait
 
 
 __all__ = ["executeSuite", "fixturesFromPyFile", "moduleFromFile", "FixtureAugmentedTestCase"]
@@ -173,6 +175,9 @@ class FixtureAugmentedTestCase(unittest.TestCase):
     for each case.
     """
 
+    _manager: hostApi.Manager
+    _locale: trait.TraitsData
+
     shareManager = True
 
     def __init__(self, fixtures, manager, locale, *args, **kwargs):
@@ -197,9 +202,9 @@ class FixtureAugmentedTestCase(unittest.TestCase):
         @param kwargs: `Dict[str, Any]` Additional keyword args passed
         along to the base class.
         """
-        self._fixtures = fixtures  # type: dict
-        self._manager = manager  # type: hostApi.Manager
-        self._locale = locale  # type: openassetio.Specification
+        self._fixtures = fixtures
+        self._manager = manager
+        self._locale = locale
 
         super(FixtureAugmentedTestCase, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
## Description

Discovered whilst working on OpenAssetIO/OpenAssetIO-Manager-BAL#84.

When developing test cases for the `openassetio.test.manager` API Compliance test suite, it is extremely useful to have code completion for the injected `Manager` instance (`self._manager`).

The previous PyCharm-specific type hint for `self._manager` no longer worked,  and the hint for `self._locale` was just plain wrong.

So use real type hints for these members.

- [x] I have updated the release notes.
- [ ] ~~I have updated all relevant user documentation.~~
