### PR TITLE
Fix terminology `Mapper` initialisation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,6 +42,10 @@ v1.0.0-beta.x.x
   multiple shared libraries, allowing external libraries to link.
   [#1340](https://github.com/OpenAssetIO/OpenAssetIO/issues/1340)
 
+- Fixed the (Python-only) `terminology.Mapper` class such that its
+  terminology dict can be updated by the manager.
+  [#1356](https://github.com/OpenAssetIO/OpenAssetIO/pull/1356)
+
 v1.0.0-beta.2.2
 ---------------
 

--- a/src/openassetio-python/package/openassetio/hostApi/terminology.py
+++ b/src/openassetio-python/package/openassetio/hostApi/terminology.py
@@ -136,5 +136,5 @@ class Mapper:
         # Get any custom strings from the manager that we should use in the UI,
         # this is to allow a consistent terminology across implementations of a
         # specific asset management system.
-        manager.updateTerminology(self.__terminology)
+        self.__terminology = manager.updateTerminology(self.__terminology)
         self.__terminology[kTerm_Manager] = manager.displayName()


### PR DESCRIPTION
## Description

Discovered whilst working on  #1202. Since the `updateTerminology` API methods were moved to C++, the input terminology dictionary is no longer mutated. Instead, the dictionary is copied (by the Python bindings), and the manager plugin is expected to return a mutated copy.

The `Mapper` class was still assuming the input terminology dict would be mutated. This was never detected in the unit tests, because we were erroneously subclassing `Manager` rather than `ManagerInterface`, and so short-circuiting the Python->C++->Python code path.

So refactor the tests to instead create a mock `ManagerInterface` and catch this problem. Fix the problem by overwriting the `Mapper`'s internal terminology dictionary, rather than expecting it to be mutated.

- [x] I have updated the release notes.
- [ ] ~~I have updated all relevant user documentation.~~
