### PR TITLE
Make non-subclassable C++ Python bindings classes `final`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,11 +4,19 @@ Release Notes
 v1.0.0-beta.x.x
 ---------------
 
+_This release might not be source compatible for Python hosts. See
+breaking changes, below._
+
 ### Breaking changes
 
 - Removed official support for Python 3.7. The minimum supported Python
   version is now Python 3.9.
   [#1365](https://github.com/OpenAssetIO/OpenAssetIO/pull/1365)
+
+- Marked as "final" several C++ Python bindings of classes that do not
+  support Python inheritance, such that an error will be encountered at
+  import time if an attempt is made to inherit from them.
+  [#1357](https://github.com/OpenAssetIO/OpenAssetIO/pull/1357)
 
 - Updated the API contract to no longer require that managers throw an
   exception when an unrecognized setting is given during initialization.

--- a/src/openassetio-python/cmodule/src/hostApi/EntityReferencePagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/EntityReferencePagerBinding.cpp
@@ -18,7 +18,8 @@ void registerEntityReferencePager(const py::module& mod) {
   using openassetio::hostApi::EntityReferencePager;
   using openassetio::hostApi::EntityReferencePagerPtr;
 
-  py::class_<EntityReferencePager, EntityReferencePagerPtr>{mod, "EntityReferencePager"}
+  py::class_<EntityReferencePager, EntityReferencePagerPtr>{mod, "EntityReferencePager",
+                                                            py::is_final()}
       .def(py::init(RetainCommonPyArgs::forFn<&EntityReferencePager::make>()),
            py::arg("entityReferencePagerInterface").none(false),
            py::arg("hostSession").none(false))

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -54,7 +54,7 @@ void registerManager(const py::module& mod) {
   using openassetio::managerApi::ManagerInterfacePtr;
   using openassetio::trait::TraitsDataPtr;
 
-  py::class_<Manager, ManagerPtr> pyManager{mod, "Manager"};
+  py::class_<Manager, ManagerPtr> pyManager{mod, "Manager", py::is_final()};
 
   // BatchElementErrorPolicy tags for tag dispatch overload resolution
   // idiom.

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerFactoryBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerFactoryBinding.cpp
@@ -19,8 +19,8 @@ void registerManagerFactory(const py::module& mod) {
   using openassetio::hostApi::ManagerPtr;
   using openassetio::log::LoggerInterfacePtr;
 
-  // TODO(DF): `py::final()` once ManagerFactory is fully C++.
-  py::class_<ManagerFactory, ManagerFactoryPtr> managerFactory(mod, "ManagerFactory");
+  py::class_<ManagerFactory, ManagerFactoryPtr> managerFactory(mod, "ManagerFactory",
+                                                               py::is_final());
   managerFactory
       .def(py::init(RetainCommonPyArgs::forFn<&ManagerFactory::make>()),
            py::arg("hostInterface").none(false),

--- a/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemBinding.cpp
+++ b/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemBinding.cpp
@@ -18,7 +18,7 @@ void registerCppPluginSystem(const py::module_ &mod) {
   // catch if this changes (e.g. if we add logger calls in the other
   // methods).
 
-  py::class_<CppPluginSystem, CppPluginSystem::Ptr>(mod, "CppPluginSystem")
+  py::class_<CppPluginSystem, CppPluginSystem::Ptr>(mod, "CppPluginSystem", py::is_final())
       .def(py::init(RetainCommonPyArgs::forFn<&CppPluginSystem::make>()),
            py::arg("logger").none(false))
       .def("reset", &CppPluginSystem::reset)

--- a/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemManagerImplementationFactoryBinding.cpp
+++ b/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemManagerImplementationFactoryBinding.cpp
@@ -10,43 +10,15 @@
 #include "../_openassetio.hpp"
 #include "../overrideMacros.hpp"
 
-namespace openassetio {
-inline namespace OPENASSETIO_CORE_ABI_VERSION {
-namespace pluginSystem {
-namespace {
-using openassetio::pluginSystem::CppPluginSystemManagerImplementationFactory;
-struct PyCppPluginSystemManagerImplementationFactory
-    : CppPluginSystemManagerImplementationFactory {
-  using CppPluginSystemManagerImplementationFactory::CppPluginSystemManagerImplementationFactory;
-
-  [[nodiscard]] openassetio::Identifiers identifiers() override {
-    OPENASSETIO_PYBIND11_OVERRIDE_PURE(
-        openassetio::Identifiers, CppPluginSystemManagerImplementationFactory, identifiers,
-        /* no args */);
-  }
-
-  [[nodiscard]] openassetio::managerApi::ManagerInterfacePtr instantiate(
-      const openassetio::Identifier& identifier) override {
-    OPENASSETIO_PYBIND11_OVERRIDE_PURE(PyRetainingSharedPtr<managerApi::ManagerInterface>,
-                                       CppPluginSystemManagerImplementationFactory, instantiate,
-                                       identifier);
-  }
-};
-}  // namespace
-}  // namespace pluginSystem
-}  // namespace OPENASSETIO_CORE_ABI_VERSION
-}  // namespace openassetio
-
 void registerCppPluginSystemManagerImplementationFactory(const py::module_& mod) {
   using openassetio::hostApi::ManagerImplementationFactoryInterface;
   using openassetio::log::LoggerInterfacePtr;
   using openassetio::pluginSystem::CppPluginSystemManagerImplementationFactory;
-  using openassetio::pluginSystem::PyCppPluginSystemManagerImplementationFactory;
 
   py::class_<CppPluginSystemManagerImplementationFactory, ManagerImplementationFactoryInterface,
-             PyCppPluginSystemManagerImplementationFactory,
+
              CppPluginSystemManagerImplementationFactory::Ptr>(
-      mod, "CppPluginSystemManagerImplementationFactory")
+      mod, "CppPluginSystemManagerImplementationFactory", py::is_final())
       .def_readonly_static("kPluginEnvVar",
                            &CppPluginSystemManagerImplementationFactory::kPluginEnvVar)
       .def(py::init(


### PR DESCRIPTION
Discovered whilst working on #1202.

When a Python script defines a class that inherits from a C++ class, the natural expectation would be that calls to an overridden method in C++ via a C++ base class reference would call out to the Python method implementation.

However, this is not the case unless we have explicitly enabled it in the bindings by providing a so-called "trampoline" class.

So to prevent confusion, we add a tag to the Python bindings to declare the class as "final", so that it is an error at Python import time when a class inherits from that C++ class.

However, there were several classes that we had never added the `is_final` tag to.

So add this tag to appropriate Python bindings.

Also add to `CppPluginSystemManagerImplementationFactory`, despite it defining a trampoline class. This class was never intended to be derived from by Python classes. Hence remove its unnecessary trampoline class.

## Description

Closes # (issue)

- [x] I have updated the release notes.
- [ ] ~~I have updated all relevant user documentation.~~
