### PR TITLE
Fix SimpleCppManager override default capabilities

### DIFF
--- a/examples/manager/SimpleCppManager/src/SimpleCppManager.cpp
+++ b/examples/manager/SimpleCppManager/src/SimpleCppManager.cpp
@@ -100,6 +100,9 @@ struct SimpleCppManagerInterface final : openassetio::managerApi::ManagerInterfa
     // Support customisable capabilities. Assume a single-row CSV
     // format.
     if (const auto& maybeValue = valueFromSettings(kSettingsKeyForCapabilities)) {
+      // Remove default capabilities - they will all come from settings.
+      capabilities_.clear();
+
       std::istringstream csvRowAsStream{*maybeValue};
       std::string capability;
       // Loop over each listed capability.

--- a/examples/manager/SimpleCppManager/tests/test_SimpleCppManager.py
+++ b/examples/manager/SimpleCppManager/tests/test_SimpleCppManager.py
@@ -137,6 +137,18 @@ class Test_SimpleCppManager_initialize:
         with pytest.raises(errors.NotImplementedException):
             a_fresh_simple_cpp_manager.contextFromPersistenceToken("abc")
 
+    def test_when_default_capability_missing_from_explicit_settings_then_capability_unavailable(
+        self, a_fresh_simple_cpp_manager
+    ):
+        settings = a_fresh_simple_cpp_manager.settings()
+        # Same as default, but without "resolution".
+        settings["capabilities"] = (
+            "entityReferenceIdentification,managementPolicyQueries,entityTraitIntrospection"
+        )
+        a_fresh_simple_cpp_manager.initialize(settings)
+
+        assert not a_fresh_simple_cpp_manager.hasCapability(Manager.Capability.kResolution)
+
     def test_when_capability_is_overridden_then_stub_implementations_available(
         self, a_fresh_simple_cpp_manager, a_context
     ):


### PR DESCRIPTION
Discovered whilst working on #1202. When capabilities were explicitly given as a list in the settings, the pre-existing capability set was not reset, meaning it wasn't possible to "switch off" the default capabilities.

So `clear()` the capability set when settings are detected that should override it, before filling up the set again with those settings.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~
