### PR TITLE
Add hybrid plugin system

### DIFF
--- a/doc/doxygen/src/Configuration.dox
+++ b/doc/doxygen/src/Configuration.dox
@@ -40,11 +40,19 @@
  *
  * @section installing_manager_plugins Installing Manager plugins
  *
- * @note To aid problem solving, the plugin system logs debug messages
- * when it searches for, and loads plugins.
+ * @note To aid problem solving, the plugin systems log debug messages
+ * when they search for and load plugins.
  *
- * Presently, OpenAssetIO only supports Python based plugins.
- * These can be installed in one of two ways.
+ * OpenAssetIO supports Python, C++, and @ref
+ * installing_manager_plugins_hybrid "hybrid" plugins.
+ *
+ * Typically there will only be a single asset management system in use,
+ * with a corresponding plugin(s). However, if there are multiple
+ * systems available with their own OpenAssetIO manager plugins, it is
+ * safe, and encouraged, to install all of them such that they're
+ * discoverable (as described below). For example, some host
+ * applications may support multiple managers simultaneously.
+ *
  *
  * @subsection installing_manager_plugins_pip Using pip
  *
@@ -83,16 +91,21 @@
  * variable can be set to point to one or more directories containing
  * manager plugins.
  *
+ * This is required for C++ plugins, but can be used for Python plugins
+ * as well, where entry point discovery (described above) is not
+ * available.
+ *
  * It is a standard 'left-most wins' search-path, that uses platform
  * specific delimiters (see @ref plugin_path_var "here" for more
  * information).
  *
- * This variable is completely independent from `$PYTHONPATH` or any
- * other language/host specific configuration.
+ * This variable is completely independent from `$PYTHONPATH`,
+ * `$LD_LIBRARY_PATH`, or any other language/host specific
+ * configuration.
  *
  * This can simplify deployment by allowing a common location to be
- * specified to service multiple hosts and Python versions (assuming the
- * manager plugins have been suitably coded).
+ * specified to, for example, service multiple hosts and Python versions
+ * (assuming the manager plugins have been suitably coded).
  *
  * To install a plugin using this approach:
  *
@@ -100,6 +113,47 @@
  * - Place this in your chosen location. This can be anywhere on a
  *   filesystem that is visible to the hosts that you wish to use.
  * - Set, or extend @ref plugin_path_var to include this location.
+ *
+ *
+ * @subsection installing_manager_plugins_hybrid Hybrid plugins
+ *
+ * The @fqref{pluginSystem.HybridPluginSystemManagerImplementationFactory}
+ * "hybrid plugin system" allows multiple plugin systems to be composed.
+ * Typically, this means a C++ and a Python plugin system.
+ *
+ * This reduces boilerplate for supporting multiple plugin systems
+ * simultaneously. It also has the unique ability to compose multiple
+ * plugins together, dispatching to the appropriate plugin for a given
+ * API request.
+ *
+ * The hybrid plugin system should be the default choice for any host
+ * that can support both Python and C++ plugins - i.e. any pure Python
+ * host or any C++ host with an embedded Python interpreter.
+ *
+ * The appropriate plugin for an API request is determined as follows:
+ *
+ * - On construction, the hybrid plugin system is provided with a list
+ *   of plugin systems to compose (e.g.
+ *   @fqref{pluginSystem.CppPluginSystemManagerImplementationFactory}
+ *   "C++" and @ref
+ *   openassetio.pluginSystem.PythonPluginSystemManagerImplementationFactory
+ *   "Python"). The order of this list establishes a priority order.
+ * - When the host requests a plugin with a particular identifier (via
+ *   a @ref host_default_config "config file" or otherwise), any plugin
+ *   that matches the identifier, from any listed plugin system, is a
+ *   candidate for API requests.
+ * - When a specific API request is made, the highest priority plugin
+ *   is used that supports the
+ *   @fqref{managerApi.ManagerInterface.Capability} "capability"
+ *   associated with the API method.
+ *
+ * Note that the OpenAssetIO API is designed to be stateless. By this
+ * we mean that all data required to service an API request is provided
+ * with every API method invocation. In particular, the @ref Context
+ * can be used by managers to coordinate higher-level state
+ * across API method invocations. This can enable data sharing
+ * between multiple constituent plugins of a hybrid plugin, without
+ * them requiring an explicit communication channel.
  *
  *
  * @section host_settings Host configuration

--- a/doc/doxygen/src/Examples.dox
+++ b/doc/doxygen/src/Examples.dox
@@ -17,8 +17,11 @@
  * interact with an @ref asset_management_system.
  *
  * It makes use of the @ref openassetio.pluginSystem "Plugin System" to
- * discover available @ref PythonPluginSystemManagerPlugin
- * "PythonPluginSystemManagerPlugins".
+ * discover available @ref
+ * openassetio.pluginSystem.PythonPluginSystemManagerPlugin
+ * "PythonPluginSystemManagerPlugin" "PythonPluginSystemManagerPlugins"
+ * and @fqref{pluginSystem.CppPluginSystemManagerPlugin}
+ * "CppPluginSystemManagerPlugins".
  *
  * It also includes a bare-minimum example of a
  * @fqref{hostApi.HostInterface} "HostInterface" implementation.
@@ -26,7 +29,10 @@
  * @code{.py}
  * from openassetio.log import ConsoleLogger, SeverityFilter
  * from openassetio.hostApi import HostInterface, Manager, ManagerFactory
- * from openassetio.pluginSystem import PythonPluginSystemManagerImplementationFactory
+ * from openassetio.pluginSystem import (
+ *     CppPluginSystemManagerImplementationFactory,
+ *     PythonPluginSystemManagerImplementationFactory,
+ *     HybridPluginSystemManagerImplementationFactory)
  *
  * class ExamplesHost(HostInterface):
  *     """
@@ -45,9 +51,12 @@
  * logger = SeverityFilter(ConsoleLogger())
  *
  * # We need to provide the mechanism by which managers are created, the
- * # built-in plugin system allows these to be loaded from
- * # OPENASSETIO_PLUGIN_PATH.
- * factory_impl = PythonPluginSystemManagerImplementationFactory(logger)
+ * # built-in plugin systems allow these to be loaded from
+ * # OPENASSETIO_PLUGIN_PATH. The hybrid plugin system allows multiple
+ * # plugin systems to be composed.
+ * factory_impl = HybridPluginSystemManagerImplementationFactory([
+ *     CppPluginSystemManagerImplementationFactory(logger),
+ *     PythonPluginSystemManagerImplementationFactory(logger)], logger)
  *
  * # We then need our implementation of the HostInterface class
  * host_interface = ExamplesHost()

--- a/doc/doxygen/src/ForHosts.dox
+++ b/doc/doxygen/src/ForHosts.dox
@@ -98,10 +98,19 @@
  *      in a @fqref{log.SeverityFilter} "SeverityFilter".
  *    - A @fqref{hostApi.ManagerImplementationFactoryInterface}
  *      "ManagerImplementationFactoryInterface" capable of instantiating
- *      managers. In the majority of cases a default-configured @ref
+ *      managers. Where a Python environment is available, the most
+ *      flexible option is to construct a
+ *      @fqref{pluginSystem.HybridPluginSystemManagerImplementationFactory}
+ *      "hybrid plugin system", composing a default-configured
+ *      @fqref{pluginSystem.CppPluginSystemManagerImplementationFactory}
+ *      "C++ plugin system" and @ref
  *      openassetio.pluginSystem.PythonPluginSystemManagerImplementationFactory
- *      "PythonPluginSystemManagerImplementationFactory" will be
- *      sufficient.
+ *      "Python plugin system" (C++ hosts should see
+ *      @fqref{python.hostApi.createPythonPluginSystemManagerImplementationFactory}
+ *      "createPythonPluginSystemManagerImplementationFactory"). Plugin
+ *      systems can be used on their own too - for example, if a Python
+ *      environment isn't available, the C++ plugin system could be used
+ *      directly.
  *
  *   Note that in some environments, a default manager may not be
  *   configured. As a host, can error here, or choose to present the

--- a/doc/doxygen/src/ForManagers.dox
+++ b/doc/doxygen/src/ForManagers.dox
@@ -12,8 +12,7 @@
  *
  * - The implementation of any given manager may consist of
  *   several discrete services, but within any OpenAssetIO session, it
- *   is represented though a singular @ref
- *   PythonPluginSystemManagerPlugin.
+ *   is represented though a singular @ref glossary_manager_plugin
  *
  * - The API is initialized and coordinated by a @ref host. The host may
  *   instantiate one or more managers.
@@ -22,11 +21,11 @@
  *   through the manager's implementation of the @ref ManagerInterface.
  *
  * - A manager's implementation of the @ref ManagerInterface supplied
- *   through its @ref PythonPluginSystemManagerPlugin is wrapped in the
- *   @fqref{hostApi.Manager} "Manager" class before
- *   being made available to the @ref host. This is to allow for host
- *   session state management and other auditing/logging functionality.
- *   It also provides a degree of isolation against future API changes.
+ *   through its @ref glossary_manager_plugin is wrapped in the
+ *   @fqref{hostApi.Manager} "Manager" class before being made available
+ *   to the @ref host. This is to allow for host session state
+ *   management and other auditing/logging functionality. It also
+ *   provides a degree of isolation against future API changes.
  *
  * - Methods of the @ref ManagerInterface are required to be reentrant
  *   and thread-safe. The response to any method should only depend on
@@ -127,8 +126,8 @@
  * - Implement @fqref{managerApi.ManagerInterface.resolve} "resolve" and
  *   populate the requested trait property values.
  *
- * - Implement a @ref PythonPluginSystemManagerPlugin and install this
- *   on @ref plugin_path_var.
+ * - Implement a @ref glossary_manager_plugin and install this on @ref
+ *   plugin_path_var.
  *
  * @subsection manager_todo_publishing Required for Publishing
  *
@@ -226,6 +225,8 @@
  * @see @fqref{managerApi.ManagerInterface} "ManagerInterface"
  * @see @ref openassetio.pluginSystem.PythonPluginSystemManagerPlugin
  * "PythonPluginSystemManagerPlugin"
+ * @see @fqref{pluginSystem.CppPluginSystemManagerPlugin}
+ * "CppPluginSystemManagerPlugin"
  * @see @fqref{Context} "Context"
  * @see @fqref{managerApi.Host} "Host"
  */

--- a/doc/doxygen/src/Glossary.dox
+++ b/doc/doxygen/src/Glossary.dox
@@ -234,19 +234,31 @@
  * to be performed by the API middleware.
  *
  *
- * @section PythonPluginSystemManagerPlugin Manager Plugin
+ * @section glossary_manager_plugin Manager Plugin
  *
- * The Plug-in mechanism implemented by the @ref
- * openassetio.pluginSystem automatically discovers packages that
- * provide an instance of the openassetio.pluginSystem.PythonPluginSystemManagerPlugin
- * using a search-path based mechanism. This is independent of
- * $PYTHONPATH, and presently searches using the environment variable
- * @ref plugin_path_var
+ * The plug-in mechanism implemented by the @ref
+ * openassetio.pluginSystem automatically discovers libraries that
+ * provide an instance of @ref
+ * openassetio.pluginSystem.PythonPluginSystemManagerPlugin
+ * "PythonPluginSystemManagerPlugin" or
+ * @fqref{pluginSystem.CppPluginSystemManagerPlugin}
+ * "CppPluginSystemManagerPlugin" using a search-path based mechanism.
+ * This is independent of $PYTHONPATH, and searches using the
+ * environment variable @ref plugin_path_var
  *
- * The PythonPluginSystemManagerPlugin instance is then responsible for
- * constructing an instance of the respective @ref
- * asset_management_system's implementation of the
- * @fqref{managerApi.ManagerInterface} "ManagerInterface".
+ * The plugin instance is then responsible for constructing an instance
+ * of the respective @ref asset_management_system's implementation of
+ * the @fqref{managerApi.ManagerInterface} "ManagerInterface".
+ *
+ * Plugins have an associated unique identifier. Hosts query plugin
+ * systems for plugins that advertise the particular identifier they are
+ * interested in (e.g. see @ref default_config_var).
+ *
+ * Multiple plugins that advertise the same identifier, but are written
+ * in different languages, can be transparently composed, such that API
+ * calls are routed based on priority and/or capability, using a
+ * @fqref{pluginSystem.HybridPluginSystemManagerImplementationFactory}
+ * "hybrid" of the plugin systems.
  *
  *
  * @section default_config_var $OPENASSETIO_DEFAULT_CONFIG
@@ -264,11 +276,11 @@
  *
  * @section plugin_path_var $OPENASSETIO_PLUGIN_PATH
  *
- * This is the environment variable used to discover @ref PythonPluginSystemManagerPlugin
- * "PythonPluginSystemManagerPlugins", it is searched left-to-right,
- * using standard `$PATH` semantics (delimited by `:` on POSIX systems
- * and `;` on Windows). The first package that registers a specific
- * identifier wins.
+ * This is the environment variable used to discover @ref
+ * glossary_manager_plugin, it is searched left-to-right, using standard
+ * `$PATH` semantics (delimited by `:` on POSIX systems and `;` on
+ * Windows). The first package that registers a specific identifier
+ * wins.
  *
  * So to override a plug-in with a dev version, ensure it is to the left
  * of the standard plug-in.
@@ -361,9 +373,8 @@
  * concepts (eg @ref trait "traits" and their properties into their own
  * internal structures, and back again when queried.
  *
- * Managers are made available via a @ref
- * PythonPluginSystemManagerPlugin, that ultimately registers classes
- * derived from the @ref ManagerInterface.
+ * Managers are made available via a @ref glossary_manager_plugin, that
+ * ultimately registers classes derived from the @ref ManagerInterface.
  *
  * A @ref host never uses the ManagerInterface class directly, but instead
  * uses the @fqref{hostApi.Manager} "Manager" class. This

--- a/doc/doxygen/src/MainPage.dox
+++ b/doc/doxygen/src/MainPage.dox
@@ -35,7 +35,7 @@
  * @startuml
  * node Host {
  *   package OpenAssetIO {
- *     collections PythonPluginSystemManagerPlugin
+ *     collections "Manager Plugin" as ManagerPlugin
  *   }
  * }
  *
@@ -44,8 +44,8 @@
  *   collections "Resolver, etc..."
  * }
  *
- * PythonPluginSystemManagerPlugin -right-> ams
- * ams -left-> PythonPluginSystemManagerPlugin
+ * ManagerPlugin -right-> ams
+ * ams -left-> ManagerPlugin
  * @enduml
  *
  * It aims to reduce the integration effort and maintenance overhead of

--- a/doc/doxygen/src/Testing.dox
+++ b/doc/doxygen/src/Testing.dox
@@ -4,7 +4,7 @@
  * @section testing_manager_plugins Testing Manager Plugins
  *
  * The API distribution includes a test harness that can be used to test
- * the implementation of any given @ref PythonPluginSystemManagerPlugin.
+ * the implementation of any given @ref glossary_manager_plugin.
  * It is a
  * <a href="https://docs.python.org/3/library/unittest.html" target="_blank"><tt>unittest</tt></a>
  * based framework that can be used stand-alone via the command line,
@@ -13,8 +13,7 @@
  * The harness acts as an OpenAssetIO @ref host. Two things are needed
  * to test any given codebase:
  *
- * - A @ref openassetio.pluginSystem.PythonPluginSystemManagerPlugin
- *   "PythonPluginSystemManagerPlugin" implementation for the manager to
+ * - A @ref glossary_manager_plugin implementation for the manager to
  *   be tested.
  * - A Python 'fixtures' file that provides valid inputs, and expected
  *   outputs for that manager.
@@ -59,7 +58,7 @@
  *
  * @subsection testing_manager_plugins_cli Using the Command Line
  *
- * The simplest way to test a @ref PythonPluginSystemManagerPlugin is
+ * The simplest way to test a @ref glossary_manager_plugin is
  * via the command line:
  *
  * @code{.sh}

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -81,6 +81,7 @@ target_sources(
     src/pluginSystem/CppPluginSystemManagerImplementationFactory.cpp
     src/pluginSystem/CppPluginSystemManagerPlugin.cpp
     src/pluginSystem/CppPluginSystemPlugin.cpp
+    src/pluginSystem/HybridPluginSystemManagerImplementationFactory.cpp
     src/trait/TraitsData.cpp
     src/utils/formatter.cpp
     src/utils/ostream.cpp

--- a/src/openassetio-core/include/openassetio/pluginSystem/HybridPluginSystemManagerImplementationFactory.hpp
+++ b/src/openassetio-core/include/openassetio/pluginSystem/HybridPluginSystemManagerImplementationFactory.hpp
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#pragma once
+#include <vector>
+
+#include <openassetio/export.h>
+#include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
+#include <openassetio/typedefs.hpp>
+
+OPENASSETIO_FWD_DECLARE(managerApi, ManagerInterface)
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace pluginSystem {
+OPENASSETIO_DECLARE_PTR(HybridPluginSystemManagerImplementationFactory)
+
+/**
+ * The hybrid plugin system composes one or more child plugin systems,
+ * and abstracts away routing API calls based on priority and
+ * capability.
+ *
+ * A list of factories are provided in priority order. When a plugin
+ * with a particular identifier is requested, all factories are queried
+ * and any that return positively for the identifier have their
+ * resulting @ref managerApi.ManagerInterface "ManagerInterface"
+ * instances composed into a single `ManagerInterface`, such that API
+ * calls are dispatched to the appropriate child instance, based on
+ * priority and capability.
+ *
+ * Manager plugins advertise their capabilities using @ref
+ * managerApi.ManagerInterface.hasCapability
+ * "ManagerInterface.hasCapability".
+ *
+ * If multiple plugins support the same capability, then priority is
+ * given to the plugin corresponding to the earliest in the list of
+ * provided child factories.
+ */
+class OPENASSETIO_CORE_EXPORT HybridPluginSystemManagerImplementationFactory
+    : public hostApi::ManagerImplementationFactoryInterface {
+ public:
+  using ManagerImplementationFactoryInterfaces =
+      std::vector<hostApi::ManagerImplementationFactoryInterfacePtr>;
+
+  OPENASSETIO_ALIAS_PTR(HybridPluginSystemManagerImplementationFactory)
+
+  /**
+   * Construct a new instance.
+   *
+   * @param factories List of factories to compose.
+   *
+   * @param logger Logger for progress and warnings.
+   *
+   * @return New instance.
+   */
+  static HybridPluginSystemManagerImplementationFactoryPtr make(
+      ManagerImplementationFactoryInterfaces factories, log::LoggerInterfacePtr logger);
+
+  /**
+   * Get a list of all manager plugin identifiers known to all child
+   * factories.
+   *
+   * @return List of known manager plugin identifiers.
+   */
+  Identifiers identifiers() override;
+
+  /**
+   * Create an instance of the @ref managerApi.ManagerInterface
+   * "ManagerInterface" with the specified identifier.
+   *
+   * If multiple factories return a positive result for the identifier,
+   * composition is performed to create a single @ref
+   * managerApi.ManagerInterface "ManagerInterface" that dispatches API
+   * calls to the appropriate child instance, based on advertised
+   * capability or priority order.
+   *
+   * Note that, like any other plugin system, the returned
+   * `ManagerInterface` cannot be used until @ref
+   * managerApi.ManagerInterface.initialize "initialized".
+   *
+   * @param identifier Identifier of the `ManagerInterface` to
+   * instantiate.
+   *
+   * @return Newly created interface.
+   *
+   * @throws InputValidationException if the requested identifier has
+   * not been registered as a manager plugin.
+   */
+  managerApi::ManagerInterfacePtr instantiate(const Identifier& identifier) override;
+
+ private:
+  /// Private constructor. See @ref make.
+  explicit HybridPluginSystemManagerImplementationFactory(
+      ManagerImplementationFactoryInterfaces factories, log::LoggerInterfacePtr logger);
+
+  /// Child factories to compose.
+  ManagerImplementationFactoryInterfaces factories_;
+};
+}  // namespace pluginSystem
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/src/pluginSystem/HybridPluginSystemManagerImplementationFactory.cpp
+++ b/src/openassetio-core/src/pluginSystem/HybridPluginSystemManagerImplementationFactory.cpp
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <algorithm>
+#include <cassert>
+#include <memory>
+
+#include <fmt/format.h>
+
+#include <openassetio/errors/exceptions.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/pluginSystem/HybridPluginSystemManagerImplementationFactory.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace pluginSystem {
+
+namespace {
+
+/**
+ * A ManagerInterface implementation that composes multiple child
+ * ManagerInterfaces and forwards API calls to one of the children.
+ *
+ * For most API methods, the call is forwarded to the first child that
+ * satisfies the required capability for that API call, or calls the
+ * base class implementation if no child satisfies the required
+ * capability. The priority order of children is defined by the order
+ * that they were provided to the constructor.
+ *
+ * For API calls that have no associated capability, either the first
+ * child is chosen, or the results from all children are merged - see
+ * method-specific docs for details.
+ */
+class HybridManagerInterface : public managerApi::ManagerInterface {
+  using ManagerInterfaces = std::vector<managerApi::ManagerInterfacePtr>;
+
+ public:
+  explicit HybridManagerInterface(ManagerInterfaces managerInterfacess)
+      : managerInterfaces_{std::move(managerInterfacess)} {
+    // Precondition.
+    assert(!managerInterfaces_.empty());
+  }
+
+  /**
+   * Return the identifier of the first child, on the understanding that
+   * all child implementations have the same identifier.
+   */
+  [[nodiscard]] Identifier identifier() const override {
+    return managerInterfaces_.front()->identifier();
+  }
+
+  /**
+   * Return the name of the first child, on the assumption that all
+   * child implementations have the same name.
+   */
+  [[nodiscard]] Str displayName() const override {
+    return managerInterfaces_.front()->displayName();
+  }
+
+  /**
+   * Merge the results of `info()` from all child implementations, with
+   * the first implementation taking precedence in case of a conflict.
+   */
+  [[nodiscard]] InfoDictionary info() override {
+    InfoDictionary result;
+    for (const auto& managerInterface : managerInterfaces_) {
+      result.merge(managerInterface->info());
+    }
+    return result;
+  }
+
+  /**
+   * Merge the results of `settings()` from all child implementations,
+   * with the first implementation taking precedence in case of a
+   * conflict.
+   */
+  [[nodiscard]] InfoDictionary settings(const managerApi::HostSessionPtr& hostSession) override {
+    InfoDictionary result;
+    for (const auto& managerInterface : managerInterfaces_) {
+      result.merge(managerInterface->settings(hostSession));
+    }
+    return result;
+  }
+
+  /**
+   * This hybrid manager has a capability if at least one of its child
+   * implementations has the capability.
+   */
+  [[nodiscard]] bool hasCapability(const Capability capability) override {
+    return managerInterfacesByCapability_.count(capability) > 0;
+  }
+
+  /**
+   * All child implementations are initialized with the all the same
+   * settings.
+   *
+   * Once initialization of child implementations is complete, a mapping
+   * of capability to implementation is constructed, which will be used
+   * to dispatch to the appropriate implementation in subsequent API
+   * methods.
+   */
+  void initialize(InfoDictionary managerSettings,
+                  const managerApi::HostSessionPtr& hostSession) override {
+    for (const auto& managerInterface : managerInterfaces_) {
+      managerInterface->initialize(managerSettings, hostSession);
+    }
+    // Cache a mapping of the first child interface that supports each
+    // capability.
+    //
+    // Caching now avoids the need to call hasCapability() on
+    // the child implementations again (and repeatedly) in the API
+    // methods, which could be expensive if, for example, a network call
+    // is required, or we are calling out to Python and locking the
+    // GIL, etc. The disadvantage is that capabilities cannot change
+    // after plugins have been loaded.
+    managerInterfacesByCapability_.reserve(kCapabilityNames.size());
+    for (std::size_t capabilityIdx = 0; capabilityIdx < kCapabilityNames.size(); ++capabilityIdx) {
+      const auto capability = static_cast<Capability>(capabilityIdx);
+      for (const auto& managerInterface : managerInterfaces_) {
+        if (managerInterface->hasCapability(capability)) {
+          managerInterfacesByCapability_[capability] = managerInterface;
+          break;
+        }
+      }
+    }
+  }
+
+  /**
+   * All child implementations flushed.
+   */
+  void flushCaches(const managerApi::HostSessionPtr& hostSession) override {
+    for (const auto& managerInterface : managerInterfaces_) {
+      managerInterface->flushCaches(hostSession);
+    }
+  }
+
+  /*
+   * The remaining API methods all dispatch to the first child that
+   * has the capability, or to the base class implementation if no child
+   * has the capability.
+   */
+
+  /**
+   * Convenience macro to call a method on the appropriate child manager
+   * for a capability, or else call the base class implementation.
+   */
+#define INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(capability, method, ...)                        \
+  [&] {                                                                                     \
+    if (const auto& capabilityAndManager = managerInterfacesByCapability_.find(capability); \
+        capabilityAndManager != cend(managerInterfacesByCapability_)) {                     \
+      return capabilityAndManager->second->method(__VA_ARGS__);                             \
+    }                                                                                       \
+    return ManagerInterface::method(__VA_ARGS__);                                           \
+  }()
+
+  [[nodiscard]] StrMap updateTerminology(StrMap terms,
+                                         const managerApi::HostSessionPtr& hostSession) override {
+    return INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(Capability::kCustomTerminology, updateTerminology,
+                                               std::move(terms), hostSession);
+  }
+
+  [[nodiscard]] trait::TraitsDatas managementPolicy(
+      const trait::TraitSets& traitSets, access::PolicyAccess policyAccess,
+      const ContextConstPtr& context, const managerApi::HostSessionPtr& hostSession) override {
+    return INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(Capability::kManagementPolicyQueries,
+                                               managementPolicy, traitSets, policyAccess, context,
+                                               hostSession);
+  }
+
+  [[nodiscard]] managerApi::ManagerStateBasePtr createState(
+      const managerApi::HostSessionPtr& hostSession) override {
+    return INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(Capability::kStatefulContexts, createState,
+                                               hostSession);
+  }
+
+  [[nodiscard]] managerApi::ManagerStateBasePtr createChildState(
+      const managerApi::ManagerStateBasePtr& parentState,
+      const managerApi::HostSessionPtr& hostSession) override {
+    return INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(Capability::kStatefulContexts, createChildState,
+                                               parentState, hostSession);
+  }
+
+  [[nodiscard]] Str persistenceTokenForState(
+      const managerApi::ManagerStateBasePtr& state,
+      const managerApi::HostSessionPtr& hostSession) override {
+    return INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(Capability::kStatefulContexts,
+                                               persistenceTokenForState, state, hostSession);
+  }
+
+  [[nodiscard]] managerApi::ManagerStateBasePtr stateFromPersistenceToken(
+      const Str& token, const managerApi::HostSessionPtr& hostSession) override {
+    return INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(Capability::kStatefulContexts,
+                                               stateFromPersistenceToken, token, hostSession);
+  }
+
+  [[nodiscard]] bool isEntityReferenceString(
+      const Str& someString, const managerApi::HostSessionPtr& hostSession) override {
+    return INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(Capability::kEntityReferenceIdentification,
+                                               isEntityReferenceString, someString, hostSession);
+  }
+
+  void entityExists(const EntityReferences& entityReferences, const ContextConstPtr& context,
+                    const managerApi::HostSessionPtr& hostSession,
+                    const ExistsSuccessCallback& successCallback,
+                    const BatchElementErrorCallback& errorCallback) override {
+    INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(Capability::kExistenceQueries, entityExists,
+                                        entityReferences, context, hostSession, successCallback,
+                                        errorCallback);
+  }
+
+  void entityTraits(const EntityReferences& entityReferences,
+                    access::EntityTraitsAccess entityTraitsAccess, const ContextConstPtr& context,
+                    const managerApi::HostSessionPtr& hostSession,
+                    const EntityTraitsSuccessCallback& successCallback,
+                    const BatchElementErrorCallback& errorCallback) override {
+    INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(Capability::kEntityTraitIntrospection, entityTraits,
+                                        entityReferences, entityTraitsAccess, context, hostSession,
+                                        successCallback, errorCallback);
+  }
+
+  void resolve(const EntityReferences& entityReferences, const trait::TraitSet& traitSet,
+               access::ResolveAccess resolveAccess, const ContextConstPtr& context,
+               const managerApi::HostSessionPtr& hostSession,
+               const ResolveSuccessCallback& successCallback,
+               const BatchElementErrorCallback& errorCallback) override {
+    INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(Capability::kResolution, resolve, entityReferences,
+                                        traitSet, resolveAccess, context, hostSession,
+                                        successCallback, errorCallback);
+  }
+
+  void defaultEntityReference(const trait::TraitSets& traitSets,
+                              access::DefaultEntityAccess defaultEntityAccess,
+                              const ContextConstPtr& context,
+                              const managerApi::HostSessionPtr& hostSession,
+                              const DefaultEntityReferenceSuccessCallback& successCallback,
+                              const BatchElementErrorCallback& errorCallback) override {
+    INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(Capability::kDefaultEntityReferences,
+                                        defaultEntityReference, traitSets, defaultEntityAccess,
+                                        context, hostSession, successCallback, errorCallback);
+  }
+
+  void getWithRelationship(const EntityReferences& entityReferences,
+                           const trait::TraitsDataPtr& relationshipTraitsData,
+                           const trait::TraitSet& resultTraitSet, size_t pageSize,
+                           access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+                           const managerApi::HostSessionPtr& hostSession,
+                           const RelationshipQuerySuccessCallback& successCallback,
+                           const BatchElementErrorCallback& errorCallback) override {
+    INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(Capability::kRelationshipQueries, getWithRelationship,
+                                        entityReferences, relationshipTraitsData, resultTraitSet,
+                                        pageSize, relationsAccess, context, hostSession,
+                                        successCallback, errorCallback);
+  }
+
+  void getWithRelationships(const EntityReference& entityReference,
+                            const trait::TraitsDatas& relationshipTraitsDatas,
+                            const trait::TraitSet& resultTraitSet, size_t pageSize,
+                            access::RelationsAccess relationsAccess,
+                            const ContextConstPtr& context,
+                            const managerApi::HostSessionPtr& hostSession,
+                            const RelationshipQuerySuccessCallback& successCallback,
+                            const BatchElementErrorCallback& errorCallback) override {
+    INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(Capability::kRelationshipQueries, getWithRelationships,
+                                        entityReference, relationshipTraitsDatas, resultTraitSet,
+                                        pageSize, relationsAccess, context, hostSession,
+                                        successCallback, errorCallback);
+  }
+
+  void preflight(const EntityReferences& entityReferences, const trait::TraitsDatas& traitsHints,
+                 access::PublishingAccess publishingAccess, const ContextConstPtr& context,
+                 const managerApi::HostSessionPtr& hostSession,
+                 const PreflightSuccessCallback& successCallback,
+                 const BatchElementErrorCallback& errorCallback) override {
+    INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(Capability::kPublishing, preflight, entityReferences,
+                                        traitsHints, publishingAccess, context, hostSession,
+                                        successCallback, errorCallback);
+  }
+
+  void register_(const EntityReferences& entityReferences,
+                 const trait::TraitsDatas& entityTraitsDatas,
+                 access::PublishingAccess publishingAccess, const ContextConstPtr& context,
+                 const managerApi::HostSessionPtr& hostSession,
+                 const RegisterSuccessCallback& successCallback,
+                 const BatchElementErrorCallback& errorCallback) override {
+    INVOKE_CAPABLE_MANAGER_FOR_FUNCTION(Capability::kPublishing, register_, entityReferences,
+                                        entityTraitsDatas, publishingAccess, context, hostSession,
+                                        successCallback, errorCallback);
+  }
+
+ private:
+  ManagerInterfaces managerInterfaces_;
+  std::unordered_map<Capability, managerApi::ManagerInterfacePtr> managerInterfacesByCapability_;
+};
+}  // namespace
+
+HybridPluginSystemManagerImplementationFactoryPtr
+HybridPluginSystemManagerImplementationFactory::make(
+    ManagerImplementationFactoryInterfaces factories, log::LoggerInterfacePtr logger) {
+  if (factories.empty()) {
+    throw errors::InputValidationException{
+        "HybridPluginSystem: At least one child manager implementation factory must be provided"};
+  }
+
+  return std::make_shared<HybridPluginSystemManagerImplementationFactory>(
+      HybridPluginSystemManagerImplementationFactory{std::move(factories), std::move(logger)});
+}
+
+HybridPluginSystemManagerImplementationFactory::HybridPluginSystemManagerImplementationFactory(
+    ManagerImplementationFactoryInterfaces factories, log::LoggerInterfacePtr logger)
+    : ManagerImplementationFactoryInterface{std::move(logger)}, factories_{std::move(factories)} {}
+
+Identifiers HybridPluginSystemManagerImplementationFactory::identifiers() {
+  Identifiers identifiers;
+  // Collect all identifiers from all factories.
+  for (const auto& factory : factories_) {
+    Identifiers factoryIdentifiers = factory->identifiers();
+    identifiers.insert(end(identifiers), make_move_iterator(begin(factoryIdentifiers)),
+                       make_move_iterator(end(factoryIdentifiers)));
+  }
+  // Sort and remove duplicates.
+  sort(begin(identifiers), end(identifiers));
+  identifiers.erase(unique(begin(identifiers), end(identifiers)), end(identifiers));
+  return identifiers;
+}
+
+managerApi::ManagerInterfacePtr HybridPluginSystemManagerImplementationFactory::instantiate(
+    const Identifier& identifier) {
+  std::vector<managerApi::ManagerInterfacePtr> managerInterfaces;
+
+  for (const auto& factory : factories_) {
+    const Identifiers& factoryIdentifiers = factory->identifiers();
+    if (const auto iter = find(cbegin(factoryIdentifiers), cend(factoryIdentifiers), identifier);
+        iter != cend(factoryIdentifiers)) {
+      managerInterfaces.push_back(factory->instantiate(identifier));
+    }
+  }
+
+  if (managerInterfaces.empty()) {
+    throw errors::InputValidationException{fmt::format(
+        "HybridPluginSystem: No plug-in registered with the identifier '{}'", identifier)};
+  }
+
+  if (managerInterfaces.size() == 1) {
+    return std::move(managerInterfaces[0]);
+  }
+
+  return std::make_shared<HybridManagerInterface>(std::move(managerInterfaces));
+}
+}  // namespace pluginSystem
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/tests/typedefsTest.cpp
+++ b/src/openassetio-core/tests/typedefsTest.cpp
@@ -24,6 +24,7 @@
 #include <openassetio/pluginSystem/CppPluginSystemManagerImplementationFactory.hpp>
 #include <openassetio/pluginSystem/CppPluginSystemManagerPlugin.hpp>
 #include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+#include <openassetio/pluginSystem/HybridPluginSystemManagerImplementationFactory.hpp>
 #include <openassetio/trait/TraitsData.hpp>
 
 namespace {
@@ -55,7 +56,8 @@ using ClassesWithPtrAlias = std::tuple<
     CLASS_AND_PTRS(pluginSystem::CppPluginSystem),
     CLASS_AND_PTRS(pluginSystem::CppPluginSystemManagerImplementationFactory),
     CLASS_AND_PTRS(pluginSystem::CppPluginSystemManagerPlugin),
-    CLASS_AND_PTRS(pluginSystem::CppPluginSystemPlugin)
+    CLASS_AND_PTRS(pluginSystem::CppPluginSystemPlugin),
+    CLASS_AND_PTRS(pluginSystem::HybridPluginSystemManagerImplementationFactory)
 >;
 // clang-format on
 }  // namespace

--- a/src/openassetio-python/cmodule/CMakeLists.txt
+++ b/src/openassetio-python/cmodule/CMakeLists.txt
@@ -78,6 +78,7 @@ target_sources(
     src/pluginSystem/CppPluginSystemBinding.cpp
     src/pluginSystem/CppPluginSystemPluginBinding.cpp
     src/pluginSystem/CppPluginSystemManagerImplementationFactoryBinding.cpp
+    src/pluginSystem/HybridPluginSystemManagerImplementationFactoryBinding.cpp
     src/trait/TraitsDataBinding.cpp
     src/utilsBinding.cpp
 )

--- a/src/openassetio-python/cmodule/src/_openassetio.cpp
+++ b/src/openassetio-python/cmodule/src/_openassetio.cpp
@@ -55,6 +55,7 @@ PYBIND11_MODULE(_openassetio, mod) {
   registerCppPluginSystemPlugin(pluginSystem);
   registerCppPluginSystem(pluginSystem);
   registerCppPluginSystemManagerImplementationFactory(pluginSystem);
+  registerHybridPluginSystemManagerImplementationFactory(pluginSystem);
 
 #ifdef OPENASSETIO_ENABLE_TESTS
   registerTestUtils(mod);

--- a/src/openassetio-python/cmodule/src/_openassetio.hpp
+++ b/src/openassetio-python/cmodule/src/_openassetio.hpp
@@ -117,3 +117,6 @@ void registerCppPluginSystem(const py::module& mod);
 
 // Register the C++ plugin system manager factory
 void registerCppPluginSystemManagerImplementationFactory(const py::module& mod);
+
+// Register the hybrid plugin system manager factory
+void registerHybridPluginSystemManagerImplementationFactory(const py::module& mod);

--- a/src/openassetio-python/cmodule/src/pluginSystem/HybridPluginSystemManagerImplementationFactoryBinding.cpp
+++ b/src/openassetio-python/cmodule/src/pluginSystem/HybridPluginSystemManagerImplementationFactoryBinding.cpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <algorithm>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/pluginSystem/HybridPluginSystemManagerImplementationFactory.hpp>
+
+#include "../_openassetio.hpp"
+#include "../overrideMacros.hpp"
+
+void registerHybridPluginSystemManagerImplementationFactory(const py::module_& mod) {
+  using openassetio::hostApi::ManagerImplementationFactoryInterface;
+  using openassetio::log::LoggerInterface;
+  using openassetio::managerApi::ManagerInterface;
+  using openassetio::pluginSystem::HybridPluginSystemManagerImplementationFactory;
+
+  // We must ensure any Python facade implementing a "subclass" is not
+  // destroyed whilst the C++ instance is alive. The
+  // PyRetainingSharedPtr mechanism ensures the Python object lifetime
+  // is linked to the shared_ptr lifetime.
+  using openassetio::PyRetainingSharedPtr;
+  using PyRetainingLoggerInterfacePtr = PyRetainingSharedPtr<LoggerInterface>;
+  using PyRetainingManagerImplFactoryPtrs =
+      std::vector<PyRetainingSharedPtr<ManagerImplementationFactoryInterface>>;
+
+  py::class_<HybridPluginSystemManagerImplementationFactory, ManagerImplementationFactoryInterface,
+             HybridPluginSystemManagerImplementationFactory::Ptr>(
+      mod, "HybridPluginSystemManagerImplementationFactory", py::is_final())
+      .def(py::init([](PyRetainingManagerImplFactoryPtrs factories,
+                       PyRetainingLoggerInterfacePtr logger) {
+             if (any_of(cbegin(factories), cend(factories),
+                        std::logical_not<PyRetainingManagerImplFactoryPtrs::value_type>{})) {
+               throw openassetio::errors::InputValidationException{
+                   "HybridPluginSystem: Manager implementation factory cannot be None"};
+             }
+
+             return HybridPluginSystemManagerImplementationFactory::make(
+                 {make_move_iterator(begin(factories)), make_move_iterator(end(factories))},
+                 std::move(logger));
+           }),
+           py::arg("factories"), py::arg("logger").none(false))
+      .def("identifiers", &HybridPluginSystemManagerImplementationFactory::identifiers,
+           py::call_guard<py::gil_scoped_release>{})
+      .def("instantiate", &HybridPluginSystemManagerImplementationFactory::instantiate,
+           py::arg("identifier"), py::call_guard<py::gil_scoped_release>{});
+}

--- a/src/openassetio-python/package/openassetio/pluginSystem/__init__.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/__init__.py
@@ -28,8 +28,19 @@ from .PythonPluginSystemManagerImplementationFactory import (
 
 from .. import _openassetio  # pylint: disable=no-name-in-module
 
+## @see @fqref{pluginSystem.CppPluginSystem} "CppPluginSystem"
 CppPluginSystem = _openassetio.pluginSystem.CppPluginSystem
+## @see @fqref{pluginSystem.CppPluginSystemPlugin}
+# "CppPluginSystemPlugin"
 CppPluginSystemPlugin = _openassetio.pluginSystem.CppPluginSystemPlugin
+## @see @fqref{pluginSystem.CppPluginSystemManagerImplementationFactory}
+# "CppPluginSystemManagerImplementationFactory"
 CppPluginSystemManagerImplementationFactory = (
     _openassetio.pluginSystem.CppPluginSystemManagerImplementationFactory
+)
+## @see
+# @fqref{pluginSystem.HybridPluginSystemManagerImplementationFactory}
+# "HybridPluginSystemManagerImplementationFactory"
+HybridPluginSystemManagerImplementationFactory = (
+    _openassetio.pluginSystem.HybridPluginSystemManagerImplementationFactory
 )

--- a/src/openassetio-python/package/openassetio/test/manager/_implementation.py
+++ b/src/openassetio-python/package/openassetio/test/manager/_implementation.py
@@ -23,6 +23,7 @@ import unittest
 from openassetio import hostApi, log
 from openassetio.pluginSystem import (
     CppPluginSystemManagerImplementationFactory,
+    HybridPluginSystemManagerImplementationFactory,
     PythonPluginSystemManagerImplementationFactory,
 )
 from openassetio.trait import TraitsData
@@ -47,13 +48,13 @@ def createHarness(managerIdentifier, settings=None):
     hostInterface = _ValidatorHarnessHostInterface()
     logger = log.SeverityFilter(log.ConsoleLogger())
 
-    managerFactoryImplementation = PythonPluginSystemManagerImplementationFactory(logger)
-
-    # If the python plugin cannot be found on a scan (occurs lazily when
-    # identifiers is called), then move forward with C++, as it could
-    # be there.
-    if managerIdentifier not in managerFactoryImplementation.identifiers():
-        managerFactoryImplementation = CppPluginSystemManagerImplementationFactory(logger)
+    managerFactoryImplementation = HybridPluginSystemManagerImplementationFactory(
+        [
+            CppPluginSystemManagerImplementationFactory(logger),
+            PythonPluginSystemManagerImplementationFactory(logger),
+        ],
+        logger,
+    )
 
     if managerIdentifier not in managerFactoryImplementation.identifiers():
         msg = (

--- a/src/openassetio-python/tests/cmodule/gil/test_managerfactory_gil.py
+++ b/src/openassetio-python/tests/cmodule/gil/test_managerfactory_gil.py
@@ -27,6 +27,7 @@ import pytest
 # pylint: disable=no-name-in-module
 from openassetio import _openassetio
 from openassetio.hostApi import ManagerImplementationFactoryInterface, ManagerFactory
+from openassetio.pluginSystem import HybridPluginSystemManagerImplementationFactory
 
 
 class Test_ManagerImplementationFactoryInterface_gil:
@@ -54,7 +55,7 @@ class Test_ManagerImplementationFactoryInterface_gil:
 """
                 )
 
-        assert unimplemented == []
+        assert not unimplemented
 
     def test_identifiers(self, a_threaded_manager_impl_factory, mock_manager_impl_factory):
         mock_manager_impl_factory.mock.identifiers.return_value = []
@@ -68,6 +69,50 @@ class Test_ManagerImplementationFactoryInterface_gil:
     ):
         mock_manager_impl_factory.mock.instantiate.return_value = mock_manager_interface
         a_threaded_manager_impl_factory.instantiate("")
+
+
+class Test_HybridPluginSystemManagerImplementationFactory_gil:
+    """
+    Check all methods release the GIL during C++ function body
+    execution.
+
+    See docstring for similar test under `gil/Test_ManagerInterface.py`
+    for details on how these tests are structured.
+    """
+
+    def test_all_methods_covered(self, find_unimplemented_test_cases):
+        """
+        Ensure this test class covers all methods.
+        """
+        unimplemented = find_unimplemented_test_cases(
+            HybridPluginSystemManagerImplementationFactory, self
+        )
+
+        if unimplemented:
+            print("\nSome test cases not implemented. Method templates can be found below:\n")
+            for method in unimplemented:
+                print(
+                    f"""
+    def test_{method}(self, a_threaded_hybrid_impl_factory, mock_manager_impl_factory):
+        a_threaded_hybrid_impl_factory.{method}()
+"""
+                )
+
+        assert not unimplemented
+
+    def test_identifiers(self, a_threaded_hybrid_impl_factory, mock_manager_impl_factory):
+        mock_manager_impl_factory.mock.identifiers.return_value = []
+        a_threaded_hybrid_impl_factory.identifiers()
+
+    def test_instantiate(
+        self,
+        a_threaded_hybrid_impl_factory,
+        mock_manager_impl_factory,
+        mock_manager_interface,
+    ):
+        mock_manager_impl_factory.mock.identifiers.return_value = [""]
+        mock_manager_impl_factory.mock.instantiate.return_value = mock_manager_interface
+        a_threaded_hybrid_impl_factory.instantiate("")
 
 
 class Test_ManagerFactory_gil:
@@ -115,7 +160,7 @@ class Test_ManagerFactory_gil:
 """
                 )
 
-        assert unimplemented == []
+        assert not unimplemented
 
     def test_availableManagers(
         self,
@@ -204,6 +249,13 @@ class Test_ManagerFactory_gil:
 @pytest.fixture
 def a_threaded_manager_factory(mock_host_interface, a_threaded_manager_impl_factory, mock_logger):
     return ManagerFactory(mock_host_interface, a_threaded_manager_impl_factory, mock_logger)
+
+
+@pytest.fixture
+def a_threaded_hybrid_impl_factory(a_threaded_manager_impl_factory, mock_logger):
+    return HybridPluginSystemManagerImplementationFactory(
+        [a_threaded_manager_impl_factory], mock_logger
+    )
 
 
 @pytest.fixture

--- a/src/openassetio-python/tests/package/pluginSystem/test_hybridpluginsystemmanagerimplementationfactory.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_hybridpluginsystemmanagerimplementationfactory.py
@@ -1,0 +1,1643 @@
+#   Copyright 2024 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+These tests check the functionality of the hybrid
+HybridPluginSystemManagerImplementationFactory implementation.
+"""
+import inspect
+import itertools
+from unittest import mock
+
+import pytest
+from openassetio import errors, access, Context, EntityReference
+from openassetio.trait import TraitsData
+
+# pylint: disable=unused-argument,too-many-lines,too-many-locals
+# pylint: disable=invalid-name,redefined-outer-name,
+# pylint: disable=missing-class-docstring,missing-function-docstring
+# pylint: disable=too-many-public-methods
+
+
+from openassetio.hostApi import ManagerImplementationFactoryInterface
+from openassetio.managerApi import (
+    ManagerInterface,
+    ManagerStateBase,
+    EntityReferencePagerInterface,
+)
+from openassetio.pluginSystem import HybridPluginSystemManagerImplementationFactory
+
+
+class Test_HybridPluginSystemManagerImplementationFactory_init:
+    def test_when_None_child_factory_then_raises_error(self, mock_logger, factory_a):
+        with pytest.raises(
+            errors.InputValidationException,
+            match="HybridPluginSystem: Manager implementation factory cannot be None",
+        ):
+            HybridPluginSystemManagerImplementationFactory([factory_a, None], mock_logger)
+
+    def test_when_empty_child_factories_then_raises_error(self, mock_logger):
+        with pytest.raises(
+            errors.InputValidationException,
+            match=(
+                "HybridPluginSystem: At least one child manager implementation factory must be"
+                " provided"
+            ),
+        ):
+            HybridPluginSystemManagerImplementationFactory([], mock_logger)
+
+
+class Test_HybridPluginSystemManagerImplementationFactory_identifiers:
+
+    def test_identifiers_from_all_children_deduplicated(self, mock_logger, factory_a, factory_b):
+        factory_a.mock.identifiers.return_value = ["a", "c", "b"]
+        factory_b.mock.identifiers.return_value = ["b", "c", "d"]
+
+        factory = HybridPluginSystemManagerImplementationFactory(
+            [factory_b, factory_a], mock_logger
+        )
+        assert factory.identifiers() == ["a", "b", "c", "d"]
+
+
+class Test_HybridPluginSystemManagerImplementationFactory_instantiate:
+    def test_when_no_match_from_multiple_child_factories_then_error_raised(
+        self, factory_a, factory_b, mock_logger
+    ):
+        factory_a.mock.identifiers.return_value = ["bar"]
+        factory_b.mock.identifiers.return_value = ["baz"]
+
+        factory = HybridPluginSystemManagerImplementationFactory(
+            [factory_a, factory_b], mock_logger
+        )
+
+        with pytest.raises(
+            errors.InputValidationException,
+            match="HybridPluginSystem: No plug-in registered with the identifier 'foo'",
+        ):
+            factory.instantiate("foo")
+
+    def test_when_single_factory_matches_then_uses_that_factorys_interface(
+        self, mock_logger, factory_a, factory_b, the_plugin_identifier
+    ):
+        factory_a.mock.identifiers.return_value = ["a", the_plugin_identifier]
+        factory_b.mock.identifiers.return_value = ["b"]
+
+        factory = HybridPluginSystemManagerImplementationFactory(
+            [factory_a, factory_b], mock_logger
+        )
+
+        actual_manager_interface = factory.instantiate(the_plugin_identifier)
+
+        factory_a.mock.instantiate.assert_called_once_with(the_plugin_identifier)
+        assert not factory_b.mock.instantiate.called
+        assert actual_manager_interface is factory_a.mock.instantiate.return_value
+
+    def test_when_many_factories_provided_and_one_matches_then_uses_that_factorys_interface(
+        self,
+        mock_logger,
+        create_mock_manager_interface,
+        factory_a,
+        factory_b,
+        the_plugin_identifier,
+    ):
+        factory_a.mock.identifiers.return_value = ["a"]
+        factory_b.mock.identifiers.return_value = ["b"]
+        factory_c = MockManagerImplementationFactory(mock_logger)
+        factory_c.mock.identifiers.return_value = ["c"]
+        factory_d = MockManagerImplementationFactory(mock_logger)
+        factory_d.mock.identifiers.return_value = [the_plugin_identifier]
+        factory_d.mock.instantiate.return_value = create_mock_manager_interface()
+        factory_e = MockManagerImplementationFactory(mock_logger)
+        factory_e.mock.identifiers.return_value = ["e"]
+
+        factory = HybridPluginSystemManagerImplementationFactory(
+            [factory_a, factory_b, factory_c, factory_d, factory_e], mock_logger
+        )
+
+        actual_manager_interface = factory.instantiate(the_plugin_identifier)
+
+        assert not factory_a.mock.instantiate.called
+        assert not factory_b.mock.instantiate.called
+        assert not factory_c.mock.instantiate.called
+        factory_d.mock.instantiate.assert_called_once_with(the_plugin_identifier)
+        assert not factory_e.mock.instantiate.called
+
+        assert actual_manager_interface is factory_d.mock.instantiate.return_value
+
+    def test_when_multiple_factories_match_then_hybrid_interface_used(
+        self, mock_logger, factory_a, factory_b, the_plugin_identifier
+    ):
+        factory = HybridPluginSystemManagerImplementationFactory(
+            [factory_a, factory_b], mock_logger
+        )
+
+        actual_manager_interface = factory.instantiate(the_plugin_identifier)
+
+        factory_a.mock.instantiate.assert_called_once_with(the_plugin_identifier)
+        factory_b.mock.instantiate.assert_called_once_with(the_plugin_identifier)
+        assert isinstance(actual_manager_interface, ManagerInterface)
+        assert actual_manager_interface is not factory_a.mock.instantiate.return_value
+        assert actual_manager_interface is not factory_b.mock.instantiate.return_value
+
+    def test_when_child_factories_go_out_of_scope_then_hybrid_retains_valid_reference(
+        self, mock_logger, create_mock_manager_interface, the_plugin_identifier
+    ):
+        # I.e. test that PyRetainingSharedPtr is used in C++ to refer to
+        # the child factories, so the Python facade is kept alive
+        # despite going out of scope.
+
+        def make_factory():
+            factory_a = MockManagerImplementationFactory(mock_logger)
+            factory_a.mock.identifiers.return_value = [the_plugin_identifier]
+            factory_a.mock.instantiate.return_value = create_mock_manager_interface()
+
+            factory_b = MockManagerImplementationFactory(mock_logger)
+            factory_b.mock.identifiers.return_value = [the_plugin_identifier]
+            factory_b.mock.instantiate.return_value = create_mock_manager_interface()
+
+            return HybridPluginSystemManagerImplementationFactory(
+                [factory_a, factory_b], mock_logger
+            )
+
+        factory = make_factory()
+
+        # Hoping to avoid pybind11 exception "RuntimeError: Tried to
+        # call pure virtual function"
+        manager_interface = factory.instantiate(the_plugin_identifier)
+
+        assert isinstance(manager_interface, ManagerInterface)
+
+
+class Test_HybridPluginSystemManagerImplementationFactory_ManagerInterface:
+
+    def test_identifier_uses_first_child_implementation(
+        self,
+        mock_logger,
+        factory_a,
+        factory_b,
+        the_plugin_identifier,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+    ):
+        # Note: in reality we require that plugins and their
+        # ManagerInterface instances advertise the same identifier, but
+        # just for testing here we vary them.
+
+        manager_interface_a.mock.identifier.return_value = "a"
+        manager_interface_b.mock.identifier.return_value = "b"
+
+        identifier = hybrid_manager_interface.identifier()
+
+        assert identifier == "a"
+
+        manager_interface = HybridPluginSystemManagerImplementationFactory(
+            [factory_b, factory_a], mock_logger
+        ).instantiate(the_plugin_identifier)
+
+        identifier = manager_interface.identifier()
+
+        assert identifier == "b"
+
+    def test_displayName_uses_first_child_implementation(
+        self,
+        mock_logger,
+        factory_a,
+        factory_b,
+        the_plugin_identifier,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+    ):
+        manager_interface_a.mock.displayName.return_value = "A"
+        manager_interface_b.mock.displayName.return_value = "B"
+
+        name = hybrid_manager_interface.displayName()
+
+        assert name == "A"
+
+        manager_interface = HybridPluginSystemManagerImplementationFactory(
+            [factory_b, factory_a], mock_logger
+        ).instantiate(the_plugin_identifier)
+
+        name = manager_interface.displayName()
+
+        assert name == "B"
+
+    def test_info_aggregates_all_implementations_preferring_first(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+    ):
+        manager_interface_a.mock.info.return_value = {"x": 1, "y": "i"}
+        manager_interface_b.mock.info.return_value = {"y": "k", "z": 1.2}
+
+        assert hybrid_manager_interface.info() == {"x": 1, "y": "i", "z": 1.2}
+
+    def test_settings_aggregates_all_implementations_preferring_first(
+        self,
+        a_host_session,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+    ):
+        manager_interface_a.mock.settings.return_value = {"x": "j", "y": "i"}
+        manager_interface_b.mock.settings.return_value = {"y": "k", "z": 1.2}
+
+        assert hybrid_manager_interface.settings(a_host_session) == {"x": "j", "y": "i", "z": 1.2}
+
+    def test_when_not_yet_initialized_then_no_capabilities_available(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        a_host_session,
+    ):
+        manager_interface_a.mock.hasCapability.return_value = True
+
+        for capability in ManagerInterface.Capability.__members__.values():
+            assert not hybrid_manager_interface.hasCapability(capability)
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        for capability in ManagerInterface.Capability.__members__.values():
+            assert hybrid_manager_interface.hasCapability(capability)
+
+    @pytest.mark.parametrize(
+        "capability",
+        # Couple of arbitrary capabilities.
+        (
+            ManagerInterface.Capability.kPublishing,
+            ManagerInterface.Capability.kEntityReferenceIdentification,
+        ),
+    )
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_hasCapability_is_aggregated_from_all_child_implementations(
+        self,
+        capability,
+        hasCapability_a,
+        hasCapability_b,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        a_host_session,
+    ):
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == capability and hasCapability_b
+        )
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        assert hybrid_manager_interface.hasCapability(capability) is (
+            hasCapability_a or hasCapability_b
+        )
+
+    def test_initialize_initializes_all_child_implementations_forwarding_all_arguments(
+        self, manager_interface_a, manager_interface_b, hybrid_manager_interface, a_host_session
+    ):
+        expected_settings = {"x": 1, "y": "2", "z": False}
+
+        hybrid_manager_interface.initialize(expected_settings, a_host_session)
+
+        manager_interface_a.mock.initialize.assert_called_once_with(
+            expected_settings, a_host_session
+        )
+        manager_interface_b.mock.initialize.assert_called_once_with(
+            expected_settings, a_host_session
+        )
+
+    def test_flushCaches_flushes_all_child_implementations(
+        self, manager_interface_a, manager_interface_b, hybrid_manager_interface, a_host_session
+    ):
+        hybrid_manager_interface.flushCaches(a_host_session)
+
+        manager_interface_a.mock.flushCaches.assert_called_once_with(a_host_session)
+        manager_interface_b.mock.flushCaches.assert_called_once_with(a_host_session)
+
+    #
+    # The remaining tests are all rather similar - we ensure that the
+    # appropriate child implementation is chosen based on different
+    # combinations of capabilities, and that arguments and results
+    # are forwarded.
+    #
+
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_updateTerminology(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        a_host_session,
+        hasCapability_a,
+        hasCapability_b,
+    ):
+        expected_capability = ManagerInterface.Capability.kCustomTerminology
+        some_input_terminology = {"x": "y"}
+        expected_output_terminology = {"x": "y", "z": "w"}
+
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_b
+        )
+        manager_interface_a.mock.updateTerminology.return_value = expected_output_terminology
+        manager_interface_b.mock.updateTerminology.return_value = expected_output_terminology
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        if not hasCapability_a and not hasCapability_b:
+            # Neither implementation has the capability, so we should
+            # get an exception.
+            with pytest.raises(errors.NotImplementedException):
+                hybrid_manager_interface.updateTerminology(some_input_terminology, a_host_session)
+        else:
+            # At least one implementation has the capability.
+            actual_output_terminology = hybrid_manager_interface.updateTerminology(
+                some_input_terminology, a_host_session
+            )
+            assert actual_output_terminology == expected_output_terminology
+
+            if hasCapability_a:
+                # The first implementation has the capability.
+                manager_interface_a.mock.updateTerminology.assert_called_once_with(
+                    some_input_terminology, a_host_session
+                )
+                manager_interface_b.mock.updateTerminology.assert_not_called()
+            else:
+                # The second implementation has the capability.
+                manager_interface_a.mock.updateTerminology.assert_not_called()
+                manager_interface_b.mock.updateTerminology.assert_called_once_with(
+                    some_input_terminology, a_host_session
+                )
+
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_managementPolicy(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        a_host_session,
+        hasCapability_a,
+        hasCapability_b,
+        a_context,
+    ):
+        some_trait_sets = [{"x"}]
+        a_policy_access = access.PolicyAccess.kRead
+
+        expected_capability = ManagerInterface.Capability.kManagementPolicyQueries
+        expected_policies = [TraitsData({"z"})]
+
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_b
+        )
+        manager_interface_a.mock.managementPolicy.return_value = expected_policies
+        manager_interface_b.mock.managementPolicy.return_value = expected_policies
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        if not hasCapability_a and not hasCapability_b:
+            # Neither implementation has the capability, so we should
+            # get an exception.
+            with pytest.raises(errors.NotImplementedException):
+                hybrid_manager_interface.managementPolicy(
+                    some_trait_sets, a_policy_access, a_context, a_host_session
+                )
+        else:
+            # At least one implementation has the capability.
+            actual_policies = hybrid_manager_interface.managementPolicy(
+                some_trait_sets, a_policy_access, a_context, a_host_session
+            )
+            assert actual_policies == expected_policies
+
+            if hasCapability_a:
+                # The first implementation has the capability.
+                manager_interface_a.mock.managementPolicy.assert_called_once_with(
+                    some_trait_sets, a_policy_access, a_context, a_host_session
+                )
+                manager_interface_b.mock.managementPolicy.assert_not_called()
+            else:
+                # The second implementation has the capability.
+                manager_interface_a.mock.managementPolicy.assert_not_called()
+                manager_interface_b.mock.managementPolicy.assert_called_once_with(
+                    some_trait_sets, a_policy_access, a_context, a_host_session
+                )
+
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_createState(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        a_host_session,
+        hasCapability_a,
+        hasCapability_b,
+        a_manager_state,
+    ):
+        expected_capability = ManagerInterface.Capability.kStatefulContexts
+
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_b
+        )
+        manager_interface_a.mock.createState.return_value = a_manager_state
+        manager_interface_b.mock.createState.return_value = a_manager_state
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        if not hasCapability_a and not hasCapability_b:
+            # Neither implementation has the capability, so we should
+            # get an exception.
+            with pytest.raises(errors.NotImplementedException):
+                hybrid_manager_interface.createState(a_host_session)
+        else:
+            # At least one implementation has the capability.
+            actual_state = hybrid_manager_interface.createState(a_host_session)
+            assert actual_state is a_manager_state
+
+            if hasCapability_a:
+                # The first implementation has the capability.
+                manager_interface_a.mock.createState.assert_called_once_with(a_host_session)
+                manager_interface_b.mock.createState.assert_not_called()
+            else:
+                # The second implementation has the capability.
+                manager_interface_a.mock.createState.assert_not_called()
+                manager_interface_b.mock.createState.assert_called_once_with(a_host_session)
+
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_createChildState(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        a_host_session,
+        hasCapability_a,
+        hasCapability_b,
+        a_manager_state,
+    ):
+        expected_capability = ManagerInterface.Capability.kStatefulContexts
+
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_b
+        )
+
+        class ChildManagerState(ManagerStateBase):
+            pass
+
+        child_manager_state = ChildManagerState()
+        manager_interface_a.mock.createChildState.return_value = child_manager_state
+        manager_interface_b.mock.createChildState.return_value = child_manager_state
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        if not hasCapability_a and not hasCapability_b:
+            # Neither implementation has the capability, so we should
+            # get an exception.
+            with pytest.raises(errors.NotImplementedException):
+                hybrid_manager_interface.createChildState(a_manager_state, a_host_session)
+        else:
+            # At least one implementation has the capability.
+            actual_state = hybrid_manager_interface.createChildState(
+                a_manager_state, a_host_session
+            )
+            assert actual_state is child_manager_state
+
+            if hasCapability_a:
+                # The first implementation has the capability.
+                manager_interface_a.mock.createChildState.assert_called_once_with(
+                    a_manager_state, a_host_session
+                )
+                manager_interface_b.mock.createChildState.assert_not_called()
+            else:
+                # The second implementation has the capability.
+                manager_interface_a.mock.createChildState.assert_not_called()
+                manager_interface_b.mock.createChildState.assert_called_once_with(
+                    a_manager_state, a_host_session
+                )
+
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_persistenceTokenForState(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        a_host_session,
+        hasCapability_a,
+        hasCapability_b,
+        a_manager_state,
+    ):
+        expected_capability = ManagerInterface.Capability.kStatefulContexts
+
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_b
+        )
+
+        expected_persistence_token = "some token"
+        manager_interface_a.mock.persistenceTokenForState.return_value = expected_persistence_token
+        manager_interface_b.mock.persistenceTokenForState.return_value = expected_persistence_token
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        if not hasCapability_a and not hasCapability_b:
+            # Neither implementation has the capability, so we should
+            # get an exception.
+            with pytest.raises(errors.NotImplementedException):
+                hybrid_manager_interface.persistenceTokenForState(a_manager_state, a_host_session)
+        else:
+            # At least one implementation has the capability.
+            actual_persistence_token = hybrid_manager_interface.persistenceTokenForState(
+                a_manager_state, a_host_session
+            )
+            assert actual_persistence_token == expected_persistence_token
+
+            if hasCapability_a:
+                # The first implementation has the capability.
+                manager_interface_a.mock.persistenceTokenForState.assert_called_once_with(
+                    a_manager_state, a_host_session
+                )
+                manager_interface_b.mock.persistenceTokenForState.assert_not_called()
+            else:
+                # The second implementation has the capability.
+                manager_interface_a.mock.persistenceTokenForState.assert_not_called()
+                manager_interface_b.mock.persistenceTokenForState.assert_called_once_with(
+                    a_manager_state, a_host_session
+                )
+
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_stateFromPersistenceToken(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        a_host_session,
+        hasCapability_a,
+        hasCapability_b,
+        a_manager_state,
+    ):
+        expected_capability = ManagerInterface.Capability.kStatefulContexts
+
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_b
+        )
+
+        a_persistence_token = "some token"
+        manager_interface_a.mock.stateFromPersistenceToken.return_value = a_manager_state
+        manager_interface_b.mock.stateFromPersistenceToken.return_value = a_manager_state
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        if not hasCapability_a and not hasCapability_b:
+            # Neither implementation has the capability, so we should
+            # get an exception.
+            with pytest.raises(errors.NotImplementedException):
+                hybrid_manager_interface.stateFromPersistenceToken(
+                    a_persistence_token, a_host_session
+                )
+        else:
+            # At least one implementation has the capability.
+            actual_state = hybrid_manager_interface.stateFromPersistenceToken(
+                a_persistence_token, a_host_session
+            )
+            assert actual_state is a_manager_state
+
+            if hasCapability_a:
+                # The first implementation has the capability.
+                manager_interface_a.mock.stateFromPersistenceToken.assert_called_once_with(
+                    a_persistence_token, a_host_session
+                )
+                manager_interface_b.mock.stateFromPersistenceToken.assert_not_called()
+            else:
+                # The second implementation has the capability.
+                manager_interface_a.mock.stateFromPersistenceToken.assert_not_called()
+                manager_interface_b.mock.stateFromPersistenceToken.assert_called_once_with(
+                    a_persistence_token, a_host_session
+                )
+
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_isEntityReferenceString(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        hasCapability_a,
+        hasCapability_b,
+        a_host_session,
+    ):
+        expected_capability = ManagerInterface.Capability.kEntityReferenceIdentification
+
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_b
+        )
+
+        test_reference = "test_reference"
+        manager_interface_a.mock.isEntityReferenceString.return_value = True
+        manager_interface_b.mock.isEntityReferenceString.return_value = True
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        if not hasCapability_a and not hasCapability_b:
+            # Neither implementation has the capability, so we should
+            # get an exception.
+            with pytest.raises(errors.NotImplementedException):
+                hybrid_manager_interface.isEntityReferenceString(test_reference, a_host_session)
+        else:
+            # At least one implementation has the capability.
+            result = hybrid_manager_interface.isEntityReferenceString(
+                test_reference, a_host_session
+            )
+            assert result is True
+
+            if hasCapability_a:
+                # The first implementation has the capability.
+                manager_interface_a.mock.isEntityReferenceString.assert_called_once_with(
+                    test_reference, a_host_session
+                )
+                manager_interface_b.mock.isEntityReferenceString.assert_not_called()
+            else:
+                # The second implementation has the capability.
+                manager_interface_a.mock.isEntityReferenceString.assert_not_called()
+                manager_interface_b.mock.isEntityReferenceString.assert_called_once_with(
+                    test_reference, a_host_session
+                )
+
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_entityExists(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        hasCapability_a,
+        hasCapability_b,
+        a_context,
+        a_host_session,
+    ):
+        expected_capability = ManagerInterface.Capability.kExistenceQueries
+        entity_references = [EntityReference("x")]
+        expected_success_cb = mock.Mock()
+        expected_error_cb = mock.Mock()
+
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_b
+        )
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        if not hasCapability_a and not hasCapability_b:
+            # Neither implementation has the capability, so we should
+            # get an exception.
+            with pytest.raises(errors.NotImplementedException):
+                hybrid_manager_interface.entityExists(
+                    entity_references,
+                    a_context,
+                    a_host_session,
+                    expected_success_cb,
+                    expected_error_cb,
+                )
+        else:
+            # At least one implementation has the capability.
+            hybrid_manager_interface.entityExists(
+                entity_references,
+                a_context,
+                a_host_session,
+                expected_success_cb,
+                expected_error_cb,
+            )
+
+            if hasCapability_a:
+                # The first implementation has the capability.
+                manager_interface_a.mock.entityExists.assert_called_once_with(
+                    entity_references, a_context, a_host_session, mock.ANY, mock.ANY
+                )
+                manager_interface_b.mock.entityExists.assert_not_called()
+
+                actual_success_cb = manager_interface_a.mock.entityExists.call_args[0][3]
+                actual_error_cb = manager_interface_a.mock.entityExists.call_args[0][4]
+            else:
+                # The second implementation has the capability.
+                manager_interface_a.mock.entityExists.assert_not_called()
+                manager_interface_b.mock.entityExists.assert_called_once_with(
+                    entity_references, a_context, a_host_session, mock.ANY, mock.ANY
+                )
+
+                actual_success_cb = manager_interface_b.mock.entityExists.call_args[0][3]
+                actual_error_cb = manager_interface_b.mock.entityExists.call_args[0][4]
+
+            # Ensure the callbacks have been passed through. These will
+            # be converted to an intermediate representation by
+            # pybind11, so we cannot do a naive comparison.
+
+            expected_success_cb_args = (123, True)
+            expected_error_cb_args = (
+                123,
+                errors.BatchElementError(
+                    errors.BatchElementError.ErrorCode.kEntityAccessError, "z"
+                ),
+            )
+            actual_success_cb(*expected_success_cb_args)
+            actual_error_cb(*expected_error_cb_args)
+            expected_success_cb.assert_called_once_with(*expected_success_cb_args)
+            expected_error_cb.assert_called_once_with(
+                *expected_error_cb_args,
+            )
+
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_entityTraits(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        hasCapability_a,
+        hasCapability_b,
+        a_context,
+        a_host_session,
+    ):
+        expected_capability = ManagerInterface.Capability.kEntityTraitIntrospection
+        entity_references = [EntityReference("x")]
+        entity_traits_access = access.EntityTraitsAccess.kRead
+        expected_success_cb = mock.Mock()
+        expected_error_cb = mock.Mock()
+
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_b
+        )
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        if not hasCapability_a and not hasCapability_b:
+            # Neither implementation has the capability, so we should
+            # get an exception.
+            with pytest.raises(errors.NotImplementedException):
+                hybrid_manager_interface.entityTraits(
+                    entity_references,
+                    entity_traits_access,
+                    a_context,
+                    a_host_session,
+                    expected_success_cb,
+                    expected_error_cb,
+                )
+        else:
+            # At least one implementation has the capability.
+            hybrid_manager_interface.entityTraits(
+                entity_references,
+                entity_traits_access,
+                a_context,
+                a_host_session,
+                expected_success_cb,
+                expected_error_cb,
+            )
+
+            if hasCapability_a:
+                # The first implementation has the capability.
+                manager_interface_a.mock.entityTraits.assert_called_once_with(
+                    entity_references,
+                    entity_traits_access,
+                    a_context,
+                    a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+                manager_interface_b.mock.entityTraits.assert_not_called()
+
+                actual_success_cb = manager_interface_a.mock.entityTraits.call_args[0][4]
+                actual_error_cb = manager_interface_a.mock.entityTraits.call_args[0][5]
+            else:
+                # The second implementation has the capability.
+                manager_interface_a.mock.entityTraits.assert_not_called()
+                manager_interface_b.mock.entityTraits.assert_called_once_with(
+                    entity_references,
+                    entity_traits_access,
+                    a_context,
+                    a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+
+                actual_success_cb = manager_interface_b.mock.entityTraits.call_args[0][4]
+                actual_error_cb = manager_interface_b.mock.entityTraits.call_args[0][5]
+
+            # Ensure the callbacks have been passed through. These will
+            # be converted to an intermediate representation by
+            # pybind11, so we cannot do a naive comparison.
+
+            expected_success_cb_args = (123, {"t"})
+            expected_error_cb_args = (
+                123,
+                errors.BatchElementError(
+                    errors.BatchElementError.ErrorCode.kEntityAccessError, "z"
+                ),
+            )
+            actual_success_cb(*expected_success_cb_args)
+            actual_error_cb(*expected_error_cb_args)
+            expected_success_cb.assert_called_once_with(*expected_success_cb_args)
+            expected_error_cb.assert_called_once_with(
+                *expected_error_cb_args,
+            )
+
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_resolve(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        hasCapability_a,
+        hasCapability_b,
+        a_context,
+        a_host_session,
+    ):
+        expected_capability = ManagerInterface.Capability.kResolution
+        entity_references = [EntityReference("x")]
+        trait_set = {"t"}
+        resolve_access = access.ResolveAccess.kRead
+        expected_success_cb = mock.Mock()
+        expected_error_cb = mock.Mock()
+
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_b
+        )
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        if not hasCapability_a and not hasCapability_b:
+            # Neither implementation has the capability, so we should
+            # get an exception.
+            with pytest.raises(errors.NotImplementedException):
+                hybrid_manager_interface.resolve(
+                    entity_references,
+                    trait_set,
+                    resolve_access,
+                    a_context,
+                    a_host_session,
+                    expected_success_cb,
+                    expected_error_cb,
+                )
+        else:
+            # At least one implementation has the capability.
+            hybrid_manager_interface.resolve(
+                entity_references,
+                trait_set,
+                resolve_access,
+                a_context,
+                a_host_session,
+                expected_success_cb,
+                expected_error_cb,
+            )
+
+            if hasCapability_a:
+                # The first implementation has the capability.
+                manager_interface_a.mock.resolve.assert_called_once_with(
+                    entity_references,
+                    trait_set,
+                    resolve_access,
+                    a_context,
+                    a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+                manager_interface_b.mock.resolve.assert_not_called()
+
+                actual_success_cb = manager_interface_a.mock.resolve.call_args[0][5]
+                actual_error_cb = manager_interface_a.mock.resolve.call_args[0][6]
+
+            else:
+                # The second implementation has the capability.
+                manager_interface_a.mock.resolve.assert_not_called()
+                manager_interface_b.mock.resolve.assert_called_once_with(
+                    entity_references,
+                    trait_set,
+                    resolve_access,
+                    a_context,
+                    a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+
+                actual_success_cb = manager_interface_b.mock.resolve.call_args[0][5]
+                actual_error_cb = manager_interface_b.mock.resolve.call_args[0][6]
+
+            # Ensure the callbacks have been passed through. These will
+            # be converted to an intermediate representation by
+            # pybind11, so we cannot do a naive comparison.
+
+            expected_success_cb_args = (123, TraitsData({"t"}))
+            expected_error_cb_args = (
+                123,
+                errors.BatchElementError(
+                    errors.BatchElementError.ErrorCode.kEntityAccessError, "z"
+                ),
+            )
+            actual_success_cb(*expected_success_cb_args)
+            actual_error_cb(*expected_error_cb_args)
+            expected_success_cb.assert_called_once_with(*expected_success_cb_args)
+            expected_error_cb.assert_called_once_with(
+                *expected_error_cb_args,
+            )
+
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_defaultEntityReference(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        hasCapability_a,
+        hasCapability_b,
+        a_context,
+        a_host_session,
+    ):
+        expected_capability = ManagerInterface.Capability.kDefaultEntityReferences
+        trait_sets = [{"t"}]
+        default_entity_access = access.DefaultEntityAccess.kRead
+        expected_success_cb = mock.Mock()
+        expected_error_cb = mock.Mock()
+
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_b
+        )
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        if not hasCapability_a and not hasCapability_b:
+            # Neither implementation has the capability, so we should
+            # get an exception.
+            with pytest.raises(errors.NotImplementedException):
+                hybrid_manager_interface.defaultEntityReference(
+                    trait_sets,
+                    default_entity_access,
+                    a_context,
+                    a_host_session,
+                    expected_success_cb,
+                    expected_error_cb,
+                )
+        else:
+            # At least one implementation has the capability.
+            hybrid_manager_interface.defaultEntityReference(
+                trait_sets,
+                default_entity_access,
+                a_context,
+                a_host_session,
+                expected_success_cb,
+                expected_error_cb,
+            )
+
+            if hasCapability_a:
+                # The first implementation has the capability.
+                manager_interface_a.mock.defaultEntityReference.assert_called_once_with(
+                    trait_sets,
+                    default_entity_access,
+                    a_context,
+                    a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+                manager_interface_b.mock.defaultEntityReference.assert_not_called()
+
+                actual_success_cb = manager_interface_a.mock.defaultEntityReference.call_args[0][4]
+                actual_error_cb = manager_interface_a.mock.defaultEntityReference.call_args[0][5]
+
+            else:
+                # The second implementation has the capability.
+                manager_interface_a.mock.defaultEntityReference.assert_not_called()
+                manager_interface_b.mock.defaultEntityReference.assert_called_once_with(
+                    trait_sets,
+                    default_entity_access,
+                    a_context,
+                    a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+
+                actual_success_cb = manager_interface_b.mock.defaultEntityReference.call_args[0][4]
+                actual_error_cb = manager_interface_b.mock.defaultEntityReference.call_args[0][5]
+
+            # Ensure the callbacks have been passed through. These will
+            # be converted to an intermediate representation by
+            # pybind11, so we cannot do a naive comparison.
+            if hasCapability_a:
+                actual_success_cb = manager_interface_a.mock.defaultEntityReference.call_args[0][4]
+                actual_error_cb = manager_interface_a.mock.defaultEntityReference.call_args[0][5]
+            else:
+                actual_success_cb = manager_interface_b.mock.defaultEntityReference.call_args[0][4]
+                actual_error_cb = manager_interface_b.mock.defaultEntityReference.call_args[0][5]
+
+            expected_success_cb_args = (123, EntityReference("default"))
+            expected_error_cb_args = (
+                123,
+                errors.BatchElementError(
+                    errors.BatchElementError.ErrorCode.kEntityAccessError, "z"
+                ),
+            )
+            actual_success_cb(*expected_success_cb_args)
+            actual_error_cb(*expected_error_cb_args)
+            expected_success_cb.assert_called_once_with(*expected_success_cb_args)
+            expected_error_cb.assert_called_once_with(
+                *expected_error_cb_args,
+            )
+
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_getWithRelationship(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        hasCapability_a,
+        hasCapability_b,
+        a_context,
+        a_host_session,
+        an_entity_reference_pager,
+    ):
+        expected_capability = ManagerInterface.Capability.kRelationshipQueries
+        entity_references = [EntityReference("test")]
+        relationship_traits_data = TraitsData({"r"})
+        result_trait_set = {"t"}
+        page_size = 100
+        relations_access = access.RelationsAccess.kRead
+        expected_success_cb = mock.Mock()
+        expected_error_cb = mock.Mock()
+
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_b
+        )
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        if not hasCapability_a and not hasCapability_b:
+            # Neither implementation has the capability, so we should
+            # get an exception.
+            with pytest.raises(errors.NotImplementedException):
+                hybrid_manager_interface.getWithRelationship(
+                    entity_references,
+                    relationship_traits_data,
+                    result_trait_set,
+                    page_size,
+                    relations_access,
+                    a_context,
+                    a_host_session,
+                    expected_success_cb,
+                    expected_error_cb,
+                )
+        else:
+            # At least one implementation has the capability.
+            hybrid_manager_interface.getWithRelationship(
+                entity_references,
+                relationship_traits_data,
+                result_trait_set,
+                page_size,
+                relations_access,
+                a_context,
+                a_host_session,
+                expected_success_cb,
+                expected_error_cb,
+            )
+
+            if hasCapability_a:
+                # The first implementation has the capability.
+                manager_interface_a.mock.getWithRelationship.assert_called_once_with(
+                    entity_references,
+                    relationship_traits_data,
+                    result_trait_set,
+                    page_size,
+                    relations_access,
+                    a_context,
+                    a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+                manager_interface_b.mock.getWithRelationship.assert_not_called()
+                actual_success_cb = manager_interface_a.mock.getWithRelationship.call_args[0][7]
+                actual_error_cb = manager_interface_a.mock.getWithRelationship.call_args[0][8]
+
+            else:
+                # The second implementation has the capability.
+                manager_interface_a.mock.getWithRelationship.assert_not_called()
+                manager_interface_b.mock.getWithRelationship.assert_called_once_with(
+                    entity_references,
+                    relationship_traits_data,
+                    result_trait_set,
+                    page_size,
+                    relations_access,
+                    a_context,
+                    a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+
+                actual_success_cb = manager_interface_b.mock.getWithRelationship.call_args[0][7]
+                actual_error_cb = manager_interface_b.mock.getWithRelationship.call_args[0][8]
+
+            # Ensure the callbacks have been passed through. These
+            # will be converted to an intermediate representation by
+            # pybind11, so we cannot do a naive comparison.
+
+            expected_success_cb_args = (123, an_entity_reference_pager)
+            expected_error_cb_args = (
+                123,
+                errors.BatchElementError(
+                    errors.BatchElementError.ErrorCode.kEntityAccessError, "z"
+                ),
+            )
+            actual_success_cb(*expected_success_cb_args)
+            actual_error_cb(*expected_error_cb_args)
+            expected_success_cb.assert_called_once_with(*expected_success_cb_args)
+            expected_error_cb.assert_called_once_with(
+                *expected_error_cb_args,
+            )
+
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_getWithRelationships(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        hasCapability_a,
+        hasCapability_b,
+        a_context,
+        a_host_session,
+        an_entity_reference_pager,
+    ):
+        expected_capability = ManagerInterface.Capability.kRelationshipQueries
+        entity_reference = EntityReference("test")
+        relationship_traits_datas = [TraitsData({"r1"})]
+        result_trait_set = {"t"}
+        page_size = 100
+        relations_access = access.RelationsAccess.kRead
+        expected_success_cb = mock.Mock()
+        expected_error_cb = mock.Mock()
+
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_b
+        )
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        if not hasCapability_a and not hasCapability_b:
+            # Neither implementation has the capability, so we should
+            # get an exception.
+            with pytest.raises(errors.NotImplementedException):
+                hybrid_manager_interface.getWithRelationships(
+                    entity_reference,
+                    relationship_traits_datas,
+                    result_trait_set,
+                    page_size,
+                    relations_access,
+                    a_context,
+                    a_host_session,
+                    expected_success_cb,
+                    expected_error_cb,
+                )
+        else:
+            # At least one implementation has the capability.
+            hybrid_manager_interface.getWithRelationships(
+                entity_reference,
+                relationship_traits_datas,
+                result_trait_set,
+                page_size,
+                relations_access,
+                a_context,
+                a_host_session,
+                expected_success_cb,
+                expected_error_cb,
+            )
+
+            if hasCapability_a:
+                # The first implementation has the capability.
+                manager_interface_a.mock.getWithRelationships.assert_called_once_with(
+                    entity_reference,
+                    relationship_traits_datas,
+                    result_trait_set,
+                    page_size,
+                    relations_access,
+                    a_context,
+                    a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+                manager_interface_b.mock.getWithRelationships.assert_not_called()
+
+                actual_success_cb = manager_interface_a.mock.getWithRelationships.call_args[0][7]
+                actual_error_cb = manager_interface_a.mock.getWithRelationships.call_args[0][8]
+
+            else:
+                # The second implementation has the capability.
+                manager_interface_a.mock.getWithRelationships.assert_not_called()
+                manager_interface_b.mock.getWithRelationships.assert_called_once_with(
+                    entity_reference,
+                    relationship_traits_datas,
+                    result_trait_set,
+                    page_size,
+                    relations_access,
+                    a_context,
+                    a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+
+                actual_success_cb = manager_interface_b.mock.getWithRelationships.call_args[0][7]
+                actual_error_cb = manager_interface_b.mock.getWithRelationships.call_args[0][8]
+
+            # Ensure the callbacks have been passed through. These
+            # will be converted to an intermediate representation by
+            # pybind11, so we cannot do a naive comparison.
+
+            expected_success_cb_args = (123, an_entity_reference_pager)
+            expected_error_cb_args = (
+                123,
+                errors.BatchElementError(
+                    errors.BatchElementError.ErrorCode.kEntityAccessError, "z"
+                ),
+            )
+            actual_success_cb(*expected_success_cb_args)
+            actual_error_cb(*expected_error_cb_args)
+            expected_success_cb.assert_called_once_with(*expected_success_cb_args)
+            expected_error_cb.assert_called_once_with(
+                *expected_error_cb_args,
+            )
+
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_preflight(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        hasCapability_a,
+        hasCapability_b,
+        a_context,
+        a_host_session,
+    ):
+        expected_capability = ManagerInterface.Capability.kPublishing
+        entity_references = [EntityReference("x")]
+        traits_hints = [TraitsData({"h"})]
+        publishing_access = access.PublishingAccess.kWrite
+        expected_success_cb = mock.Mock()
+        expected_error_cb = mock.Mock()
+
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_b
+        )
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        if not hasCapability_a and not hasCapability_b:
+            # Neither implementation has the capability, so we should
+            # get an exception.
+            with pytest.raises(errors.NotImplementedException):
+                hybrid_manager_interface.preflight(
+                    entity_references,
+                    traits_hints,
+                    publishing_access,
+                    a_context,
+                    a_host_session,
+                    expected_success_cb,
+                    expected_error_cb,
+                )
+        else:
+            # At least one implementation has the capability.
+            hybrid_manager_interface.preflight(
+                entity_references,
+                traits_hints,
+                publishing_access,
+                a_context,
+                a_host_session,
+                expected_success_cb,
+                expected_error_cb,
+            )
+
+            if hasCapability_a:
+                # The first implementation has the capability.
+                manager_interface_a.mock.preflight.assert_called_once_with(
+                    entity_references,
+                    traits_hints,
+                    publishing_access,
+                    a_context,
+                    a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+                manager_interface_b.mock.preflight.assert_not_called()
+
+                actual_success_cb = manager_interface_a.mock.preflight.call_args[0][5]
+                actual_error_cb = manager_interface_a.mock.preflight.call_args[0][6]
+
+            else:
+                # The second implementation has the capability.
+                manager_interface_a.mock.preflight.assert_not_called()
+                manager_interface_b.mock.preflight.assert_called_once_with(
+                    entity_references,
+                    traits_hints,
+                    publishing_access,
+                    a_context,
+                    a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+
+                actual_success_cb = manager_interface_b.mock.preflight.call_args[0][5]
+                actual_error_cb = manager_interface_b.mock.preflight.call_args[0][6]
+
+            # Ensure the callbacks have been passed through. These will
+            # be converted to an intermediate representation by
+            # pybind11, so we cannot do a naive comparison.
+
+            expected_success_cb_args = (123, EntityReference("foo"))
+            expected_error_cb_args = (
+                123,
+                errors.BatchElementError(
+                    errors.BatchElementError.ErrorCode.kEntityAccessError, "z"
+                ),
+            )
+            actual_success_cb(*expected_success_cb_args)
+            actual_error_cb(*expected_error_cb_args)
+            expected_success_cb.assert_called_once_with(*expected_success_cb_args)
+            expected_error_cb.assert_called_once_with(
+                *expected_error_cb_args,
+            )
+
+    @pytest.mark.parametrize(
+        "hasCapability_a,hasCapability_b", itertools.product((True, False), repeat=2)
+    )
+    def test_register(
+        self,
+        manager_interface_a,
+        manager_interface_b,
+        hybrid_manager_interface,
+        hasCapability_a,
+        hasCapability_b,
+        a_context,
+        a_host_session,
+    ):
+        expected_capability = ManagerInterface.Capability.kPublishing
+        entity_references = [EntityReference("x")]
+        entity_traits_datas = [TraitsData({"h"})]
+        publishing_access = access.PublishingAccess.kWrite
+        expected_success_cb = mock.Mock()
+        expected_error_cb = mock.Mock()
+
+        manager_interface_a.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_a
+        )
+        manager_interface_b.mock.hasCapability.side_effect = (
+            lambda cap: cap == expected_capability and hasCapability_b
+        )
+
+        hybrid_manager_interface.initialize({}, a_host_session)
+
+        if not hasCapability_a and not hasCapability_b:
+            # Neither implementation has the capability, so we should
+            # get an exception.
+            with pytest.raises(errors.NotImplementedException):
+                hybrid_manager_interface.register(
+                    entity_references,
+                    entity_traits_datas,
+                    publishing_access,
+                    a_context,
+                    a_host_session,
+                    expected_success_cb,
+                    expected_error_cb,
+                )
+        else:
+            # At least one implementation has the capability.
+            hybrid_manager_interface.register(
+                entity_references,
+                entity_traits_datas,
+                publishing_access,
+                a_context,
+                a_host_session,
+                expected_success_cb,
+                expected_error_cb,
+            )
+
+            if hasCapability_a:
+                # The first implementation has the capability.
+                manager_interface_a.mock.register.assert_called_once_with(
+                    entity_references,
+                    entity_traits_datas,
+                    publishing_access,
+                    a_context,
+                    a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+                manager_interface_b.mock.register.assert_not_called()
+
+                actual_success_cb = manager_interface_a.mock.register.call_args[0][5]
+                actual_error_cb = manager_interface_a.mock.register.call_args[0][6]
+
+            else:
+                # The second implementation has the capability.
+                manager_interface_a.mock.register.assert_not_called()
+                manager_interface_b.mock.register.assert_called_once_with(
+                    entity_references,
+                    entity_traits_datas,
+                    publishing_access,
+                    a_context,
+                    a_host_session,
+                    mock.ANY,
+                    mock.ANY,
+                )
+
+                actual_success_cb = manager_interface_b.mock.register.call_args[0][5]
+                actual_error_cb = manager_interface_b.mock.register.call_args[0][6]
+
+            # Ensure the callbacks have been passed through. These will
+            # be converted to an intermediate representation by
+            # pybind11, so we cannot do a naive comparison.
+
+            expected_success_cb_args = (123, EntityReference("foo"))
+            expected_error_cb_args = (
+                123,
+                errors.BatchElementError(
+                    errors.BatchElementError.ErrorCode.kEntityAccessError, "z"
+                ),
+            )
+            actual_success_cb(*expected_success_cb_args)
+            actual_error_cb(*expected_error_cb_args)
+            expected_success_cb.assert_called_once_with(*expected_success_cb_args)
+            expected_error_cb.assert_called_once_with(
+                *expected_error_cb_args,
+            )
+
+
+def test_all_manager_interface_methods_tested(subtests):
+    methods_to_test = (
+        name
+        for (name, obj) in inspect.getmembers(ManagerInterface)
+        if not name.startswith("_") and inspect.isroutine(obj)
+    )
+
+    test_methods = tuple(
+        name
+        for (name, obj) in inspect.getmembers(
+            Test_HybridPluginSystemManagerImplementationFactory_ManagerInterface
+        )
+        if not name.startswith("_") and inspect.isroutine(obj)
+    )
+
+    for method_to_test in methods_to_test:
+        with subtests.test(method_to_test=method_to_test):
+            assert any(
+                test_method == f"test_{method_to_test}"
+                or test_method.startswith(f"test_{method_to_test}_")
+                for test_method in test_methods
+            )
+
+
+@pytest.fixture
+def a_context():
+    return Context(TraitsData({"y"}))
+
+
+@pytest.fixture
+def an_entity_reference_pager():
+    class Pager(EntityReferencePagerInterface):
+        pass
+
+    return Pager()
+
+
+@pytest.fixture
+def a_manager_state():
+    class ManagerState(ManagerStateBase):
+        pass
+
+    return ManagerState()
+
+
+@pytest.fixture
+def hybrid_manager_interface(hybrid_factory, the_plugin_identifier):
+    return hybrid_factory.instantiate(the_plugin_identifier)
+
+
+@pytest.fixture
+def hybrid_factory(factory_a, factory_b, mock_logger):
+    return HybridPluginSystemManagerImplementationFactory([factory_a, factory_b], mock_logger)
+
+
+@pytest.fixture
+def factory_a(manager_interface_a, mock_logger, the_plugin_identifier):
+    factory = MockManagerImplementationFactory(mock_logger)
+    factory.mock.identifiers.return_value = [the_plugin_identifier]
+    factory.mock.instantiate.return_value = manager_interface_a
+    return factory
+
+
+@pytest.fixture
+def factory_b(manager_interface_b, mock_logger, the_plugin_identifier):
+    factory = MockManagerImplementationFactory(mock_logger)
+    factory.mock.identifiers.return_value = [the_plugin_identifier]
+    factory.mock.instantiate.return_value = manager_interface_b
+    return factory
+
+
+@pytest.fixture
+def manager_interface_a(create_mock_manager_interface):
+    return create_mock_manager_interface()
+
+
+@pytest.fixture
+def manager_interface_b(create_mock_manager_interface):
+    return create_mock_manager_interface()
+
+
+@pytest.fixture
+def the_plugin_identifier():
+    return "org.openassetio.test.plugin"
+
+
+class MockManagerImplementationFactory(ManagerImplementationFactoryInterface):
+    """
+    `ManagerImplementationFactoryInterface` that forwards calls to an
+    internal mock.
+    """
+
+    def __init__(self, logger):
+        ManagerImplementationFactoryInterface.__init__(self, logger)
+        self.mock = mock.create_autospec(
+            ManagerImplementationFactoryInterface, spec_set=True, instance=True
+        )
+
+    def identifiers(self):
+        return self.mock.identifiers()
+
+    def instantiate(self, identifier):
+        return self.mock.instantiate(identifier)


### PR DESCRIPTION
## Description

Closes #1202.

OpenAssetIO currently supports two different manager plugin backends in the core library, Python and C++. We expect more backends to be added in the future. For example, there has been active investigation into a gRPC backend.

By "backend" we specifically mean an implementation of the abstract base class `ManagerImplementationFactoryInterface`. The host application chooses an implementation, then injects it into a `ManagerFactory`, which is then responsible for producing `Manager` instances that the host application can use.

The idea of a hybrid plugin system is to allow multiple backend plugin providers to be composed, such that API calls can be routed to the most appropriate plugin. For example, performance-critical API requests could route to a C++ plugin, whilst less critical requests route to a Python plugin.

As an added bonus, having a built-in facility to compose multiple backends reduces boilerplate for hosts that wish to support multiple plugin system backends.

So add a `HybridPluginSystemManagerImplementationFactory`, which implements the `ManagerImplementationFactoryInterface` interface, and takes a list of child `ManagerImplementationFactoryInterface` implementations during construction. The host application can then provide an instance of a hybrid factory to their `ManagerFactory`, taking care of the boilerplate of managing multiple plugin systems.

When a host application attempts to load a plugin with a particular unique identifier, then all child plugin systems are searched. If a match is found in a single plugin system, then its manager implementation is returned directly. If a match is found in multiple plugin systems, then a proxy manager is constructed that routes calls to the appropriate manager implementation.

The "appropriate" manager implementation to route to varies. In most cases, the highest priority implementation that advertises the capability associated with the API call is chosen (i.e. it is routed based on the response of the manager(s) to `hasCapability(...)`).

The priority order of implementations corresponds to the order of the child factories in the list that was provided to the hybrid factory on construction.

Some API methods don't have an associated capability. For these, routing is "common sense":

For `initialize`, all implementations are provided with all the settings. For example, if using a `.toml` OpenAssetIO config file (see `OPENASSETIO_DEFAULT_CONFIG`), then the settings in that file will be provided to _all_ the matching manager implementations. This could cause problems if two plugins use the same settings key but require different values. Future work may look at ways to disambiguate.

For `identifier` and `displayName` the highest priority manager implementation is chosen.

For `info` and `settings`, the results of all manager implementations are merged, with the highest priority manager taking precedence if any dictionary keys conflict.

For `flushCaches` all manager implementations are flushed.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.

## Reviewer Notes

See Jupyter Notebook for illustration in https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation/pull/99
