### PR TITLE
Fix CTest for multi-config generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ include(ThirdParty)
 add_custom_target(
     openassetio.internal.install
     COMMAND "${CMAKE_COMMAND}" --build "${PROJECT_BINARY_DIR}"
-    --target install --parallel
+    --target install --parallel --config $<CONFIG>
 )
 
 

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -63,6 +63,7 @@ function(openassetio_add_generic_test_target target_name)
     add_test(
         NAME ${target_name}
         COMMAND ${CMAKE_COMMAND} --build "${PROJECT_BINARY_DIR}" --target ${target_name} --parallel
+        --config $<CONFIG>
     )
 endfunction()
 


### PR DESCRIPTION
## Description

Discovered whilst debugging #1340. When using a multi-config CMake generator (e.g. Visual Studio), running `ctest` would fail because the active configuration (Release, Debug, etc) wasn't propagated to the CMake subprocesses responsible for building/installing/running. The symptom, on Windows, was errors trying to link Release artifacts to Debug artifacts causing MSVCRT mismatches.

So fix the custom CMake subprocess targets so that the active configuration is propagated.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~
