### PR TITLE
Update deprecated hook in scan_entry_points docstring

### DIFF
--- a/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystem.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystem.py
@@ -56,7 +56,8 @@ class PythonPluginSystem(object):
     def scan(self, paths):
         """
         Searches the supplied paths for modules that define a
-        PythonPluginSystemPlugin through a top-level `openassetioPlugin` variable.
+        PythonPluginSystemPlugin through a top-level `openassetioPlugin`
+        variable.
 
         Paths are searched left-to-right, but only the first instance of
         any given plugin identifier will be used, and subsequent
@@ -105,7 +106,8 @@ class PythonPluginSystem(object):
     def scan_entry_points(self, entryPointName):
         """
         Searches packages for entry points that define a
-        PythonPluginSystemPlugin through a top-level `plugin` variable.
+        PythonPluginSystemPlugin through a top-level `openassetioPlugin`
+        variable.
 
         @note The order of discovery is determined by `importlib`, only
         the first plugin with any given identifier will be registered.


### PR DESCRIPTION
## Description

In #1115 we changed from `plugin` to `openassetioPlugin` for the hook that Python plugins must define, to better match the C++ plugin system, and head off any potential ambiguities.

However, we missed a docstring, which was still referring to the deprecated `plugin`. So update it.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~
