### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -34,7 +34,7 @@ jobs:
           # These are the platform build strings provided to
           # cibuildwheel, with wildcarding. See
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-        python-build: ['cp37*64', 'cp39*64', 'cp310*64', 'cp311*64']
+        python-build: ['cp39*64', 'cp310*64', 'cp311*64']
     defaults:
       run:
         # Annoyingly required here since `matrix` isn't available in the

--- a/README.md
+++ b/README.md
@@ -156,8 +156,7 @@ which appears to overlap with a subset of `OpenAssetIO`s concerns.
 
 ### System requirements
 
-OpenAssetIO aligns itself with [VFX Reference Platform CY2022](https://vfxplatform.com/)
-with additional support for python 3.7.
+OpenAssetIO aligns itself with [VFX Reference Platform CY2022](https://vfxplatform.com/).
 
 Windows, macOS, and Linux are all supported platforms.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,12 @@ Release Notes
 v1.0.0-beta.x.x
 ---------------
 
+### Breaking changes
+
+- Removed official support for Python 3.7. The minimum supported Python
+  version is now Python 3.9.
+  [#1365](https://github.com/OpenAssetIO/OpenAssetIO/pull/1365)
+
 ### New Features
 
 - Added SimpleCppManager - a minimal C++ manager and plugin example

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -34,7 +34,7 @@ following packages are installed:
 Binary builds additionally require the following packages to be
 available.
 
-- [Python 3.7+](https://www.python.org/) (development install)
+- [Python 3.9+](https://www.python.org/) (development install)
 - [pybind11](https://pybind11.readthedocs.io/en/stable/) 2.8.1+
 - [toml++](https://marzer.github.io/tomlplusplus/) 3.2.0+
 - [fmt](https://github.com/fmtlib/fmt) 9.1.0
@@ -55,11 +55,6 @@ must be discoverable by CMake's [`find_package`](https://cmake.org/cmake/help/la
 During development, we tend use [ConanCenter](https://conan.io/center/)
 to fulfill the [`find_package`](https://cmake.org/cmake/help/latest/command/find_package.html) requirement.
 See [Building](#building) for more information.
-
-> **Warning**
->
-> If attempting to build on CentOS 7 using the ConanCenter
-> Python 3.7 package you will likely hit an [issue installing pkgconf](https://github.com/conan-io/conan-center-index/issues/8541).
 
 > **Warning**
 >

--- a/doc/contributing/CODING_STANDARDS.md
+++ b/doc/contributing/CODING_STANDARDS.md
@@ -54,7 +54,8 @@ disambiguating fixtures from tests.
 
 ### Python
 
-Python code should be written using only features included in Python 3.7.
+Python code should be written using only features included in Python
+3.9.
 
 Where feasible, Python unit test cases should use a class for each unit,
 where the methods of the test class are the test cases for that unit. In

--- a/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystem.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystem.py
@@ -117,9 +117,8 @@ class PythonPluginSystem(object):
         there was a problem loading importlib_metadata.
         """
 
-        # We opt to use the backport implementation of modern importlib to avoid
-        # needing to support 3+ code paths to cover Python 3.7 to 3.10. It is
-        # made available for 3.7 onwards (for now, at least).
+        # We opt to use the backport implementation of modern importlib
+        # since the API changes from 3.9 to 3.10.
         # Pip installs should have this module available, but other methods may not,
         # so be tolerant of it being missing.
         try:

--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -4,8 +4,6 @@
 [build-system]
 requires = [
     "setuptools>=65.5.0",
-    # CMake 3.29 PyPI package requires importlib_metadata, which is not
-    # available in a fresh Python 3.7 environment.
     "cmake==3.28.3",
     "ninja>=1.10.2.4",
     # For generating .pyi stub files.
@@ -16,7 +14,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "openassetio"
 version = "1.0.0b2.rev2"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
     "importlib_metadata >= 3.6"
 ]
@@ -39,7 +37,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/src/openassetio-python/tests/package/pluginSystem/resources/broken/src/missing_plugin/pyproject.toml
+++ b/src/openassetio-python/tests/package/pluginSystem/resources/broken/src/missing_plugin/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "missing-plugin"
 version = "0.0.0"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 
 description = """\
     A test OpenAssetIO Manager plugin that is missing the top-level

--- a/src/openassetio-python/tests/package/pluginSystem/resources/broken/src/raises_exception/pyproject.toml
+++ b/src/openassetio-python/tests/package/pluginSystem/resources/broken/src/raises_exception/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "raises-exception"
 version = "0.0.0"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 
 description = """\
     A test OpenAssetIO Manager plugin that raises an exception during inmport.

--- a/src/openassetio-python/tests/package/pluginSystem/resources/entryPoint/src/pyproject.toml
+++ b/src/openassetio-python/tests/package/pluginSystem/resources/entryPoint/src/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "packaged-plugin"
 version = "0.0.0"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 
 description = """\
     A test OpenAssetIO Manager plugin that can be pip installed and \

--- a/src/openassetio-python/tests/package/test/manager/test_main.py
+++ b/src/openassetio-python/tests/package/test/manager/test_main.py
@@ -105,8 +105,6 @@ def execute_cli(fixtures_path, *extra_args):
     # correctly configured with the appropriate dependencies, so we
     # attempt to use the same executable as the tests.
 
-    # Str wrapping prevents issues with Path objects in Windows
-    # Python 3.7
     all_args = [sys.executable, "-m", "openassetio.test.manager"]
     if fixtures_path:
         all_args.extend(["-f", str(fixtures_path)])


### PR DESCRIPTION
## Description

Part of #1340, but it's been coming for a while.

The trigger for finally doing this is the need for `os.add_dll_directory` support.

So removed Python 3.7 PyPI distributions, and all mention of it from the codebase.

The new minimum supported Python version is now 3.9. The older versions may continue to work for a time, but this is no longer guaranteed nor supported.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.
