### PR TITLE
Allow API compliance if `initialize`d with unknown settings

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,12 @@ v1.0.0-beta.x.x
   version is now Python 3.9.
   [#1365](https://github.com/OpenAssetIO/OpenAssetIO/pull/1365)
 
+- Updated the API contract to no longer require that managers throw an
+  exception when an unrecognized setting is given during initialization.
+  The `openassetio.test.manager` API Compliance test suite no longer
+  asserts that this is the case.
+  [#1202](https://github.com/OpenAssetIO/OpenAssetIO/issues/1202)
+
 ### New Features
 
 - Added SimpleCppManager - a minimal C++ manager and plugin example

--- a/src/openassetio-python/package/openassetio/test/manager/apiComplianceSuite.py
+++ b/src/openassetio-python/package/openassetio/test/manager/apiComplianceSuite.py
@@ -143,27 +143,6 @@ class Test_initialize(FixtureAugmentedTestCase):
 
         self.assertEqual(self._manager.settings(), expected)
 
-    def test_when_settings_have_invalid_keys_then_raises_KeyError(self):
-        invalid_settings = self.requireFixture(
-            "some_settings_with_new_values_and_invalid_keys", skipTestIfMissing=True
-        )
-
-        with self.assertRaises(KeyError):
-            self._manager.initialize(invalid_settings)
-
-    def test_when_settings_have_invalid_keys_then_all_settings_unchanged(self):
-        expected = self._manager.settings()
-        invalid_settings = self.requireFixture(
-            "some_settings_with_new_values_and_invalid_keys", skipTestIfMissing=True
-        )
-
-        try:
-            self._manager.initialize(invalid_settings)
-        except Exception:  # pylint: disable=broad-except
-            pass
-
-        self.assertEqual(self._manager.settings(), expected)
-
     def test_when_settings_have_all_keys_then_all_settings_updated(self):
         updated = self.requireFixture("some_settings_with_all_keys", skipTestIfMissing=True)
 


### PR DESCRIPTION
## Description

Part of #1202. The upcoming hybrid plugin system will allow multiple manager plugins that advertise the same unique ID to be initialised together and composed.

If the settings passed to the constituent manager plugins must be tailored for each one, then significant extra work must be done to design and implement a way to disambiguate and split up the settings.

A much simpler solution is to allow an arbitrary settings dict to be passed to a manager, and they can select which settings they are interested in. This way we can provide a single settings dictionary (as provided, for example, by the OpenAssetIO `.toml` config file mechanism), and distribute that single dict to all child plugins of a hybrid plugin.

The disadvantage is if two plugins require the same key to map to a different value. Future work can be scheduled to tackle this case, if it's a problem.

So update the `openassetio.test.manager` API Compliance test suite, used by manager authors to validate their plugin, to no longer assert that unrecognized settings trigger an exception. As an aside, the exception that was expected was a `KeyError`, which already made little sense for C++.

- [x] I have updated the release notes.
- [ ] ~~I have updated all relevant user documentation.~~

