### PR TITLE
Use `std::set` for trait sets

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,8 +4,10 @@ Release Notes
 v1.0.0-beta.x.x
 ---------------
 
-_This release might not be source compatible for Python hosts. See
-breaking changes, below._
+_This release breaks binary compatibility and may break source
+compatibility with C++ hosts and managers. In addition, this release may
+break source compatibility for Python hosts. See breaking changes
+section for more details._
 
 ### Breaking changes
 
@@ -23,6 +25,14 @@ breaking changes, below._
   The `openassetio.test.manager` API Compliance test suite no longer
   asserts that this is the case.
   [#1202](https://github.com/OpenAssetIO/OpenAssetIO/issues/1202)
+
+- Switched from `std::unordered_set` to `std::set` for trait sets (via
+  `TraitSet` alias) in C++. This allows C++ `std` algorithm set
+  operations to work. Python is unaffected. This is mostly a
+  source-compatible change, provided the `TraitSet` alias is used in
+  consuming code, and no `unordered_set`-specific API is used (e.g.
+  `reserve(...)`).
+  [#1339](https://github.com/OpenAssetIO/OpenAssetIO/issues/1339)
 
 ### New Features
 

--- a/doc/contributing/CODING_STANDARDS.md
+++ b/doc/contributing/CODING_STANDARDS.md
@@ -427,7 +427,7 @@ a C++ function call and those mutations persist to the next invocation.
 However, some C++ types are converted to/from native Python types,
 including primitives such as `int` and `float`, but also (by default)
 `std::string` and container types like `std::vector` (converted to
-Python `list`) and `std::unordered_set` (converted to Python `set`).
+Python `list`) and `std::set` (converted to Python `set`).
 
 In these cases, the initial conversion of the C++ default value to a
 Python object (to be stored in the function record) necessitates a copy.

--- a/src/openassetio-core/include/openassetio/trait/collection.hpp
+++ b/src/openassetio-core/include/openassetio/trait/collection.hpp
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <unordered_set>
+#include <set>
 #include <vector>
 
 #include <openassetio/export.h>
@@ -24,7 +24,7 @@ namespace trait {
  * no single ID can appear more than once and the order of the IDs
  * has no meaning and is not preserved.
  */
-using TraitSet = std::unordered_set<TraitId>;
+using TraitSet = std::set<TraitId>;
 
 /**
  * An ordered list of trait sets.

--- a/src/openassetio-core/src/trait/TraitsData.cpp
+++ b/src/openassetio-core/src/trait/TraitsData.cpp
@@ -22,7 +22,6 @@ class TraitsData::Impl {
 
   [[nodiscard]] trait::TraitSet traitSet() const {
     trait::TraitSet ids;
-    ids.reserve(data_.size());
     for (const auto& item : data_) {
       ids.insert(item.first);
     }


### PR DESCRIPTION
## Description

Closes #1339.

C++ has set operation algorithms. However, these only work for sorted containers. `std::unordered_set` is not a sorted container, and so (ironically) cannot use set operations.

Most of our prototyping has been done in Python, where set operations are a part of the core language, and we have used them extensively to compare and combine trait sets.

The main benefit of `unordered_set` is the better average-case time complexity. However, for small sets the difference in performance between `std::set` and `std::unordered_set` is negligible (and may even favour `std::set`). In practice, we haven't seen any large 100k+ trait sets in the wild, which is where we'd expect the performance difference to show up (see links in GitHub issue for details).

Clearly this is a breaking change. However, we do at least use a `TraitSet` alias everywhere, so as long as no downstream project is using `std::unordered_set` directly, or non-generic APIs, then source compatibility will be maintained.

We use the default pybind11 bindings for trait sets, which means the set is duplicated as a Python native set. So the Python core library (and hence downstream Python projects) are unaffected.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.
