### PR TITLE
Add kAuthError error code

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -47,6 +47,10 @@ section for more details._
   `openassetio.dll`, if required.
   [#1340](https://github.com/OpenAssetIO/OpenAssetIO/issues/1340)
 
+- Added `kAuthError` to the set of possible `BatchElementError` error
+  codes.
+  [#1009](https://github.com/OpenAssetIO/OpenAssetIO/issues/1009)
+
 ### Improvements
 
 - Added singular overload of `managementPolicy` for convenience.

--- a/src/openassetio-core/include/openassetio/errors/BatchElementError.hpp
+++ b/src/openassetio-core/include/openassetio/errors/BatchElementError.hpp
@@ -126,6 +126,20 @@ class BatchElementError final {
      * the manager.
      */
     kInvalidTraitSet = OPENASSETIO_BatchErrorCode_kInvalidTraitSet,
+
+    /**
+     * Error code indicating that the host is not authorized for a
+     * pariticular request.
+     *
+     * The operation may be valid if attempted again, once the
+     * authorization issue is resolved.
+     *
+     * This can be due to insufficient or incomplete authentication as
+     * well as authorization, and could be specific to a particular
+     * action, or a particular entity. The error message should provide
+     * details of the reason.
+     */
+    kAuthError = OPENASSETIO_BatchErrorCode_kAuthError,
   };
 
   /**

--- a/src/openassetio-core/include/openassetio/errors/errorCodes.h
+++ b/src/openassetio-core/include/openassetio/errors/errorCodes.h
@@ -47,3 +47,6 @@
 
 /// Failure due to a TraitSet being unknown to the manager
 #define OPENASSETIO_BatchErrorCode_kInvalidTraitSet (OPENASSETIO_BatchErrorCode_BEGIN + 6)
+
+/// Failure due to a authentication or authorization.
+#define OPENASSETIO_BatchErrorCode_kAuthError (OPENASSETIO_BatchErrorCode_BEGIN + 7)

--- a/src/openassetio-core/src/errors/exceptionMessages.cpp
+++ b/src/openassetio-core/src/errors/exceptionMessages.cpp
@@ -27,6 +27,8 @@ Str errorCodeName(BatchElementError::ErrorCode code) {
       return "invalidPreflightHint";
     case BatchElementError::ErrorCode::kInvalidTraitSet:
       return "invalidTraitSet";
+    case BatchElementError::ErrorCode::kAuthError:
+      return "authError";
   }
 
   assert(false);  // Impossible case.

--- a/src/openassetio-python/cmodule/src/errors/BatchElementErrorBinding.cpp
+++ b/src/openassetio-python/cmodule/src/errors/BatchElementErrorBinding.cpp
@@ -25,7 +25,8 @@ void registerBatchElementError(const py::module& mod) {
       .value("kEntityAccessError", BatchElementError::ErrorCode::kEntityAccessError)
       .value("kEntityResolutionError", BatchElementError::ErrorCode::kEntityResolutionError)
       .value("kInvalidPreflightHint", BatchElementError::ErrorCode::kInvalidPreflightHint)
-      .value("kInvalidTraitSet", BatchElementError::ErrorCode::kInvalidTraitSet);
+      .value("kInvalidTraitSet", BatchElementError::ErrorCode::kInvalidTraitSet)
+      .value("kAuthError", BatchElementError::ErrorCode::kAuthError);
 
   batchElementError
       .def(py::init<BatchElementError::ErrorCode, openassetio::Str>(), py::arg("code"),

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -88,6 +88,7 @@ class BatchFirstMethodTest:
         "entityResolutionError",
         "invalidPreflightHint",
         "invalidTraitSet",
+        "authError",
     ]
 
     def assert_callback_overload_wraps_the_corresponding_method_of_the_held_interface(

--- a/src/openassetio-python/tests/package/test_batchelementerror.py
+++ b/src/openassetio-python/tests/package/test_batchelementerror.py
@@ -36,6 +36,7 @@ class Test_BatchElementError_ErrorCode:
         assert int(BatchElementError.ErrorCode.kEntityResolutionError) == 132
         assert int(BatchElementError.ErrorCode.kInvalidPreflightHint) == 133
         assert int(BatchElementError.ErrorCode.kInvalidTraitSet) == 134
+        assert int(BatchElementError.ErrorCode.kAuthError) == 135
 
 
 class Test_BatchElementError_inheritance:
@@ -119,6 +120,7 @@ class Test_BatchElementException:
             BatchElementError.ErrorCode.kEntityResolutionError,
             BatchElementError.ErrorCode.kInvalidPreflightHint,
             BatchElementError.ErrorCode.kInvalidTraitSet,
+            BatchElementError.ErrorCode.kAuthError,
         ],
     )
     def test_when_thrown_then_correct_data_set(self, exception_code):


### PR DESCRIPTION
## Description

Closes #1009. 

Add a `kAuthError` error code to `BatchElementError`s so that manager's have a means to inform the user that they do not (currently) have access to an action or asset.

This then allows host applications to branch differently on authentication or authorization related errors, if they wish.

- [x] I have updated the release notes.
- [ ] ~~I have updated all relevant user documentation.~~
