### PR TITLE
Default libstdc++ ABI based on Python version

### DIFF
--- a/.github/bootstrap_platform/action.yml
+++ b/.github/bootstrap_platform/action.yml
@@ -14,8 +14,8 @@ runs:
   - name: Set up Python
     uses: actions/setup-python@v4
     with:
-      # CY2022 (https://vfxplatform.com)
-      python-version: "3.9"
+      # CY2022 by default (https://vfxplatform.com)
+      python-version: ${{ matrix.python_version || '3.9' }}
 
   - name: Cache conan packages
     id: cache-conan

--- a/.github/bootstrap_platform/action.yml
+++ b/.github/bootstrap_platform/action.yml
@@ -15,7 +15,7 @@ runs:
     uses: actions/setup-python@v4
     with:
       # CY2022 by default (https://vfxplatform.com)
-      python-version: ${{ matrix.python_version || '3.9' }}
+      python-version: ${{ matrix.config.python_version || matrix.python_version || '3.9' }}
 
   - name: Cache conan packages
     id: cache-conan

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.config.os }} - ${{matrix.python-build}}
+    name: Build wheels on ${{ matrix.config.os }} for Python ${{matrix.python_version}}
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
@@ -31,14 +31,19 @@ jobs:
           - os: windows-2019
             preamble: call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64
             shell: cmd
-          # These are the platform build strings provided to
-          # cibuildwheel, with wildcarding. See
-          # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-        python-build: ['cp39*64', 'cp310*64', 'cp311*64']
+        # We matrix the python build here ourselves, rather than
+        # letting cibuildwheel do its regular python matrix, as we
+        # want to allow a full release pipeline to run "vertically" on
+        # CI, on individual agents, rather than building every python
+        # version sequentially on each platform. This is done less for
+        # performance reasons (although it does help) and more so a
+        # single failing python version won't interrupt every other
+        # deploy on that platform. It also helps by ensuring that the
+        # `bootstrap_platform` workflow uses the appropriate Python
+        # version.
+        python_version: ["3.9", "3.10", "3.11"]
     defaults:
       run:
-        # Annoyingly required here since `matrix` isn't available in the
-        # `shell` property of individual steps.
         shell: ${{ matrix.config.shell }}
 
     steps:
@@ -46,6 +51,14 @@ jobs:
 
       - name: Bootstrap
         uses: ./.github/bootstrap_platform
+
+      - name: Python version to CIBW version format
+        # These are the platform build strings provided to
+        # cibuildwheel, with wildcarding. E.g. "cp311*64". See
+        # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
+        run: >
+          echo CIBW_BUILD="cp"$(printf ${{ matrix.python_version }} | sed 's/\.//')"*64" >> $GITHUB_ENV
+        shell: bash
 
       - name: Build wheels
         run: |
@@ -58,17 +71,19 @@ jobs:
           # different, and are containerised fully, therefore they get
           # their toolchain path from pyproject.toml
           CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/.conan/conan_paths.cmake
-          # We matrix the python build here ourselves, rather than
-          # letting cibuildwheel do its regular python matrix, as we
-          # want to allow a full release pipeline to run "vertically" on
-          # CI, on individual agents, rather than building every python
-          # version sequentially on each platform. This is done less for
-          # performance reasons (although it does help) and more so a
-          # single failing python version won't interrupt every other
-          # deploy on that platform.
-          CIBW_BUILD: ${{ matrix.python-build }}
           CIBW_SKIP: '*musllinux* *arm64*'
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          # Python 3.9 implies VFX Reference Platform CY22, which
+          # specifies glibc 2.17 and the deprecated libstdc++ ABI, and
+          # is typically associated with CentOS 7. The manylinux2014
+          # container is CentOS 7 based so is a great fit in this case.
+          # However, for CY23+, i.e. Python 3.10+, glibc is 2.28
+          # and the non-deprecated libstdc++ ABI should be used. In this
+          # case, manylinux_2_28 must be used to support the
+          # non-deprecated libstdc++ ABI, i.e. so that compiler macro
+          # `-D_GLIBCXX_USE_CXX11_ABI=1` will work. See
+          # https://github.com/pypa/manylinux and
+          # https://vfxplatform.com
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.config.python_version == '3.9' && 'manylinux2014' || 'manylinux_2_28' }}
           PIP_VERBOSE: 1
           # Required as we make use of c++17 features
           MACOSX_DEPLOYMENT_TARGET: 10.15

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -199,7 +199,7 @@ jobs:
           OPENASSETIO_DLL_PATH: ${{ github.workspace }}/dist/bin
 
   cpp-manager-plugin:
-    name: C++ manager plugin on ${{ matrix.config.os }}
+    name: C++ manager plugin on ${{ matrix.config.os }} and Python ${{ matrix.config.python_version }}
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
@@ -208,12 +208,19 @@ jobs:
           - os: windows-2019
             preamble: call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64
             site-packages: Lib/site-packages
+            python_version: "3.9"
             shell: cmd
           - os: ubuntu-20.04
             site-packages: lib/python3.9/site-packages
+            python_version: "3.9"
+            shell: bash
+          - os: ubuntu-20.04
+            site-packages: lib/python3.10/site-packages
+            python_version: "3.10"  # CY23
             shell: bash
           - os: macos-12
             site-packages: lib/python3.9/site-packages
+            python_version: "3.9"
             shell: bash
     defaults:
       run:
@@ -250,7 +257,7 @@ jobs:
 
           cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
           -DOPENASSETIO_ENABLE_TESTS=ON
-          -DOPENASSETIO_GLIBCXX_USE_CXX11_ABI=OFF
+          -DOPENASSETIO_GLIBCXX_USE_CXX11_ABI=${{ matrix.config.python_version == '3.9' && 'OFF' || 'ON' }}
 
           cmake --build build --parallel --config RelWithDebInfo
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,12 @@ option(OPENASSETIO_ENABLE_POSITION_INDEPENDENT_CODE
 #   to `1`, but can be overridden.
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
     CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0)
+    if (NOT DEFINED OPENASSETIO_GLIBCXX_USE_CXX11_ABI)
+        # Set a flag so that subsequent CMake scripts know that this is
+        # the first time the option has been defined and so it is set to
+        # the default.
+        set(OPENASSETIO_GLIBCXX_USE_CXX11_ABI_IS_DEFAULT TRUE)
+    endif()
     option(OPENASSETIO_GLIBCXX_USE_CXX11_ABI "For gcc, use the new C++11 library ABI" OFF)
 endif ()
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -66,6 +66,13 @@ section for more details._
 
 ### Improvements
 
+- Updated the default libstdc++ ABI (i.e. CMake option
+  `OPENASSETIO_GLIBCXX_USE_CXX11_ABI`) to be based on the detected
+  Python version (if Python is enabled) such that it is consistent with
+  the VFX Reference Platform. This means Python wheels for Python 3.10+
+  will now use the non-deprecated ABI.
+  [#1352](https://github.com/OpenAssetIO/OpenAssetIO/issues/1352)
+
 - Added singular overload of `managementPolicy` for convenience.
   [#856](https://github.com/OpenAssetIO/OpenAssetIO/issues/856)
 

--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -106,6 +106,26 @@ if (OPENASSETIO_ENABLE_PYTHON)
 
 
     #-------------------------------------------------------------------
+    # On first CMake configure, update libstdc++ ABI option to best
+    # match the Python version (based on VFX Reference Platform).
+
+    if (OPENASSETIO_GLIBCXX_USE_CXX11_ABI_IS_DEFAULT)
+        if (Python_VERSION VERSION_GREATER_EQUAL "3.10")
+            set(
+                OPENASSETIO_GLIBCXX_USE_CXX11_ABI ON CACHE BOOL
+                "For gcc, use the new C++11 library ABI (default ON for >=CY23 Python version)"
+                FORCE
+            )
+        else ()
+            set(
+                OPENASSETIO_GLIBCXX_USE_CXX11_ABI OFF CACHE BOOL
+                "For gcc, use the new C++11 library ABI (default OFF for <CY23 Python version)"
+                FORCE
+            )
+        endif()
+    endif()
+
+    #-------------------------------------------------------------------
     # Target to create a Python virtual environment in the install tree.
 
     # Target to create a Python environment in the install directory.

--- a/resources/build/bootstrap-cibuildwheel-manylinux.sh
+++ b/resources/build/bootstrap-cibuildwheel-manylinux.sh
@@ -17,10 +17,10 @@ export CONAN_USER_HOME="$HOME/conan"
 # Create default conan profile so we can configure it before instlibXcomposite-develall.
 # Use --force so that if it already exists we don't error out.
 conan profile new default --detect --force
-# Use old C++11 ABI as per VFX Reference Platform CY2022. Not strictly
-# necessary as this is the default for conan, but we can't be certain
-# it'll remain the default in future.
-conan profile update settings.compiler.libcxx=libstdc++ default
+# Use appropriate libstdc++ ABI for the target VFX Reference Platform,
+# as detected by target Python version. The magic here is `sort -VC`.
+libstdcxxabi=$(printf "Python 3.10\n%s" "$(python --version)" | sort -VC && echo "libstdc++11" || echo "libstdc++")
+conan profile update settings.compiler.libcxx="${libstdcxxabi}" default
 # If we need to pin a package to a specific Conan recipe revision, then
 # we need to explicitly opt-in to this functionality.
 conan config set general.revisions_enabled=True

--- a/resources/build/bootstrap-ubuntu-20.04.sh
+++ b/resources/build/bootstrap-ubuntu-20.04.sh
@@ -14,10 +14,10 @@ export CONAN_USER_HOME="$HOME/conan"
 # Create default conan profile so we can configure it before install.
 # Use --force so that if it already exists we don't error out.
 conan profile new default --detect --force
-# Use old C++11 ABI as per VFX Reference Platform CY2022. Not strictly
-# necessary as this is the default for conan, but we can't be certain
-# it'll remain the default in future.
-conan profile update settings.compiler.libcxx=libstdc++ default
+# Use appropriate libstdc++ ABI for the target VFX Reference Platform,
+# as detected by target Python version. The magic here is `sort -VC`.
+libstdcxxabi=$(printf "Python 3.10\n%s" "$(python --version)" | sort -VC && echo "libstdc++11" || echo "libstdc++")
+conan profile update settings.compiler.libcxx="${libstdcxxabi}" default
 # If we need to pin a package to a specific Conan recipe revision, then
 # we need to explicitly opt-in to this functionality.
 conan config set general.revisions_enabled=True

--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -144,5 +144,5 @@ environment-pass = ["PIP_VERBOSE", "OPENASSETIO_TEST_ENABLE_PYTHON_STUBGEN"]
 
 [tool.cibuildwheel.linux]
 # Linux runs in a docker container, with the project at top level
-before-build = "resources/build/bootstrap-cibuildwheel-manylinux-2014.sh"
+before-build = "resources/build/bootstrap-cibuildwheel-manylinux.sh"
 environment = { CMAKE_TOOLCHAIN_FILE=".conan/conan_paths.cmake" }


### PR DESCRIPTION
## Description

Closes #1352. When we detect that we're likely building using GCC for VFX Reference Platform CY23 or above, we should use the libstdc++ C++11 ABI by default, otherwise we use the deprecated ABI.

- [x] I have updated the release notes.
- [ ] ~~I have updated all relevant user documentation.~~

## Reviewer notes

This is part of a broader epic https://github.com/OpenAssetIO/OpenAssetIO/issues/1351 and subsequent tasks in that epic may mean this solution needs to be refactored, in particular https://github.com/OpenAssetIO/OpenAssetIO/issues/1353