### PR TITLE
Re-enable integration tests on Ubuntu 

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -112,11 +112,8 @@ jobs:
         config:
         - os: windows-2022
           site-packages: Lib/site-packages
-        # TODO(DF): Disabled pending upstream changes to use system
-        # default libstdc++ - i.e. dropping CY22 support in favour of
-        # CY24.
-#        - os: ubuntu-22.04
-#          site-packages: lib/python3.11/site-packages
+        - os: ubuntu-22.04
+          site-packages: lib/python3.11/site-packages
         - os: macos-12
           site-packages: lib/python3.11/site-packages
     defaults:


### PR DESCRIPTION
## Description

Re-enable integration tests on Ubuntu now that downstream repos have been updated to work with the changes from https://github.com/OpenAssetIO/OpenAssetIO/pull/1391.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~
