### PR TITLE
[Release] Bump version to v1.0.0-rc.1.0 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,12 @@
 Release Notes
 =============
 
-v1.0.0-beta.x.x
+v1.0.0-rc.x.x
 ---------------
 
-_This release breaks binary compatibility and may break source
-compatibility with C++ hosts and managers. In addition, this release may
-break source compatibility for Python hosts. See breaking changes
-section for more details._
+_This release breaks binary compatibility with C++ hosts and managers.
+It may break source compatibility for hosts and managers in both C++ and
+Python. See breaking changes section for more details._
 
 ### Breaking changes
 
@@ -52,6 +51,9 @@ section for more details._
   will use the system default libstdc++ ABI, rather than defaulting to
   the old ABI.
   [#1353](https://github.com/OpenAssetIO/OpenAssetIO/issues/1353)
+
+- Removed support for querying the "beta" version number of the library.
+  [#1401](https://github.com/OpenAssetIO/OpenAssetIO/issues/1401)
 
 ### New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-v1.0.0-rc.x.x
+v1.0.0-rc.1.0
 ---------------
 
 _This release breaks binary compatibility with C++ hosts and managers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-The OpenAssetIO project is working towards an initial beta release of
+The OpenAssetIO project is working towards an initial v1.0.0 release of
 the core API.
 
 We are looking for early adopters who can help fine tune its final form,
@@ -46,8 +46,8 @@ Managers.
 - [ ] Trait/Specification versioning support
 - [ ] Debug trace logging support.
 - [x] Entity introspection API methods.
-- [ ] C++ Plugin System
-- [ ] Hybrid C++/Python manager bridge.
+- [x] C++ Plugin System
+- [x] Hybrid C++/Python manager bridge.
 
 ## Y24 onwards
 - Read-through cache mix-ins.

--- a/cmake/templates/include/openassetio/version.hpp.in
+++ b/cmake/templates/include/openassetio/version.hpp.in
@@ -11,20 +11,7 @@
 #define OPENASSETIO_VERSION_MAJOR @OpenAssetIO_VERSION_MAJOR@
 #define OPENASSETIO_VERSION_MINOR @OpenAssetIO_VERSION_MINOR@
 #define OPENASSETIO_VERSION_PATCH @OpenAssetIO_VERSION_PATCH@
-// clang-format on
-
-// For the time being, beta versions must be manually updated prior to
-// the release
-#define OPENASSETIO_BETA_VERSION_MAJOR 2
-#define OPENASSETIO_BETA_VERSION_MINOR 2
-
-#define OPENASSETIO_STRINGIFY(x) #x
-#define OPENASSETIO_MACRO_TO_STRING(x) OPENASSETIO_STRINGIFY(x)
-
-// clang-format off
-#define OPENASSETIO_VERSION_STRING                                                             \
-  "v@OpenAssetIO_VERSION@-beta." OPENASSETIO_MACRO_TO_STRING(OPENASSETIO_BETA_VERSION_MAJOR)\
-  "." OPENASSETIO_MACRO_TO_STRING(OPENASSETIO_BETA_VERSION_MINOR)
+#define OPENASSETIO_VERSION_STRING "v@OpenAssetIO_VERSION@-rc.1.0"
 // clang-format on
 
 namespace openassetio {
@@ -41,29 +28,13 @@ constexpr std::size_t minorVersion() { return OPENASSETIO_VERSION_MINOR; }
  * The patch version of the OpenAssetIO library.
  */
 constexpr std::size_t patchVersion() { return OPENASSETIO_VERSION_PATCH; }
-
-/**
- * The beta major version of the OpenAssetIO library.
- *
- * Whilst OpenAssetIO is in beta, its main versioning remains at 1.0.0,
- * and the beta versions are incremented.
- * When OpenAssetIO leaves beta, this value will return 0.
- */
-constexpr std::size_t betaMajorVersion() { return OPENASSETIO_BETA_VERSION_MAJOR; }
-/**
- * The beta minor version of the OpenAssetIO library.
- *
- * Whilst OpenAssetIO is in beta, its main versioning remains at 1.0.0,
- * and the beta versions are incremented.
- * When OpenAssetIO leaves beta, this value will return 0.
- */
-constexpr std::size_t betaMinorVersion() { return OPENASSETIO_BETA_VERSION_MINOR; }
-
 /**
  * A string containing the OpenAssetIO version string.
  *
- * The format is {MAJOR}.{MINOR}.{PATCH}-beta{BETAMAJOR}.{BETAMINOR}.
- * When OpenAssetIO leaves beta, the beta section will be removed.
+ * The format is {MAJOR}.{MINOR}.{PATCH}-rc.{RCMAJOR}.{RCMINOR}
+ *
+ * When OpenAssetIO is out of pre-release, the "rc" section will be
+ * removed.
  */
 constexpr std::string_view versionString() { return OPENASSETIO_VERSION_STRING; }
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/doc/contributing/PROCESS.md
+++ b/doc/contributing/PROCESS.md
@@ -133,11 +133,12 @@ To make a new OpenAssetIO release, follow this procedure.
   - [pyproject.toml](../../src/openassetio-python/pyproject.toml)
     (under `[project]` section).
   - [version.hpp.in](../../cmake/templates/include/openassetio/version.hpp.in)
-    (for beta releases only, at the top).
+    (for changes to/from pre-releases only, at the top).
   - [test_version.py](../../src/openassetio-python/tests/package/test_version.py)
     (at the top).
-  - [CMakeLists.txt](../../CMakeLists.txt) (an argument to `project()`,
-    no need to update for an alpha or beta increment).
+  - [CMakeLists.txt](../../CMakeLists.txt) 
+    (an argument to `project()`, no need to update for a pre-release
+    increment).
 - If there is an ABI change (major release), update
   `set(_core_abi_version X)` in
   [`src/openassetio-core/CMakeLists.txt`](../../src/openassetio-core/CMakeLists.txt)

--- a/doc/contributing/PROCESS.md
+++ b/doc/contributing/PROCESS.md
@@ -44,7 +44,7 @@ We have a few golden rules for commits to release branches:
 
 - All code should follow the project coding standards.
 - `main` and maintenance branches should always be functional, once we
-  pass alpha and beta, they must always be release ready.
+  pass pre-release, they must always be release ready.
 - Commits should form meaningful atomic units of change. The build
   should never be (intentionally) broken between commits merged to
   release branches.
@@ -176,8 +176,8 @@ To make a new OpenAssetIO release, follow this procedure.
     - Remove line wrapping from the release notes, each note
       should becomes a single line.
       (vim users: `set tw=9999`, `gg<S-V><S-G>gq`)
-  - If this is an alpha or beta release, ensure `Set as a pre-release`
-    checkbox is checked.
+  - If this is a pre-release, ensure `Set as a pre-release` checkbox is
+    checked.
   - Click "Publish Release"
 - In response to a release being published, two things happen.
   - The [Deploy PyPI](https://github.com/OpenAssetIO/OpenAssetIO/actions/workflows/deploy-pypi.yml)

--- a/doc/contributing/PULL_REQUESTS.md
+++ b/doc/contributing/PULL_REQUESTS.md
@@ -3,8 +3,8 @@
 PRs should aim to be small, containing a single meaningful change to
 the project. For all merges, the target branch should be functional
 after merge.
-- For feature branches, or during alpha development, the target should
-  be functional, but not necessarily feature-complete.
+- For feature branches the target should be functional, but not
+  necessarily feature-complete.
 - For release branches the target should always be in a release-ready
   state before, and after any PR is merged.
 

--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "OpenAssetIO [beta]"
+PROJECT_NAME           = "OpenAssetIO"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/doc/doxygen/src/MainPage.dox
+++ b/doc/doxygen/src/MainPage.dox
@@ -18,11 +18,6 @@
      href="https://github.com/OpenAssetIO/OpenAssetIO/">OpenAssetIO
      codebase</a>
  *
- * @warning The API has a long history. The OpenAssetIO release version is
- * currently in a beta stage and is subject to some refinements over the
- * coming months. See the <a href="https://github.com/orgs/OpenAssetIO/projects/1"
- * target="_blank">project tracker</a> for more details.
- *
  * OpenAssetIO defines a common set of interactions between a @ref host
  * of the API (eg: a Digital Content Creation tool or pipeline script)
  * and an @ref asset_management_system.

--- a/src/openassetio-core/tests/versionTest.cpp
+++ b/src/openassetio-core/tests/versionTest.cpp
@@ -8,7 +8,5 @@ SCENARIO("OpenassetIO exposes version information") {
   CHECK(openassetio::majorVersion() == OPENASSETIO_VERSION_MAJOR);
   CHECK(openassetio::minorVersion() == OPENASSETIO_VERSION_MINOR);
   CHECK(openassetio::patchVersion() == OPENASSETIO_VERSION_PATCH);
-  CHECK(openassetio::betaMajorVersion() == OPENASSETIO_BETA_VERSION_MAJOR);
-  CHECK(openassetio::betaMinorVersion() == OPENASSETIO_BETA_VERSION_MINOR);
   CHECK(openassetio::versionString() == OPENASSETIO_VERSION_STRING);
 }

--- a/src/openassetio-python/cmodule/src/versionBinding.cpp
+++ b/src/openassetio-python/cmodule/src/versionBinding.cpp
@@ -9,7 +9,5 @@ void registerVersion(py::module& mod) {
   mod.def("majorVersion", &openassetio::majorVersion);
   mod.def("minorVersion", &openassetio::minorVersion);
   mod.def("patchVersion", &openassetio::patchVersion);
-  mod.def("betaMajorVersion", &openassetio::betaMajorVersion);
-  mod.def("betaMinorVersion", &openassetio::betaMinorVersion);
   mod.def("versionString", &openassetio::versionString);
 }

--- a/src/openassetio-python/package/openassetio/__init__.py
+++ b/src/openassetio-python/package/openassetio/__init__.py
@@ -84,7 +84,5 @@ from ._openassetio import (
     majorVersion,
     minorVersion,
     patchVersion,
-    betaMajorVersion,
-    betaMinorVersion,
     versionString,
 )

--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openassetio"
-version = "1.0.0b2.rev2"
+version = "1.0.0rc1.rev0"
 requires-python = ">=3.10"
 
 authors = [
@@ -25,7 +25,7 @@ description = """\
     """
 keywords = ["asset", "ams", "dam", "mam", "pipeline", "dcc", "media", "resolver"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
     "License :: OSI Approved :: Apache Software License",

--- a/src/openassetio-python/tests/package/test_version.py
+++ b/src/openassetio-python/tests/package/test_version.py
@@ -28,25 +28,21 @@ import pytest
 import openassetio
 
 # Update this value each release
-openassetio_version_string = "v1.0.0-beta.2.2"
+openassetio_version_string = "v1.0.0-rc.1.0"
 
 
 @pytest.fixture(scope="module")
 def extracted_version_nums():
     # Extract version numbers so we can test them
-    pattern = r"v(\d+)\.(\d+)\.(\d+)-beta\.(\d+)\.(\d+)"
+    pattern = r"v(\d+)\.(\d+)\.(\d+)"
     match = re.search(pattern, openassetio_version_string)
     major_version = match.group(1)
     minor_version = match.group(2)
     patch_version = match.group(3)
-    beta_major_version = match.group(4)
-    beta_minor_version = match.group(5)
     return (
         int(major_version),
         int(minor_version),
-        int(patch_version),
-        int(beta_major_version),
-        int(beta_minor_version),
+        int(patch_version)
     )
 
 
@@ -62,9 +58,3 @@ class Test_Version:
 
     def test_patch_version(self, extracted_version_nums):
         assert openassetio.patchVersion() == extracted_version_nums[2]
-
-    def test_major_beta_version(self, extracted_version_nums):
-        assert openassetio.betaMajorVersion() == extracted_version_nums[3]
-
-    def test_minor_beta_version(self, extracted_version_nums):
-        assert openassetio.betaMinorVersion() == extracted_version_nums[4]

--- a/src/openassetio-python/tests/package/test_version.py
+++ b/src/openassetio-python/tests/package/test_version.py
@@ -39,11 +39,7 @@ def extracted_version_nums():
     major_version = match.group(1)
     minor_version = match.group(2)
     patch_version = match.group(3)
-    return (
-        int(major_version),
-        int(minor_version),
-        int(patch_version)
-    )
+    return int(major_version), int(minor_version), int(patch_version)
 
 
 class Test_Version:


### PR DESCRIPTION
## Description

Closes #1401. Bump from beta to release candidate. 

Remove "beta" version introspection functions. We could have adapted these somehow, but that would be a lot of work for no current use-case.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.
