### PR TITLE
Add link to Ftrack plugin

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://www.ftrack.com"
+    }
+  ]
+}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -64,6 +64,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        # Suppress ftrack.com, which errors with http 520 when accessed
+        # via GitHub CI, for unknown reasons.
+        config-file: .github/markdown-link-check-config.json
 
   # Note: in order to keep an `actions/cache` cache up to date, we must
   # use the approach detailed in

--- a/doc/doxygen/src/MainPage.dox
+++ b/doc/doxygen/src/MainPage.dox
@@ -6,13 +6,8 @@
  * * 📐 Get off to a good start with the <a
      href="https://github.com/OpenAssetIO/Template-OpenAssetIO-Manager-Python">Python
      manager template.</a>
- * * 📖 See some examples: <a
-     href="https://github.com/ynput/ayon-openassetio-manager-plugin/tree/main#readme">Ayon
-     manager plugin</a>, <a
-     href="https://github.com/OpenAssetIO/usdOpenAssetIOResolver#readme">USD
-     Asset Resolver prototype</a>, <a
-     href="https://github.com/OpenAssetIO/otio-openassetio">OTIO media
-     linker</a>
+ * * 📖 See some <a href="https://github.com/OpenAssetIO/OpenAssetIO/tree/main/examples#readme">examples</a>
+ *   in the OpenAssetIO ecosystem, including USD, OTIO, Ftrack, Ayon, and more.
  * * 📖 See a <a
      href="https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation/blob/main/examples/hello_openassetio.ipynb">Hello World</a> tutorial example, with more tutorial examples to be found in <a
      href="https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation/tree/main/examples/">OpenAssetIO-MediaCreation</a>

--- a/examples/README.md
+++ b/examples/README.md
@@ -88,6 +88,13 @@ offering. Their
 [manager plugin](https://github.com/ynput/ayon-openassetio-manager-plugin)
 is available on GitHub.
 
+### Ftrack manager plugin
+
+[Ftrack Studio](https://www.ftrack.com/en/studio) is a commercial
+production tracking and asset management system. They maintain a
+[manager plugin](https://github.com/ftrackhq/ftrack-openassetio-manager)
+on GitHub.
+
 ### Blender OpenAssetIO demo script
 
 [Blender](https://www.blender.org/) is an open source 3D digital content


### PR DESCRIPTION
## Description

Closes #1399. Add a link to the Ftrack manager plugin in the `examples/README.md`. Also update the Doxygen API docs main page to link to this README rather than maintaining a separate list of examples.

- [ ] ~~I have updated the release notes.~~
- [x] I have updated all relevant user documentation.

## Reviewer Notes

To build the docs
```
cd docs/doxygen
make
```
The docs will be placed in a `html` directory under `docs/doxygen`.