### PR TITLE
Add convenience signatures for `defaultEntityReference`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,20 @@
 Release Notes
 =============
 
+v1.0.0-rc.x.x
+---------------
+
+_This release remains binary and source compatible for both hosts and
+managers._
+
+## New features
+
+- Added `defaultEntityReference` overloads for convenience, providing
+  alternatives to the core callback-based workflow. Includes querying
+  for a single result vs. a batch of results, and exception vs. result
+  object workflows.
+  [#1170](https://github.com/OpenAssetIO/OpenAssetIO/issues/1170)
+
 v1.0.0-rc.1.0
 ---------------
 

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -1513,7 +1513,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * no meaningful default, so the caller should be robust to this
    * situation.
    *
-   * @param traitSets  The relevant trait sets for the type of entities
+   * @param traitSets The relevant trait sets for the type of entities
    * required, these will be interpreted in conjunction with the context
    * to determine the most sensible default.
    *
@@ -1557,6 +1557,202 @@ class OPENASSETIO_CORE_EXPORT Manager final {
                               const ContextConstPtr& context,
                               const DefaultEntityReferenceSuccessCallback& successCallback,
                               const BatchElementErrorCallback& errorCallback);
+
+  /**
+   * Called to determine an @ref EntityReference considered to be a
+   * sensible default for the given entity @ref trait_set
+   * "trait set" and @ref Context "context".
+   *
+   * See documentation for the <!--
+   * --> @ref defaultEntityReference(const trait::TraitSets&, <!--
+   * --> access::DefaultEntityAccess, const ContextConstPtr&, <!--
+   * --> const DefaultEntityReferenceSuccessCallback&, <!--
+   * --> const BatchElementErrorCallback&)
+   * "callback signature" for more details on default entity behaviour.
+   *
+   * Any errors that occur during the query will be immediately thrown
+   * as an exception, either from the @ref manager plugin (for errors
+   * not specific to the default entity query) or as a
+   * @fqref{errors.BatchElementException}
+   * "BatchElementException"-derived error.
+   *
+   * @param traitSet The relevant trait set for the type of entity
+   * required. This will be interpreted in conjunction with the @p
+   * context to determine the most sensible default.
+   *
+   * @param defaultEntityAccess Intended usage of the returned entity
+   * reference.
+   *
+   * @param context The calling context.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Exception.
+   *
+   * @return Default entity reference for the @p traitSet and @p
+   * context. If the query is well-formed, but there is no available
+   * default entity reference, then the `optional` entity reference will
+   * not contain a value.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kDefaultEntityReferences.
+   *
+   * @see @ref Capability.kDefaultEntityReferences
+   */
+  std::optional<EntityReference> defaultEntityReference(
+      const trait::TraitSet& traitSet, access::DefaultEntityAccess defaultEntityAccess,
+      const ContextConstPtr& context,
+      const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
+
+  /**
+   * Called to determine an @ref EntityReference considered to be a
+   * sensible default for the given entity @ref trait_set
+   * "trait set" and @ref Context "context".
+   *
+   * See documentation for the <!--
+   * --> @ref defaultEntityReference(const trait::TraitSets&, <!--
+   * --> access::DefaultEntityAccess, const ContextConstPtr&, <!--
+   * --> const DefaultEntityReferenceSuccessCallback&, <!--
+   * --> const BatchElementErrorCallback&)
+   * "callback signature" for more details on default entity behaviour.
+   *
+   * If successful, the result is populated with a suitable default
+   * entity reference, or an empty optional if there is no suitable
+   * default.
+   *
+   * Otherwise, the result is populated with an error object detailing
+   * the reason for the failure.
+   *
+   * @param traitSet The relevant trait set for the type of entity
+   * required. This will be interpreted in conjunction with the @p
+   * context to determine the most sensible default.
+   *
+   * @param defaultEntityAccess Intended usage of the returned entity
+   * reference.
+   *
+   * @param context The calling context.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Variant.
+   *
+   * @return Either an error object, or the default entity reference
+   * for the @p traitSet and @p context. If the query is well-formed,
+   * but there is no available default entity reference, then the
+   * `optional` entity reference will not contain a value.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kDefaultEntityReferences.
+   *
+   * @see @ref Capability.kDefaultEntityReferences
+   */
+  std::variant<errors::BatchElementError, std::optional<EntityReference>> defaultEntityReference(
+      const trait::TraitSet& traitSet, access::DefaultEntityAccess defaultEntityAccess,
+      const ContextConstPtr& context, const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
+
+  /**
+   * Called to determine an @ref EntityReference considered to be a
+   * sensible default for each of the given entity @ref trait_set
+   * "trait sets" and @ref Context "context".
+   *
+   * See documentation for the <!--
+   * --> @ref defaultEntityReference(const trait::TraitSets&, <!--
+   * --> access::DefaultEntityAccess, const ContextConstPtr&, <!--
+   * --> const DefaultEntityReferenceSuccessCallback&, <!--
+   * --> const BatchElementErrorCallback&)
+   * "callback signature" for more details on default entity behaviour.
+   *
+   * Any errors that occur during the query will be immediately thrown
+   * as an exception, either from the @ref manager plugin (for errors
+   * not specific to the default entity query) or as a
+   * @fqref{errors.BatchElementException}
+   * "BatchElementException"-derived error.
+   *
+   * @param traitSets The relevant trait sets for each type of entity
+   * required. These will be interpreted in conjunction with the @p
+   * context to determine the most sensible default.
+   *
+   * @param defaultEntityAccess Intended usage of the returned entity
+   * reference.
+   *
+   * @param context The calling context.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Exception.
+   *
+   * @return A list of default entity references, each corresponding an
+   * entry in @p traitSets. If the query is well-formed, but there is no
+   * available default entity reference, then the `optional` entity
+   * reference will not contain a value.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kDefaultEntityReferences.
+   *
+   * @see @ref Capability.kDefaultEntityReferences
+   */
+  std::vector<std::optional<EntityReference>> defaultEntityReference(
+      const trait::TraitSets& traitSets, access::DefaultEntityAccess defaultEntityAccess,
+      const ContextConstPtr& context,
+      const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
+
+  /**
+   * Called to determine an @ref EntityReference considered to be a
+   * sensible default for each of the given entity @ref trait_set
+   * "trait sets" and @ref Context "context".
+   *
+   * See documentation for the <!--
+   * --> @ref defaultEntityReference(const trait::TraitSets&, <!--
+   * --> access::DefaultEntityAccess, const ContextConstPtr&, <!--
+   * --> const DefaultEntityReferenceSuccessCallback&, <!--
+   * --> const BatchElementErrorCallback&)
+   * "callback signature" for more details on default entity behaviour.
+   *
+   * If successful, the corresponding element of the result is populated
+   * with a suitable default entity reference, or an empty `optional` if
+   * there is no suitable default.
+   *
+   * Otherwise, the corresponding entry of the result is populated with
+   * an error object detailing the reason for the failure.
+   *
+   * @param traitSets The relevant trait sets for each type of entity
+   * required. These will be interpreted in conjunction with the @p
+   * context to determine the most sensible default.
+   *
+   * @param defaultEntityAccess Intended usage of the returned entity
+   * reference.
+   *
+   * @param context The calling context.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Variant.
+   *
+   * @return A list where each element is either an error object, or the
+   * default entity reference for the corresponding @p traitSet and @p
+   * context. If the query is well-formed, but there is no available
+   * default entity reference for a particular trait set, then the
+   * `optional` entity reference corresponding to that trait set will
+   * not contain a value.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kDefaultEntityReferences.
+   *
+   * @see @ref Capability.kDefaultEntityReferences
+   */
+  std::vector<std::variant<errors::BatchElementError, std::optional<EntityReference>>>
+  defaultEntityReference(const trait::TraitSets& traitSets,
+                         access::DefaultEntityAccess defaultEntityAccess,
+                         const ContextConstPtr& context,
+                         const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
 
   /// @}
 

--- a/src/openassetio-core/src/errors/exceptionMessages.hpp
+++ b/src/openassetio-core/src/errors/exceptionMessages.hpp
@@ -9,6 +9,7 @@
 #include <openassetio/access.hpp>
 #include <openassetio/errors/BatchElementError.hpp>
 #include <openassetio/internal.hpp>
+#include <openassetio/trait/collection.hpp>
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -17,9 +18,10 @@ namespace errors {
 Str errorCodeName(BatchElementError::ErrorCode code);
 
 /**Construct a full message to place into a convenience exception.*/
-std::string createBatchElementExceptionMessage(const BatchElementError& err, size_t index,
-                                               const EntityReference& entityReference,
-                                               std::optional<internal::access::Access> access);
+Str createBatchElementExceptionMessage(const BatchElementError& err, size_t index,
+                                       std::optional<internal::access::Access> access,
+                                       const std::optional<EntityReference>& entityReference,
+                                       const std::optional<trait::TraitSet>& traitSet);
 }  // namespace errors
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/src/hostApi/ManagerConveniences.cpp
+++ b/src/openassetio-core/src/hostApi/ManagerConveniences.cpp
@@ -31,7 +31,7 @@ trait::TraitsDataPtr Manager::managementPolicy(const trait::TraitSet &traitSet,
  ******************************************/
 
 // Singular Except
-bool hostApi::Manager::entityExists(
+bool Manager::entityExists(
     const EntityReference &entityReference, const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
   bool result{};
@@ -48,7 +48,7 @@ bool hostApi::Manager::entityExists(
 }
 
 // Singular variant
-std::variant<errors::BatchElementError, bool> hostApi::Manager::entityExists(
+std::variant<errors::BatchElementError, bool> Manager::entityExists(
     const EntityReference &entityReference, const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
   std::variant<errors::BatchElementError, bool> result;
@@ -63,7 +63,7 @@ std::variant<errors::BatchElementError, bool> hostApi::Manager::entityExists(
 }
 
 // Multi except
-std::vector<hostApi::Manager::BoolAsUint> hostApi::Manager::entityExists(
+std::vector<Manager::BoolAsUint> Manager::entityExists(
     const EntityReferences &entityReferences, const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
   std::vector<BoolAsUint> results;
@@ -84,7 +84,7 @@ std::vector<hostApi::Manager::BoolAsUint> hostApi::Manager::entityExists(
 }
 
 // Multi variant
-std::vector<std::variant<errors::BatchElementError, bool>> hostApi::Manager::entityExists(
+std::vector<std::variant<errors::BatchElementError, bool>> Manager::entityExists(
     const EntityReferences &entityReferences, const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
   std::vector<std::variant<errors::BatchElementError, bool>> results;
@@ -104,7 +104,7 @@ std::vector<std::variant<errors::BatchElementError, bool>> hostApi::Manager::ent
  ******************************************/
 
 // Singular Except
-trait::TraitSet hostApi::Manager::entityTraits(
+trait::TraitSet Manager::entityTraits(
     const EntityReference &entityReference, const access::EntityTraitsAccess entityTraitsAccess,
     const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
@@ -125,7 +125,7 @@ trait::TraitSet hostApi::Manager::entityTraits(
 }
 
 // Singular variant
-std::variant<errors::BatchElementError, trait::TraitSet> hostApi::Manager::entityTraits(
+std::variant<errors::BatchElementError, trait::TraitSet> Manager::entityTraits(
     const EntityReference &entityReference, const access::EntityTraitsAccess entityTraitsAccess,
     const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
@@ -143,7 +143,7 @@ std::variant<errors::BatchElementError, trait::TraitSet> hostApi::Manager::entit
 }
 
 // Multi except
-std::vector<trait::TraitSet> hostApi::Manager::entityTraits(
+std::vector<trait::TraitSet> Manager::entityTraits(
     const EntityReferences &entityReferences, const access::EntityTraitsAccess entityTraitsAccess,
     const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
@@ -191,7 +191,7 @@ hostApi::Manager::entityTraits(
  ******************************************/
 
 // Singular Except
-trait::TraitsDataPtr hostApi::Manager::resolve(
+trait::TraitsDataPtr Manager::resolve(
     const EntityReference &entityReference, const trait::TraitSet &traitSet,
     const access::ResolveAccess resolveAccess, const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
@@ -211,7 +211,7 @@ trait::TraitsDataPtr hostApi::Manager::resolve(
 }
 
 // Singular variant
-std::variant<errors::BatchElementError, trait::TraitsDataPtr> hostApi::Manager::resolve(
+std::variant<errors::BatchElementError, trait::TraitsDataPtr> Manager::resolve(
     const EntityReference &entityReference, const trait::TraitSet &traitSet,
     const access::ResolveAccess resolveAccess, const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
@@ -229,7 +229,7 @@ std::variant<errors::BatchElementError, trait::TraitsDataPtr> hostApi::Manager::
 }
 
 // Multi except
-std::vector<trait::TraitsDataPtr> hostApi::Manager::resolve(
+std::vector<trait::TraitsDataPtr> Manager::resolve(
     const EntityReferences &entityReferences, const trait::TraitSet &traitSet,
     const access::ResolveAccess resolveAccess, const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
@@ -359,7 +359,7 @@ std::vector<std::variant<errors::BatchElementError, EntityReference>> Manager::p
  ******************************************/
 
 // Singular Except
-EntityReference hostApi::Manager::register_(
+EntityReference Manager::register_(
     const EntityReference &entityReference, const trait::TraitsDataPtr &entityTraitsData,
     const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
@@ -380,7 +380,7 @@ EntityReference hostApi::Manager::register_(
 }
 
 // Singular variant
-std::variant<errors::BatchElementError, EntityReference> hostApi::Manager::register_(
+std::variant<errors::BatchElementError, EntityReference> Manager::register_(
     const EntityReference &entityReference, const trait::TraitsDataPtr &entityTraitsData,
     const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
@@ -398,7 +398,7 @@ std::variant<errors::BatchElementError, EntityReference> hostApi::Manager::regis
 }
 
 // Multi except
-std::vector<EntityReference> hostApi::Manager::register_(
+std::vector<EntityReference> Manager::register_(
     const EntityReferences &entityReferences, const trait::TraitsDatas &entityTraitsDatas,
     const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
@@ -422,7 +422,7 @@ std::vector<EntityReference> hostApi::Manager::register_(
 }
 
 // Multi variant
-std::vector<std::variant<errors::BatchElementError, EntityReference>> hostApi::Manager::register_(
+std::vector<std::variant<errors::BatchElementError, EntityReference>> Manager::register_(
     const EntityReferences &entityReferences, const trait::TraitsDatas &entityTraitsDatas,
     const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
     [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
@@ -445,7 +445,7 @@ std::vector<std::variant<errors::BatchElementError, EntityReference>> hostApi::M
  ******************************************/
 
 // Singular Except
-EntityReferencePagerPtr hostApi::Manager::getWithRelationship(
+EntityReferencePagerPtr Manager::getWithRelationship(
     const EntityReference &entityReference, const trait::TraitsDataPtr &relationshipTraitsData,
     const size_t pageSize, const access::RelationsAccess relationsAccess,
     const ContextConstPtr &context, const trait::TraitSet &resultTraitSet,
@@ -488,7 +488,7 @@ hostApi::Manager::getWithRelationship(
 }
 
 // Multi Except
-std::vector<EntityReferencePagerPtr> hostApi::Manager::getWithRelationship(
+std::vector<EntityReferencePagerPtr> Manager::getWithRelationship(
     const EntityReferences &entityReferences, const trait::TraitsDataPtr &relationshipTraitsData,
     const size_t pageSize, const access::RelationsAccess relationsAccess,
     const ContextConstPtr &context, const trait::TraitSet &resultTraitSet,
@@ -514,7 +514,7 @@ std::vector<EntityReferencePagerPtr> hostApi::Manager::getWithRelationship(
 
 // Multi Variant
 std::vector<std::variant<errors::BatchElementError, EntityReferencePagerPtr>>
-hostApi::Manager::getWithRelationship(
+Manager::getWithRelationship(
     const EntityReferences &entityReferences, const trait::TraitsDataPtr &relationshipTraitsData,
     const size_t pageSize, const access::RelationsAccess relationsAccess,
     const ContextConstPtr &context, const trait::TraitSet &resultTraitSet,
@@ -540,7 +540,7 @@ hostApi::Manager::getWithRelationship(
  ******************************************/
 
 // Multi Except
-std::vector<EntityReferencePagerPtr> hostApi::Manager::getWithRelationships(
+std::vector<EntityReferencePagerPtr> Manager::getWithRelationships(
     const EntityReference &entityReference, const trait::TraitsDatas &relationshipTraitsDatas,
     const size_t pageSize, const access::RelationsAccess relationsAccess,
     const ContextConstPtr &context, const trait::TraitSet &resultTraitSet,
@@ -564,7 +564,7 @@ std::vector<EntityReferencePagerPtr> hostApi::Manager::getWithRelationships(
 
 // Multi Variant
 std::vector<std::variant<errors::BatchElementError, EntityReferencePagerPtr>>
-hostApi::Manager::getWithRelationships(
+Manager::getWithRelationships(
     const EntityReference &entityReference, const trait::TraitsDatas &relationshipTraitsDatas,
     const size_t pageSize, const access::RelationsAccess relationsAccess,
     const ContextConstPtr &context, const trait::TraitSet &resultTraitSet,

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -115,6 +115,65 @@ void registerManager(const py::module& mod) {
       .def("createEntityReferenceIfValid", &Manager::createEntityReferenceIfValid,
            py::arg("entityReferenceString"), py::call_guard<py::gil_scoped_release>{})
       .def(
+          "defaultEntityReference",
+          [](Manager& self, const trait::TraitSet& traitSet,
+             const access::DefaultEntityAccess defaultEntityReferenceAccess,
+             const ContextConstPtr& context) {
+            return self.defaultEntityReference(traitSet, defaultEntityReferenceAccess, context);
+          },
+          py::arg("traitSet"), py::arg("defaultEntityReferenceAccess"),
+          py::arg("context").none(false), py::call_guard<py::gil_scoped_release>{})
+      .def(
+          "defaultEntityReference",
+          [](Manager& self, const trait::TraitSets& traitSets,
+             const access::DefaultEntityAccess defaultEntityReferenceAccess,
+             const ContextConstPtr& context) {
+            return self.defaultEntityReference(traitSets, defaultEntityReferenceAccess, context);
+          },
+          py::arg("traitSets"), py::arg("defaultEntityReferenceAccess"),
+          py::arg("context").none(false), py::call_guard<py::gil_scoped_release>{})
+      .def("defaultEntityReference",
+           py::overload_cast<const trait::TraitSet&, access::DefaultEntityAccess,
+                             const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::defaultEntityReference),
+           py::arg("traitSet"), py::arg("defaultEntityReferenceAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("defaultEntityReference",
+           py::overload_cast<const trait::TraitSets&, access::DefaultEntityAccess,
+                             const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::defaultEntityReference),
+           py::arg("traitSets"), py::arg("defaultEntityReferenceAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("defaultEntityReference",
+           py::overload_cast<const trait::TraitSets&, access::DefaultEntityAccess,
+                             const ContextConstPtr&,
+                             const Manager::DefaultEntityReferenceSuccessCallback&,
+                             const Manager::BatchElementErrorCallback&>(
+               &Manager::defaultEntityReference),
+           py::arg("traitSets"), py::arg("defaultEntityReferenceAccess"),
+           py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("defaultEntityReference",
+           py::overload_cast<const trait::TraitSet&, access::DefaultEntityAccess,
+                             const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::defaultEntityReference),
+           py::arg("traitSet"), py::arg("defaultEntityReferenceAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("defaultEntityReference",
+           py::overload_cast<const trait::TraitSets&, access::DefaultEntityAccess,
+                             const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::defaultEntityReference),
+           py::arg("traitSets"), py::arg("defaultEntityReferenceAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def(
           "entityExists",
           [](Manager& self, const EntityReference& entityReference,
              const ContextConstPtr& context) {
@@ -295,10 +354,6 @@ void registerManager(const py::module& mod) {
           },
           py::arg("entityReferences"), py::arg("traitSet"), py::arg("resolveAccess"),
           py::arg("context").none(false), py::call_guard<py::gil_scoped_release>{})
-      .def("defaultEntityReference", &Manager::defaultEntityReference, py::arg("traitSets"),
-           py::arg("defaultEntityAccess"), py::arg("context").none(false),
-           py::arg("successCallback"), py::arg("errorCallback"),
-           py::call_guard<py::gil_scoped_release>{})
       .def("getWithRelationship",
            py::overload_cast<const EntityReferences&, const trait::TraitsDataPtr&, size_t,
                              access::RelationsAccess, const ContextConstPtr&,

--- a/src/openassetio-python/tests/cmodule/gil/test_manager_gil.py
+++ b/src/openassetio-python/tests/cmodule/gil/test_manager_gil.py
@@ -89,17 +89,22 @@ class Test_Manager_gil:
         a_threaded_manager.persistenceTokenForContext(a_context)
 
     def test_defaultEntityReference(self, a_threaded_manager, a_context):
-        # Defend against forgetting to include convenience signatures in
-        # this test, once added.
-        assert "Overloaded" not in a_threaded_manager.defaultEntityReference.__doc__
+        tag = Manager.BatchElementErrorPolicyTag
+        an_access = access.DefaultEntityAccess.kRead
 
         a_threaded_manager.defaultEntityReference(
             [],
-            access.DefaultEntityAccess.kRead,
+            an_access,
             a_context,
             fail,
             fail,
         )
+        a_threaded_manager.defaultEntityReference(set(), an_access, a_context)
+        a_threaded_manager.defaultEntityReference(set(), an_access, a_context, tag.kException)
+        a_threaded_manager.defaultEntityReference(set(), an_access, a_context, tag.kVariant)
+        a_threaded_manager.defaultEntityReference([], an_access, a_context)
+        a_threaded_manager.defaultEntityReference([], an_access, a_context, tag.kException)
+        a_threaded_manager.defaultEntityReference([], an_access, a_context, tag.kVariant)
 
     def test_displayName(self, mock_manager_interface, a_threaded_manager):
         mock_manager_interface.mock.displayName.return_value = "My Name"


### PR DESCRIPTION
## Description

Closes #1170. Add overloads for `defaultEntityReference`, similar to other API methods. I.e. singular vs. batch, exception vs. result (variant).

- [x] I have updated the release notes.
- [ ] ~~I have updated all relevant user documentation.~~
