### PR TITLE
Don't export pybind11 exception types

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,13 @@ managers._
   object workflows.
   [#1170](https://github.com/OpenAssetIO/OpenAssetIO/issues/1170)
 
+### Bug fixes
+
+- pybind11 exception class symbols are no longer exported from the
+  OpenAssetIO Python extension module, so that hosts using a different
+  version of pybind11 do not conflict.
+  [#1416](https://github.com/OpenAssetIO/OpenAssetIO/issues/1416)
+
 v1.0.0-rc.1.0
 ---------------
 

--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -79,6 +79,13 @@ if (OPENASSETIO_ENABLE_PYTHON)
 
     # pybind11 for C++ Python bindings.
     find_package(pybind11 2 REQUIRED)
+    # TODO(DF): Remove if/when fixed upstream: https://github.com/pybind/pybind11/issues/5359
+    # Ensure the pybind11 exception types are not exported. If a host
+    # uses a different version of pybind11 then we can get bad ODR bugs.
+    get_target_property(_pybind11_defs pybind11::module INTERFACE_COMPILE_DEFINITIONS)
+    list(APPEND _pybind11_defs PYBIND11_EXPORT_EXCEPTION=)
+    set_target_properties(
+        pybind11::module PROPERTIES INTERFACE_COMPILE_DEFINITIONS "${_pybind11_defs}")
 
 
     #-------------------------------------------------------------------

--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -78,9 +78,7 @@ if (OPENASSETIO_ENABLE_PYTHON)
     endif ()
 
     # pybind11 for C++ Python bindings.
-    # TODO(DF): Our pybind11 conan package doesn't give version info, so
-    #   we can't pin it at the moment.
-    find_package(pybind11 REQUIRED)
+    find_package(pybind11 2 REQUIRED)
 
 
     #-------------------------------------------------------------------


### PR DESCRIPTION
## TODO

- Double-check Windows.
- Automated test?

## Description

Closes #1416.

For example, the ABI of the `error_already_set` type was changed radically between pybind11 2.9 and 2.10. If OpenAssetIO is  built with 2.10 and the host is built with 2.9, and the exception is caught in the host (even as a `std::exception`), and `.what()` is called on it, the wrong implementation of `.what()` may be executed, giving garbled text. This exact scenario was seen in practice.

Disabling the export of the pybind11 exception will cause problems if we ever need to catch a pybind11-specific exception in a different DSO. We don't currently have that use-case, however.

So disable the export of pybind11 exceptions by overriding its `PYBIND11_EXPORT_EXCEPTION` macro wherever the `pybind11::module` CMake target is linked.

Host applications can still catch the pybind11 exception as a `std::exception`, and safely call `.what()` on it to extract the error
message, and the correct implementation will be used. 

- [x] I have updated the release notes.
- [ ] ~~I have updated all relevant user documentation.~~

## Reviewer Notes

The alternative is to insist that hosts build with the same pybind11 as is used to build OpenAssetIO, which isn't entirely unreasonable.

The root cause was discovered using a gdb debug session of a gcc 11 build, which revealed that the OpenAssetIO pybind11 was used to construct the exception object, but the host pybind11 was used for its vtable pointer.

## Test Instructions

<!--- Provide instructions to the reviewer on how to explicitly test
      these changes. --->
