### PR TITLE
C++->Python exception "raise from" support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,13 @@ managers._
   object workflows.
   [#1170](https://github.com/OpenAssetIO/OpenAssetIO/issues/1170)
 
+## Bug fixes
+
+- Added "raise from" behaviour in C++->Python exception translation, in
+  case a Python exception is already active when the C++ exception
+  occurs.
+  [#1419](https://github.com/OpenAssetIO/OpenAssetIO/issues/1419)
+
 v1.0.0-rc.1.0
 ---------------
 

--- a/src/openassetio-python/tests/cmodule/test_errors.py
+++ b/src/openassetio-python/tests/cmodule/test_errors.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2023 The Foundry Visionmongers Ltd
+#   Copyright 2023-2024 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -127,6 +127,16 @@ class Test_errors:
             _openassetio._testutils.isPythonExceptionCatchableAs(
                 exception_thrower, "OpenAssetIOException"
             )
+
+
+class Test_raise_from:
+    def test_when_CPython_error_indicator_and_cpp_exception_thrown_then_exceptions_combined(self):
+
+        with pytest.raises(errors.OpenAssetIOException, match="Cpp exception") as err:
+            _openassetio._testutils.setErrorIndicatorAndThrowCppException()
+
+        assert isinstance(err.value.__cause__, TypeError)
+        assert str(err.value.__cause__) == "CPython exception"
 
 
 def make_exception(exception_type):


### PR DESCRIPTION
## Description

Closes #1419. If a C++ exception occurs in a pybind11-bound C++ function, then we attempt to translate the C++ exception to a Python exception. As part of this we execute Python statements, in-particular we import `openassetio._openassetio.errors`. Attempting to do this import whilst the Python error indicator is set causes a fatal error in Python.

This can happen if e.g. in the call stack of a pybind11-bound function, some C++ code uses the CPython API, which triggers a Python exception, but then the C++ code goes on to throw its own exception too.

So handle this case by fetching the pre-existing exception, and setting the `__cause__` and `__context__` of the newly translated C++->Python exception.

The code duplicates the logic in `pybind11::raise_from`. We can't use that function directly, since it only supports simple exceptions that can be created with `PyErr_SetString` (i.e. doesn't support `BatchElementError`, whose constructor takes arguments other than a string `message`).

- [x] I have updated the release notes.
- [ ] ~~I have updated all relevant user documentation.~~
