### PR TITLE
`EntityReference` associative container support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,13 @@ managers._
   object workflows.
   [#1170](https://github.com/OpenAssetIO/OpenAssetIO/issues/1170)
 
+## Improvements
+
+- Added operators and hash functions to the `EntityReference` type, in
+  both C++ and Python, such that `EntityReference` objects can be used
+  as keys in associative containers (e.g. `dict`/`std::unordered_map`).
+  [#573](https://github.com/OpenAssetIO/OpenAssetIO/issues/573)
+
 ## Bug fixes
 
 - Added "raise from" behaviour in C++->Python exception translation, in

--- a/src/openassetio-core/tests/CMakeLists.txt
+++ b/src/openassetio-core/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(openassetio-core-cpp-test-exe
     typedefsTest.cpp
     BatchElementErrorTest.cpp
     ContextTest.cpp
+    EntityReferenceTest.cpp
     TraitsDataTest.cpp
     versionTest.cpp
     hostApi/ManagerTest.cpp

--- a/src/openassetio-core/tests/EntityReferenceTest.cpp
+++ b/src/openassetio-core/tests/EntityReferenceTest.cpp
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Foundry Visionmongers Ltd
+#include <map>
+#include <set>
+#include <unordered_set>
+
+#include <catch2/catch.hpp>
+
+#include <openassetio/EntityReference.hpp>
+
+SCENARIO("EntityReference used in an ordered container") {
+  using openassetio::EntityReference;
+  GIVEN("an ordered container") {
+    std::set<EntityReference> container;
+    WHEN("an entity reference is added") {
+      container.emplace("foo");
+      container.emplace("foo");
+      container.emplace("bar");
+      THEN("it is found in the container") {
+        CHECK(container.size() == 2);
+        CHECK(container.count(EntityReference{"foo"}) == 1);
+        CHECK(container.count(EntityReference{"bar"}) == 1);
+      }
+    }
+  }
+}
+
+SCENARIO("EntityReference used in an unordered container") {
+  using openassetio::EntityReference;
+  GIVEN("an unordered container") {
+    std::unordered_set<EntityReference> container;
+    WHEN("an entity reference is added") {
+      container.emplace("foo");
+      container.emplace("foo");
+      container.emplace("bar");
+      THEN("it is found in the container") {
+        CHECK(container.size() == 2);
+        CHECK(container.count(EntityReference{"foo"}) == 1);
+        CHECK(container.count(EntityReference{"bar"}) == 1);
+      }
+    }
+  }
+}
+
+SCENARIO("EntityReference equality and ordering") {
+  using openassetio::EntityReference;
+  GIVEN("two equal entity references") {
+    const EntityReference ref1{"foo"};
+    const EntityReference ref2{"foo"};
+
+    WHEN("they are compared for equality") {
+      THEN("they are equal") { CHECK(ref1 == ref2); }
+    }
+    WHEN("they are compared for non-equality") {
+      THEN("they are equal") { CHECK_FALSE(ref1 != ref2); }
+    }
+    WHEN("they are compared less than or equal") {
+      THEN("they are equal") {
+        CHECK(ref1 <= ref2);
+        CHECK(ref2 <= ref1);
+      }
+    }
+    WHEN("they are compared greater than or equal") {
+      THEN("they are equal") {
+        CHECK(ref1 >= ref2);
+        CHECK(ref2 >= ref1);
+      }
+    }
+  }
+  GIVEN("two unequal entity references") {
+    const EntityReference ref1{"bar"};
+    const EntityReference ref2{"foo"};
+
+    WHEN("they are compared for non-equality") {
+      THEN("they are not equal") { CHECK_FALSE(ref1 == ref2); }
+    }
+    WHEN("they are compared for non-equality") {
+      THEN("they are not equal") { CHECK(ref1 != ref2); }
+    }
+    WHEN("they are compared for greater than") {
+      THEN("they are ordered lexicographically") { CHECK(ref1 < ref2); }
+    }
+    WHEN("they are compared for greater than") {
+      THEN("they are ordered lexicographically") { CHECK(ref2 > ref1); }
+    }
+    WHEN("they are compared less than or equal") {
+      THEN("they are ordered lexicographically") { CHECK(ref1 <= ref2); }
+    }
+    WHEN("they are compared greater than or equal") {
+      THEN("they are ordered lexicographically") { CHECK(ref2 >= ref1); }
+    }
+  }
+}

--- a/src/openassetio-python/cmodule/src/EntityReferenceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/EntityReferenceBinding.cpp
@@ -30,5 +30,9 @@ void registerEntityReference(const py::module& mod) {
              stringStream << self;
              return fmt::format("EntityReference('{}')", stringStream.str());
            })
-      .def(py::self == py::self);  // NOLINT(misc-redundant-expression)
+      .def(py::self == py::self)  // NOLINT(misc-redundant-expression)
+      .def(py::self < py::self)   // NOLINT(misc-redundant-expression)
+      .def(py::self <= py::self)  // NOLINT(misc-redundant-expression)
+      .def("__hash__",
+           [](const EntityReference& self) { return std::hash<EntityReference>{}(self); });
 }

--- a/src/openassetio-python/tests/package/test_entityreference.py
+++ b/src/openassetio-python/tests/package/test_entityreference.py
@@ -49,6 +49,32 @@ class Test_EntityReference_equality:
         assert EntityReference("something") != EntityReference("something else")
 
 
+class Test_EntityReference_ordering:
+    def test_when_less_than_then_compares_lesser(self):
+        assert EntityReference("a") < EntityReference("b")
+
+    def test_when_greater_than_then_compares_greater(self):
+        assert EntityReference("b") > EntityReference("a")
+
+    def test_when_greater_or_equal_than_then_compares_greater_or_equal(self):
+        assert EntityReference("b") >= EntityReference("a")
+        assert EntityReference("a") >= EntityReference("a")
+
+    def test_when_less_or_equal_than_then_compares_lesser_or_equal(self):
+        assert EntityReference("a") <= EntityReference("b")
+        assert EntityReference("a") <= EntityReference("a")
+
+
+class Test_EntityReference_hash:
+    def test_when_refs_used_in_associative_container_then_deduped_appropriately(self):
+        a_ref = EntityReference("value")
+        b_ref = EntityReference("value")
+        c_ref = EntityReference("different value")
+        d_str = "value"
+
+        assert {a_ref, b_ref, c_ref, d_str} == {a_ref, c_ref, d_str}
+
+
 class Test_EntityReference_string_equivalence:
     def test_when_used_with_format_then_result_contains_toString_value(self):
         a_ref = EntityReference("Some 🍟 with that?")


### PR DESCRIPTION
## Description

Closes #573. Entity references used to be simple strings. Now they are a strong type and lose the conveniences that come with strings.

In particular, they could not be used as keys in associative containers, in Python nor C++.

So add operators and hashing in both C++ and Python that allow entity references to be used in containers.

For completeness, add the similar operators that are not technically needed for container support, but may be useful in other situations. In particular noting that Python infers partner operators (e.g. `>` from `<`) whereas C++ (17) does not. So adding explicit support for these to C++ provides parity with Python functionality.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.