### PR TITLE
Bounds check array access in `Manager` convenience overloads

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,12 @@ _This release remains source compatible for both hosts and managers._
   as keys in associative containers (e.g. `dict`/`std::unordered_map`).
   [#573](https://github.com/OpenAssetIO/OpenAssetIO/issues/573)
 
+- Added bounds checking of array access to convenience methods that wrap
+  batch-first callback-based signatures. This avoids some potential
+  segfaults if a manager plugin calls a callback passing an invalid index
+  argument.
+  [#1196](https://github.com/OpenAssetIO/OpenAssetIO/issues/1196)
+
 - Removed the requirement to define C++ destructors for classes
   inheriting from `LoggerInterface` and
   `ManagerImplementationFactoryInterface`. I.e. the destructors are no


### PR DESCRIPTION

## Description

Closes #1196

- [x] I have updated the release notes.
- [ ] ~~I have updated all relevant user documentation.~~

An external manager plugin is expected to provide an implementation of a `ManagerInterface`. Most of its methods are batch-first and callback-based. That is, the manager plugin is expected to call a callback with the result for each element of an input batch. As such, the various callback signatures take an index argument to address a particular element in the batch.

The host-facing `Manager` middleware wraps the plugin's `ManagerInterface`. The `Manager` class adds convenience overloads that wrap each callback-based method provided by the plugin. These convenience methods include `std::vector`-returning signatures, where the `std::vector` is populated as callbacks are called, before being returned.

If the manager provides an invalid index as an argument to the callback, then the middleware could attempt to access outside the bounds of the `std::vector` it's populating, leading to segfaults.

Since the manager plugin is by definition externally provided, we should treat it as untrusted and ensure we validate its output as much as possible.

So add bounds checking around all relevant convenience methods where out-of-bounds access is possible, throwing an exception on failure. Provide a platform-agnostic human-readable exception message.

Improve the error message constructed in the `getWithRelationship(s)` exception-throwing signatures by including the input trait set. This was an omission from the work done in #1170. Adding that here has the side effect of ensuring proper bounds checking.
