### PR TITLE
Upgrade to clang-tidy/clang-format v19

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,3 +3,5 @@ Language: Cpp
 Standard: c++17
 ColumnLimit: 99
 IncludeBlocks: Preserve
+# E.g. `const int x` vs. `int const x`.
+QualifierAlignment: Left

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 Google LLC
-# Copyright 2013-2022 The Foundry Visionmongers Ltd
+# Copyright 2013-2025 The Foundry Visionmongers Ltd
 
 # Modified from: https://raw.githubusercontent.com/googleapis/google-cloud-cpp/main/.clang-tidy
 # See: https://releases.llvm.org/10.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/list.html
@@ -74,7 +74,7 @@ CheckOptions:
     - { key: readability-identifier-naming.ProtectedMemberSuffix,  value: _          }
     - { key: readability-identifier-naming.EnumConstantCase,         value: CamelCase }
     - { key: readability-identifier-naming.EnumConstantPrefix,       value: k         }
-    - { key: readability-identifier-naming.ConstexprVariableCase,    value: Camel_Snake_Case }
+    - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase }
     - { key: readability-identifier-naming.ConstexprVariablePrefix,  value: k         }
     - { key: readability-identifier-naming.GlobalConstantCase,       value: CamelCase }
     - { key: readability-identifier-naming.GlobalConstantPrefix,     value: k         }
@@ -92,3 +92,12 @@ CheckOptions:
     # OpenAssetIO define a virtual default destructor just to make them
     # polymorphic.
     - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor,  value: 1 }
+    # Suppressions for `#include` checks.
+    # * Python.h, pystate.h, pytypedefs.h, object.h, pyerrors.h,
+    #   abstract.h - Python.h is the umbrella header.
+    # * toml++/ - toml.h is the umbrella header.
+    # * ada/ - ada.h the umbrella header.
+    # * pybind11/ - pybind11.h is the umbrella header. Other headers add
+    #   functionality (e.g. stl.h), but may be falsely flagged as
+    #   unused.
+    - { key: misc-include-cleaner.IgnoreHeaders,  value: "Python.h;pystate.h;pytypedefs.h;object.h;pyerrors.h;abstract.h;toml\\+\\+/.*;ada/.*;pybind11/.*" }

--- a/cmake/StaticAnalyzers.cmake
+++ b/cmake/StaticAnalyzers.cmake
@@ -3,7 +3,7 @@
 
 #Enable clang-tidy using cmake arguments
 macro(enable_clang_tidy)
-    find_program(OPENASSETIO_CLANGTIDY_EXE NAMES clang-tidy clang-tidy-12)
+    find_program(OPENASSETIO_CLANGTIDY_EXE NAMES clang-tidy clang-tidy-19)
 
     if (OPENASSETIO_CLANGTIDY_EXE)
         # Construct the clang-tidy command line

--- a/cmake/templates/include/openassetio/version.hpp.in
+++ b/cmake/templates/include/openassetio/version.hpp.in
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #pragma once
 
 #include <cstddef>
@@ -7,12 +7,14 @@
 
 #include <openassetio/export.h>
 
+// NOLINTBEGIN(*-macro-to-enum)
 // clang-format off
 #define OPENASSETIO_VERSION_MAJOR @OpenAssetIO_VERSION_MAJOR@
 #define OPENASSETIO_VERSION_MINOR @OpenAssetIO_VERSION_MINOR@
 #define OPENASSETIO_VERSION_PATCH @OpenAssetIO_VERSION_PATCH@
 #define OPENASSETIO_VERSION_STRING "v@OpenAssetIO_VERSION@-rc.1.0"
 // clang-format on
+// NOLINTEND(*-macro-to-enum)
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {

--- a/examples/manager/SimpleCppManager/src/SimpleCppManager.cpp
+++ b/examples/manager/SimpleCppManager/src/SimpleCppManager.cpp
@@ -1,18 +1,33 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #include <algorithm>
+#include <cstdlib>
+#include <ios>
+#include <iterator>
+#include <memory>
 #include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
 
 #include <export.h>
 
+#include <openassetio/EntityReference.hpp>
+#include <openassetio/InfoDictionary.hpp>
+#include <openassetio/access.hpp>
+#include <openassetio/errors/BatchElementError.hpp>
 #include <openassetio/errors/exceptions.hpp>
 #include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/pluginSystem/CppPluginSystemManagerPlugin.hpp>
+#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
 #include <openassetio/trait/TraitsData.hpp>
+#include <openassetio/trait/collection.hpp>
+#include <openassetio/trait/property.hpp>
+#include <openassetio/typedefs.hpp>
 
 // Unique ID of the plugin.
 constexpr std::string_view kDefaultPluginId = "org.openassetio.examples.manager.simplecppmanager";
@@ -47,6 +62,7 @@ constexpr std::string_view kSettingsKeyForReadEntityTraitProperties = "read_trai
  */
 struct SimpleCppManagerInterface final : openassetio::managerApi::ManagerInterface {
   [[nodiscard]] openassetio::Identifier identifier() const override {
+    // NOLINTNEXTLINE(*-suspicious-stringview-data-usage)
     if (const char* envVar = std::getenv(kPluginIdEnvVar.data())) {
       return openassetio::Identifier{envVar};
     }
@@ -112,7 +128,7 @@ struct SimpleCppManagerInterface final : openassetio::managerApi::ManagerInterfa
             iter != cend(kCapabilityNames)) {
           const std::size_t capabilityIdx = std::distance(cbegin(kCapabilityNames), iter);
           // Update the capability set.
-          capabilities_.insert(static_cast<ManagerInterface::Capability>(capabilityIdx));
+          capabilities_.insert(static_cast<Capability>(capabilityIdx));
         } else {
           throw openassetio::errors::ConfigurationException(
               "SimpleCppManager: unsupported capability: " + capability);
@@ -448,7 +464,7 @@ struct SimpleCppManagerInterface final : openassetio::managerApi::ManagerInterfa
       const openassetio::EntityReferences& entityReferences,
       [[maybe_unused]] const openassetio::trait::TraitsDataPtr& relationshipTraitsData,
       [[maybe_unused]] const openassetio::trait::TraitSet& resultTraitSet,
-      [[maybe_unused]] const size_t pageSize,
+      [[maybe_unused]] const std::size_t pageSize,
       [[maybe_unused]] const openassetio::access::RelationsAccess relationsAccess,
       [[maybe_unused]] const openassetio::ContextConstPtr& context,
       [[maybe_unused]] const openassetio::managerApi::HostSessionPtr& hostSession,
@@ -468,7 +484,7 @@ struct SimpleCppManagerInterface final : openassetio::managerApi::ManagerInterfa
       [[maybe_unused]] const openassetio::EntityReference& entityReference,
       const openassetio::trait::TraitsDatas& relationshipTraitsDatas,
       [[maybe_unused]] const openassetio::trait::TraitSet& resultTraitSet,
-      [[maybe_unused]] const size_t pageSize,
+      [[maybe_unused]] const std::size_t pageSize,
       [[maybe_unused]] const openassetio::access::RelationsAccess relationsAccess,
       [[maybe_unused]] const openassetio::ContextConstPtr& context,
       [[maybe_unused]] const openassetio::managerApi::HostSessionPtr& hostSession,
@@ -591,7 +607,7 @@ struct SimpleCppManagerInterface final : openassetio::managerApi::ManagerInterfa
    * non-stub) functionality. Capabilities can be toggled using the
    * "capabilities" key in @ref settings_.
    */
-  std::unordered_set<ManagerInterface::Capability> capabilities_{
+  std::unordered_set<Capability> capabilities_{
       Capability::kEntityReferenceIdentification, Capability::kManagementPolicyQueries,
       Capability::kEntityTraitIntrospection, Capability::kResolution};
 
@@ -625,6 +641,7 @@ struct SimpleCppManagerInterface final : openassetio::managerApi::ManagerInterfa
  */
 struct Plugin final : openassetio::pluginSystem::CppPluginSystemManagerPlugin {
   [[nodiscard]] openassetio::Identifier identifier() const override {
+    // NOLINTNEXTLINE(*-suspicious-stringview-data-usage)
     if (const char* envVar = std::getenv(kPluginIdEnvVar.data())) {
       return openassetio::Identifier{envVar};
     }

--- a/resources/build/bootstrap-ubuntu-22.04.sh
+++ b/resources/build/bootstrap-ubuntu-22.04.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# This bootstrap script is used by both the Github CI action.
+# This bootstrap script is used by the Github CI action.
 
 set -xeo pipefail
 sudo apt-get update
 # Install gcc, linters, build tools used by conan and Python 3.
-sudo apt-get install -y build-essential pkgconf clang-format-12 clang-tidy-12 python3-pip ccache
+sudo apt-get install -y build-essential pkgconf python3-pip ccache
 
 # Install additional build tools.
 pip3 install -r "$WORKSPACE/resources/build/requirements.txt"
@@ -23,8 +23,3 @@ conan config set general.revisions_enabled=True
 # Install openassetio third-party dependencies from public Conan Center
 # package repo.
 conan install --install-folder "$WORKSPACE/.conan" --build=missing "$WORKSPACE/resources/build"
-# Ensure we have the expected version of clang-* available
-sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-12 10
-sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-12 10
-sudo update-alternatives --set clang-tidy /usr/bin/clang-tidy-12
-sudo update-alternatives --set clang-format /usr/bin/clang-format-12

--- a/resources/build/linter-requirements.txt
+++ b/resources/build/linter-requirements.txt
@@ -1,4 +1,6 @@
 cpplint==1.5.5
+clang-tidy==19.1.0
+clang-format==19.1.6
 black==24.3.0
 pylint==2.17.6
 # For cmake-lint

--- a/resources/build/requirements.txt
+++ b/resources/build/requirements.txt
@@ -1,5 +1,5 @@
 conan==1.66.0
-cmake==3.28.3
+cmake==3.31.2
 ninja==1.10.2.3
 pip>=21.3
 pybind11-stubgen==2.5.1

--- a/src/openassetio-core-c/include/.clang-tidy
+++ b/src/openassetio-core-c/include/.clang-tidy
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2013-2022 The Foundry Visionmongers Ltd
+# Copyright 2013-2025 The Foundry Visionmongers Ltd
 
 InheritParentConfig: true
 
@@ -8,3 +8,4 @@ CheckOptions:
     # e.g. "oa_nameSpace_ClassName".
     - { key: readability-identifier-naming.FunctionPrefix,  value: oa_ }
     - { key: readability-identifier-naming.FunctionCase,  value: camel_Snake_Back }
+    - { key: readability-identifier-naming.FunctionIgnoredRegexp,  value: "oa_[a-z]+[A-Za-z0-9]*(_[A-Za-z0-9_]+)?" }

--- a/src/openassetio-core-c/include/openassetio/c/InfoDictionary.h
+++ b/src/openassetio-core-c/include/openassetio/c/InfoDictionary.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #pragma once
 
 #include <stdbool.h>  // NOLINT(modernize-deprecated-headers)
@@ -75,7 +75,7 @@ typedef struct oa_InfoDictionary_t* oa_InfoDictionary_h;
  * @see @fqcref{InfoDictionary_typeOf} "typeOf()"
  * @see @ref CppPrimitiveTypes "Primitive types"
  */
-// NOLINTNEXTLINE(modernize-use-using)
+// NOLINTNEXTLINE(modernize-use-using,performance-enum-size)
 typedef enum {
   /// Boolean value type
   oa_InfoDictionary_ValueType_kBool = 1,

--- a/src/openassetio-core-c/include/openassetio/c/StringView.h
+++ b/src/openassetio-core-c/include/openassetio/c/StringView.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #pragma once
 
 #include <stddef.h>  // NOLINT(modernize-deprecated-headers)
@@ -57,9 +57,9 @@ extern "C" {
 // NOLINTNEXTLINE(modernize-use-using)
 typedef struct {
   /// Immutable buffer storing the string data.
-  const char* const data;
+  const char* data;
   /// Number of bytes used for string storage in the buffer.
-  const size_t size;
+  size_t size;
 } oa_ConstStringView;
 
 /**
@@ -115,9 +115,9 @@ typedef struct {
 // NOLINTNEXTLINE(modernize-use-using)
 typedef struct {
   /// Number of bytes available for string storage in the buffer.
-  const size_t capacity;
+  size_t capacity;
   /// Writeable buffer storing the string data.
-  char* const data;
+  char* data;
   /// Number of bytes used for string storage in the buffer.
   size_t size;
 } oa_StringView;

--- a/src/openassetio-core-c/include/openassetio/c/errors.h
+++ b/src/openassetio-core-c/include/openassetio/c/errors.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #pragma once
 
 #include "./namespace.h"
@@ -36,7 +36,7 @@ extern "C" {
 /// @}
 // oa_ErrorCode_aliases
 
-// NOLINTNEXTLINE(modernize-use-using)
+// NOLINTNEXTLINE(modernize-use-using,performance-enum-size)
 typedef enum {
   /// Error code indicating an OK result from a C API function.
   oa_ErrorCode_kOK = 0,

--- a/src/openassetio-core-c/src/errors.hpp
+++ b/src/openassetio-core-c/src/errors.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2024 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #pragma once
 
 #include <openassetio/c/StringView.h>
@@ -57,7 +57,7 @@ void extractExceptionMessage(oa_StringView *err, const Exception &exc) {
  * @return Error code.
  */
 template <typename Fn>
-auto catchUnknownExceptionAsCode(oa_StringView *err, Fn &&callable) {
+auto catchUnknownExceptionAsCode(oa_StringView *err, const Fn &callable) {
   try {
     return callable();
   } catch (std::exception &exc) {

--- a/src/openassetio-core-c/src/hostApi/Manager.cpp
+++ b/src/openassetio-core-c/src/hostApi/Manager.cpp
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
-#include <stdexcept>
-
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <openassetio/c/InfoDictionary.h>
 #include <openassetio/c/StringView.h>
 #include <openassetio/c/errors.h>
 #include <openassetio/c/hostApi/Manager.h>
+#include <openassetio/c/managerApi/HostSession.h>
 #include <openassetio/c/managerApi/ManagerInterface.h>
-#include <openassetio/c/namespace.h>
-
+#include <openassetio/InfoDictionary.hpp>
 #include <openassetio/hostApi/Manager.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
@@ -19,7 +17,6 @@
 #include "../handles/hostApi/Manager.hpp"
 #include "../handles/managerApi/HostSession.hpp"
 #include "../handles/managerApi/ManagerInterface.hpp"
-#include "openassetio/c/managerApi/HostSession.h"
 
 namespace errors = openassetio::errors;
 namespace handles = openassetio::handles;

--- a/src/openassetio-core-c/src/managerApi/CManagerInterfaceAdapter.cpp
+++ b/src/openassetio-core-c/src/managerApi/CManagerInterfaceAdapter.cpp
@@ -1,12 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
-
-#include <stdexcept>
-#include <string>
-
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include "CManagerInterfaceAdapter.hpp"
 
+#include <cstddef>
+
+#include <openassetio/c/InfoDictionary.h>
+#include <openassetio/c/StringView.h>
+#include <openassetio/c/errors.h>
+#include <openassetio/c/managerApi/CManagerInterface.h>
+#include <openassetio/export.h>
+#include <openassetio/EntityReference.hpp>
+#include <openassetio/InfoDictionary.hpp>
+#include <openassetio/access.hpp>
 #include <openassetio/errors/exceptions.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/trait/collection.hpp>
+#include <openassetio/typedefs.hpp>
+
 #include "../errors.hpp"
 #include "../handles/InfoDictionary.hpp"
 
@@ -14,7 +24,7 @@ namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace managerApi {
 
-constexpr size_t kStringBufferSize = 500;
+constexpr std::size_t kStringBufferSize = 500;
 
 CManagerInterfaceAdapter::CManagerInterfaceAdapter(oa_managerApi_CManagerInterface_h handle,
                                                    oa_managerApi_CManagerInterface_s suite)
@@ -107,8 +117,8 @@ void CManagerInterfaceAdapter::entityExists(
     [[maybe_unused]] const EntityReferences& entityReferences,
     [[maybe_unused]] const ContextConstPtr& context,
     [[maybe_unused]] const HostSessionPtr& hostSession,
-    [[maybe_unused]] const ManagerInterface::ExistsSuccessCallback& successCallback,
-    [[maybe_unused]] const ManagerInterface::BatchElementErrorCallback& errorCallback) {
+    [[maybe_unused]] const ExistsSuccessCallback& successCallback,
+    [[maybe_unused]] const BatchElementErrorCallback& errorCallback) {
   throw errors::NotImplementedException{"Not implemented"};
 }
 
@@ -118,7 +128,7 @@ void CManagerInterfaceAdapter::resolve(
     [[maybe_unused]] const access::ResolveAccess resolveAccess,
     [[maybe_unused]] const ContextConstPtr& context,
     [[maybe_unused]] const HostSessionPtr& hostSession,
-    [[maybe_unused]] const ManagerInterface::ResolveSuccessCallback& successCallback,
+    [[maybe_unused]] const ResolveSuccessCallback& successCallback,
     [[maybe_unused]] const BatchElementErrorCallback& errorCallback) {
   throw errors::NotImplementedException{"Not implemented"};
 }

--- a/src/openassetio-core-c/tests/.clang-tidy
+++ b/src/openassetio-core-c/tests/.clang-tidy
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2013-2022 The Foundry Visionmongers Ltd
+# Copyright 2013-2025 The Foundry Visionmongers Ltd
 
 InheritParentConfig: true
 
 # -readability-function-cognitive-complexity
 #   Catch2 test macros trigger this.
-# -bugprone-infinite-loop
-#   clang-tidy v12 flags false positives for Catch2 CHECK macro.
-#   TODO(DF): Remove once clang-tidy version updated.
+#
+# -bugprone-chained-comparison:
+#   False positives from Catch2 CHECK macros.
 Checks: >
     -readability-function-cognitive-complexity,
-     -bugprone-infinite-loop,
+    -bugprone-chained-comparison,
 

--- a/src/openassetio-core-c/tests/StringViewTest.cpp
+++ b/src/openassetio-core-c/tests/StringViewTest.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <string_view>
-#include <type_traits>
 
 #include <openassetio/c/StringView.h>
 
@@ -28,7 +27,6 @@ SCENARIO("Creating, modifying and querying a C API mutable StringView") {
       }
 
       AND_WHEN("string is modified through the StringView") {
-        STATIC_REQUIRE(std::is_const_v<decltype(actualStringView.capacity)>);
         actualStringView.data[1] = '0';
         actualStringView.size = 4;
 
@@ -95,13 +93,6 @@ SCENARIO("Creating and querying a C API immutable ConstStringView") {
         CHECK(actualStringView.size == expectedStr.size());
         CHECK(actualStringView.data == expectedStr.data());
         CHECK(actualStringView == expectedStr);
-      }
-
-      THEN("string cannot be modified through the ConstStringView") {
-        STATIC_REQUIRE(std::is_const_v<decltype(actualStringView.data)>);
-        STATIC_REQUIRE(
-            std::is_const_v<std::remove_reference_t<decltype(actualStringView.data[0])>>);
-        STATIC_REQUIRE(std::is_const_v<decltype(actualStringView.size)>);
       }
     }
   }

--- a/src/openassetio-core-c/tests/errorsTest.cpp
+++ b/src/openassetio-core-c/tests/errorsTest.cpp
@@ -1,24 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
+#include <cstddef>
+#include <stdexcept>
+
 #include <openassetio/c/StringView.h>
 #include <openassetio/c/errors.h>
-#include <openassetio/c/namespace.h>
 
 #include <catch2/catch.hpp>
 
-// private headers
 #include <errors.hpp>
 
 #include "StringViewReporting.hpp"
+#include "openassetio/typedefs.hpp"
 
 SCENARIO("throwIfError error code/message handling") {
   using openassetio::errors::throwIfError;
 
   GIVEN("an OK error code") {
-    const oa_ErrorCode code = oa_ErrorCode_kOK;
+    constexpr oa_ErrorCode kCode = oa_ErrorCode_kOK;
 
     WHEN("throwIfError is called") {
-      THEN("no exception is thrown") { throwIfError(code, oa_StringView{}); }
+      THEN("no exception is thrown") { throwIfError(kCode, oa_StringView{}); }
     }
   }
 
@@ -76,7 +78,7 @@ SCENARIO("Decorating an exception-throwing C++ function to instead return an err
   oa_StringView actualErrorMessage{storage.size(), storage.data(), 0};
 
   GIVEN("A callable that doesn't throw") {
-    auto const callable = [&] { return oa_ErrorCode_kOK; };
+    const auto callable = [&] { return oa_ErrorCode_kOK; };
 
     WHEN("callable is executed whilst decorated") {
       const oa_ErrorCode actualErrorCode =
@@ -92,7 +94,7 @@ SCENARIO("Decorating an exception-throwing C++ function to instead return an err
   GIVEN("A callable that throws an exception") {
     const openassetio::Str expectedErrorMessage = "some error";
 
-    auto const callable = [&]() -> oa_ErrorCode { throw std::length_error{expectedErrorMessage}; };
+    const auto callable = [&]() -> oa_ErrorCode { throw std::length_error{expectedErrorMessage}; };
 
     WHEN("callable is executed whilst decorated") {
       const oa_ErrorCode actualErrorCode =
@@ -108,7 +110,7 @@ SCENARIO("Decorating an exception-throwing C++ function to instead return an err
   GIVEN("A callable that throws a non-exception") {
     const openassetio::Str expectedErrorMessage = "Unknown non-exception object thrown";
 
-    auto const callable = [&]() -> oa_ErrorCode { throw "some error"; };
+    const auto callable = [&]() -> oa_ErrorCode { throw "some error"; };
 
     WHEN("callable is executed whilst decorated") {
       const oa_ErrorCode actualErrorCode =

--- a/src/openassetio-core-c/tests/handlesTest.cpp
+++ b/src/openassetio-core-c/tests/handlesTest.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
+#include <string>
+#include <type_traits>
 
 #include <catch2/catch.hpp>
 

--- a/src/openassetio-core-c/tests/hostApi/ManagerTest.cpp
+++ b/src/openassetio-core-c/tests/hostApi/ManagerTest.cpp
@@ -1,14 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
+#include <cstddef>
+#include <memory>
+
+#include <openassetio/c/InfoDictionary.h>
+#include <openassetio/c/StringView.h>
 #include <openassetio/c/errors.h>
 #include <openassetio/c/hostApi/Manager.h>
 #include <openassetio/c/managerApi/HostSession.h>
 #include <openassetio/c/managerApi/ManagerInterface.h>
-#include <openassetio/c/namespace.h>
 
 #include <catch2/catch.hpp>
 #include <catch2/trompeloeil.hpp>
+#include <trompeloeil.hpp>
 
+#include <openassetio/InfoDictionary.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/hostApi/Manager.hpp>
 #include <openassetio/log/LoggerInterface.hpp>
@@ -33,7 +39,7 @@ using openassetio::log::LoggerInterface;
 using openassetio::log::LoggerInterfacePtr;
 
 namespace {
-constexpr size_t kStringBufferSize = 500;
+constexpr std::size_t kStringBufferSize = 500;
 /**
  * Mock implementation of a ManagerInterface.
  *

--- a/src/openassetio-core-c/tests/main.cpp
+++ b/src/openassetio-core-c/tests/main.cpp
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #define CATCH_CONFIG_MAIN
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>  // NOLINT(misc-include-cleaner)

--- a/src/openassetio-core-c/tests/managerApi/CManagerInterfaceAdapterTest.cpp
+++ b/src/openassetio-core-c/tests/managerApi/CManagerInterfaceAdapterTest.cpp
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
-#include <openassetio/c/InfoDictionary.h>
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
+#include <cstddef>
+#include <stdexcept>
+#include <string_view>
+
 #include <openassetio/c/errors.h>
-#include <openassetio/c/namespace.h>
+#include <openassetio/InfoDictionary.hpp>
+#include <openassetio/typedefs.hpp>
 
 #include <catch2/catch.hpp>
 #include <catch2/trompeloeil.hpp>
+#include <trompeloeil.hpp>
 
 // private headers
 #include <handles/InfoDictionary.hpp>
@@ -15,7 +20,7 @@
 
 namespace {
 // Duplicated from CManagerInterfaceAdapter.
-constexpr size_t kStringBufferSize = 500;
+constexpr std::size_t kStringBufferSize = 500;
 }  // namespace
 
 namespace handles = openassetio::handles;
@@ -28,7 +33,7 @@ SCENARIO("A CManagerInterfaceAdapter is destroyed") {
     MockCManagerInterfaceImpl mockImpl;
 
     auto *handle = MockCManagerInterfaceHandleConverter::toHandle(&mockImpl);
-    auto const suite = mockManagerInterfaceSuite();
+    const auto suite = mockManagerInterfaceSuite();
 
     THEN("CManagerInterfaceAdapter's destructor calls the suite's dtor") {
       REQUIRE_CALL(mockImpl, dtor(handle));
@@ -43,7 +48,7 @@ SCENARIO("A host calls CManagerInterfaceAdapter::identifier") {
     MockCManagerInterfaceImpl mockImpl;
 
     auto *handle = MockCManagerInterfaceHandleConverter::toHandle(&mockImpl);
-    auto const suite = mockManagerInterfaceSuite();
+    const auto suite = mockManagerInterfaceSuite();
 
     // Expect the destructor to be called, i.e. when cManagerInterface
     // goes out of scope.
@@ -54,7 +59,7 @@ SCENARIO("A host calls CManagerInterfaceAdapter::identifier") {
     const openassetio::managerApi::CManagerInterfaceAdapter cManagerInterface{handle, suite};
 
     AND_GIVEN("the C suite's identifier() call succeeds") {
-      const std::string_view expectedIdentifier = "my.id";
+      constexpr std::string_view kExpectedIdentifier = "my.id";
 
       using trompeloeil::_;
 
@@ -64,8 +69,8 @@ SCENARIO("A host calls CManagerInterfaceAdapter::identifier") {
           // Ensure max size is reasonable.
           .LR_WITH(_2->capacity == kStringBufferSize)
           // Update StringView out-parameter.
-          .LR_SIDE_EFFECT(strncpy(_2->data, expectedIdentifier.data(), expectedIdentifier.size()))
-          .LR_SIDE_EFFECT(_2->size = expectedIdentifier.size())
+          .LR_SIDE_EFFECT(memcpy(_2->data, kExpectedIdentifier.data(), kExpectedIdentifier.size()))
+          .LR_SIDE_EFFECT(_2->size = kExpectedIdentifier.size())
           // Return OK code.
           .RETURN(oa_ErrorCode_kOK);
 
@@ -73,14 +78,14 @@ SCENARIO("A host calls CManagerInterfaceAdapter::identifier") {
         const openassetio::Identifier actualIdentifier = cManagerInterface.identifier();
 
         THEN("the returned identifier matches expected identifier") {
-          CHECK(actualIdentifier == expectedIdentifier);
+          CHECK(actualIdentifier == kExpectedIdentifier);
         }
       }
     }
 
     AND_GIVEN("the C suite's identifier() call fails") {
-      const std::string_view expectedErrorMsg = "some error happened";
-      const auto expectedErrorCode = oa_ErrorCode_kUnknown;
+      constexpr std::string_view kExpectedErrorMsg = "some error happened";
+      constexpr auto kExpectedErrorCode = oa_ErrorCode_kUnknown;
       const openassetio::Str expectedErrorCodeAndMsg = "1: some error happened";
 
       using trompeloeil::_;
@@ -91,10 +96,10 @@ SCENARIO("A host calls CManagerInterfaceAdapter::identifier") {
           // Ensure max size is reasonable.
           .LR_WITH(_1->capacity == kStringBufferSize)
           // Update StringView error message out-parameter.
-          .LR_SIDE_EFFECT(strncpy(_1->data, expectedErrorMsg.data(), expectedErrorMsg.size()))
-          .LR_SIDE_EFFECT(_1->size = expectedErrorMsg.size())
+          .LR_SIDE_EFFECT(memcpy(_1->data, kExpectedErrorMsg.data(), kExpectedErrorMsg.size()))
+          .LR_SIDE_EFFECT(_1->size = kExpectedErrorMsg.size())
           // Return OK code.
-          .RETURN(expectedErrorCode);
+          .RETURN(kExpectedErrorCode);
 
       WHEN("the manager's identifier is queried") {
         THEN("an exception is thrown with expected error message") {
@@ -111,7 +116,7 @@ SCENARIO("A host calls CManagerInterfaceAdapter::displayName") {
     MockCManagerInterfaceImpl mockImpl;
 
     auto *handle = MockCManagerInterfaceHandleConverter::toHandle(&mockImpl);
-    auto const suite = mockManagerInterfaceSuite();
+    const auto suite = mockManagerInterfaceSuite();
 
     // Expect the destructor to be called, i.e. when cManagerInterface
     // goes out of scope.
@@ -120,7 +125,7 @@ SCENARIO("A host calls CManagerInterfaceAdapter::displayName") {
     const openassetio::managerApi::CManagerInterfaceAdapter cManagerInterface{handle, suite};
 
     AND_GIVEN("the C suite's displayName() call succeeds") {
-      const std::string_view expectedDisplayName = "My Display Name";
+      constexpr std::string_view kExpectedDisplayName = "My Display Name";
 
       using trompeloeil::_;
 
@@ -131,8 +136,8 @@ SCENARIO("A host calls CManagerInterfaceAdapter::displayName") {
           .LR_WITH(_2->capacity == kStringBufferSize)
           // Update StringView out-parameter.
           .LR_SIDE_EFFECT(
-              strncpy(_2->data, expectedDisplayName.data(), expectedDisplayName.size()))
-          .LR_SIDE_EFFECT(_2->size = expectedDisplayName.size())
+              memcpy(_2->data, kExpectedDisplayName.data(), kExpectedDisplayName.size()))
+          .LR_SIDE_EFFECT(_2->size = kExpectedDisplayName.size())
           // Return OK code.
           .RETURN(oa_ErrorCode_kOK);
 
@@ -140,14 +145,14 @@ SCENARIO("A host calls CManagerInterfaceAdapter::displayName") {
         const openassetio::Str actualDisplayName = cManagerInterface.displayName();
 
         THEN("the returned displayName matches expected displayName") {
-          CHECK(actualDisplayName == expectedDisplayName);
+          CHECK(actualDisplayName == kExpectedDisplayName);
         }
       }
     }
 
     AND_GIVEN("the C suite's displayName() call fails") {
-      const std::string_view expectedErrorMsg = "some error happened";
-      const auto expectedErrorCode = oa_ErrorCode_kUnknown;
+      constexpr std::string_view kExpectedErrorMsg = "some error happened";
+      constexpr auto kExpectedErrorCode = oa_ErrorCode_kUnknown;
       const openassetio::Str expectedErrorCodeAndMsg = "1: some error happened";
 
       using trompeloeil::_;
@@ -158,10 +163,10 @@ SCENARIO("A host calls CManagerInterfaceAdapter::displayName") {
           // Ensure max size is reasonable.
           .LR_WITH(_1->capacity == kStringBufferSize)
           // Update StringView error message out-parameter.
-          .LR_SIDE_EFFECT(strncpy(_1->data, expectedErrorMsg.data(), expectedErrorMsg.size()))
-          .LR_SIDE_EFFECT(_1->size = expectedErrorMsg.size())
+          .LR_SIDE_EFFECT(memcpy(_1->data, kExpectedErrorMsg.data(), kExpectedErrorMsg.size()))
+          .LR_SIDE_EFFECT(_1->size = kExpectedErrorMsg.size())
           // Return OK code.
-          .RETURN(expectedErrorCode);
+          .RETURN(kExpectedErrorCode);
 
       WHEN("the manager's displayName is queried") {
         THEN("an exception is thrown with expected error message") {
@@ -178,7 +183,7 @@ SCENARIO("A host calls CManagerInterfaceAdapter::info") {
     MockCManagerInterfaceImpl mockImpl;
 
     auto *handle = MockCManagerInterfaceHandleConverter::toHandle(&mockImpl);
-    auto const suite = mockManagerInterfaceSuite();
+    const auto suite = mockManagerInterfaceSuite();
 
     // Expect the destructor to be called, i.e. when cManagerInterface
     // goes out of scope.
@@ -188,14 +193,14 @@ SCENARIO("A host calls CManagerInterfaceAdapter::info") {
 
     AND_GIVEN("the C suite's info() call succeeds") {
       const openassetio::Str expectedInfoKey = "info key";
-      const openassetio::Float expectedInfoValue = 123.456;
+      constexpr openassetio::Float kExpectedInfoValue = 123.456;
 
       using trompeloeil::_;
 
       REQUIRE_CALL(mockImpl, info(_, _, handle))
           // Update out-parameter.
           .LR_SIDE_EFFECT(handles::InfoDictionary::toInstance(_2)->insert(
-              {expectedInfoKey, expectedInfoValue}))
+              {expectedInfoKey, kExpectedInfoValue}))
           // Return OK code.
           .RETURN(oa_ErrorCode_kOK);
 
@@ -204,14 +209,14 @@ SCENARIO("A host calls CManagerInterfaceAdapter::info") {
 
         THEN("the returned info contains the expected entry") {
           const auto actualInfoValue = std::get<openassetio::Float>(infoDict.at(expectedInfoKey));
-          CHECK(actualInfoValue == expectedInfoValue);
+          CHECK(actualInfoValue == kExpectedInfoValue);
         }
       }
     }
 
     AND_GIVEN("the C suite's info() call fails") {
-      const std::string_view expectedErrorMsg = "some error happened";
-      const auto expectedErrorCode = oa_ErrorCode_kUnknown;
+      constexpr std::string_view kExpectedErrorMsg = "some error happened";
+      constexpr auto kExpectedErrorCode = oa_ErrorCode_kUnknown;
       const openassetio::Str expectedErrorCodeAndMsg = "1: some error happened";
 
       using trompeloeil::_;
@@ -222,10 +227,10 @@ SCENARIO("A host calls CManagerInterfaceAdapter::info") {
           // Ensure max size is reasonable.
           .LR_WITH(_1->capacity == kStringBufferSize)
           // Update StringView error message out-parameter.
-          .LR_SIDE_EFFECT(strncpy(_1->data, expectedErrorMsg.data(), expectedErrorMsg.size()))
-          .LR_SIDE_EFFECT(_1->size = expectedErrorMsg.size())
+          .LR_SIDE_EFFECT(memcpy(_1->data, kExpectedErrorMsg.data(), kExpectedErrorMsg.size()))
+          .LR_SIDE_EFFECT(_1->size = kExpectedErrorMsg.size())
           // Return OK code.
-          .RETURN(expectedErrorCode);
+          .RETURN(kExpectedErrorCode);
 
       WHEN("the manager's info is queried") {
         THEN("an exception is thrown with expected error message") {

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -134,6 +134,8 @@ set(_define_version
 
 # Use CMake utility to generate the export header.
 include(GenerateExportHeader)
+# Note: CMake>=3.30 recommended, since it adds Clang-Tidy linter
+# suppressions to the generated file.
 generate_export_header(
     openassetio-core
     EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/openassetio/export.h

--- a/src/openassetio-core/include/openassetio/access.hpp
+++ b/src/openassetio-core/include/openassetio/access.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
 
 #include <array>
@@ -29,6 +29,7 @@ namespace access {
  * functionality is supported by a manager, these constants largely
  * mirror those for the relevant API methods.
  */
+// NOLINTNEXTLINE(performance-enum-size): requires binary breaking change
 enum class PolicyAccess : std::underlying_type_t<internal::access::Access> {
   /**
    * Host intends to read data.
@@ -93,6 +94,7 @@ enum class PolicyAccess : std::underlying_type_t<internal::access::Access> {
 /**
  * Access pattern for @ref glossary_resolve "entity resolution".
  */
+// NOLINTNEXTLINE(performance-enum-size): requires binary breaking change
 enum class ResolveAccess : std::underlying_type_t<internal::access::Access> {
   /**
    * Used to query an existing entity for information.
@@ -115,6 +117,7 @@ enum class ResolveAccess : std::underlying_type_t<internal::access::Access> {
 /**
  * Access pattern for entity trait set queries.
  */
+// NOLINTNEXTLINE(performance-enum-size): requires binary breaking change
 enum class EntityTraitsAccess : std::underlying_type_t<internal::access::Access> {
   /**
    * Used to query the full trait set of an existing entity.
@@ -136,6 +139,7 @@ enum class EntityTraitsAccess : std::underlying_type_t<internal::access::Access>
 /**
  * Access pattern for @ref publish "publishing".
  */
+// NOLINTNEXTLINE(performance-enum-size): requires binary breaking change
 enum class PublishingAccess : std::underlying_type_t<internal::access::Access> {
   /**
    * Used whenever the entity reference explicitly targets the specific
@@ -168,6 +172,7 @@ enum class PublishingAccess : std::underlying_type_t<internal::access::Access> {
  * @fqref{managerApi.ManagerInterface.getWithRelationship}
  * "ManagerInterface.getWithRelationship" (and similar).
  */
+// NOLINTNEXTLINE(performance-enum-size): requires binary breaking change
 enum class RelationsAccess : std::underlying_type_t<internal::access::Access> {
   /**
    * Used to retrieve references to pre-existing related entities.
@@ -211,6 +216,7 @@ enum class RelationsAccess : std::underlying_type_t<internal::access::Access> {
  * @fqref{managerApi.ManagerInterface.defaultEntityReference}
  * "ManagerInterface.defaultEntityReference",
  */
+// NOLINTNEXTLINE(performance-enum-size): requires binary breaking change
 enum class DefaultEntityAccess : std::underlying_type_t<internal::access::Access> {
   /**
    * Indicate that the @ref manager should provide an entity reference

--- a/src/openassetio-core/include/openassetio/constants.hpp
+++ b/src/openassetio-core/include/openassetio/constants.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
 /**
  * @file
@@ -28,6 +28,7 @@ namespace constants {
 
 // General
 
+// NOLINTBEGIN(readability-identifier-naming): requires source breaking change.
 inline constexpr std::string_view kInfoKey_SmallIcon = "smallIcon";
 inline constexpr std::string_view kInfoKey_Icon = "icon";
 
@@ -44,6 +45,7 @@ inline constexpr std::string_view kInfoKey_Icon = "icon";
 inline constexpr std::string_view kInfoKey_EntityReferencesMatchPrefix =
     "entityReferencesMatchPrefix";
 
+// NOLINTEND(readability-identifier-naming)
 /// @}
 }  // namespace constants
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-core/include/openassetio/errors/BatchElementError.hpp
+++ b/src/openassetio-core/include/openassetio/errors/BatchElementError.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
 #pragma once
 
 #include <type_traits>
@@ -46,6 +46,7 @@ namespace errors {
 class BatchElementError final {
  public:
   /// Possible classes of error.
+  // NOLINTNEXTLINE(performance-enum-size): requires binary breaking change
   enum class ErrorCode {
     /// Fallback for uncommon errors.
     kUnknown = internal::errors::kBatchElementUnknownError,

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2024 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -121,6 +122,7 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * introspection mechanism @ref hasCapability to provide a means of
    * querying which sets of methods the manager provides.
    */
+  // NOLINTNEXTLINE(performance-enum-size): requires binary breaking change
   enum class Capability : std::underlying_type_t<internal::capability::manager::Capability> {
     /**
      * Manager makes use of the context to persist custom state for

--- a/src/openassetio-core/include/openassetio/hostApi/ManagerFactory.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/ManagerFactory.hpp
@@ -283,9 +283,9 @@ class OPENASSETIO_CORE_EXPORT ManagerFactory final {
                  ManagerImplementationFactoryInterfacePtr managerImplementationFactory,
                  log::LoggerInterfacePtr logger);
 
-  const HostInterfacePtr hostInterface_;
-  const ManagerImplementationFactoryInterfacePtr managerImplementationFactory_;
-  const log::LoggerInterfacePtr logger_;
+  HostInterfacePtr hostInterface_;
+  ManagerImplementationFactoryInterfacePtr managerImplementationFactory_;
+  log::LoggerInterfacePtr logger_;
 };
 
 }  // namespace hostApi

--- a/src/openassetio-core/include/openassetio/internal.hpp
+++ b/src/openassetio-core/include/openassetio/internal.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -16,6 +16,7 @@ namespace access {
  * simplifies serialisation, and supports language (especially C)
  * bindings.
  */
+// NOLINTNEXTLINE(performance-enum-size): requires binary breaking change
 enum Access : std::size_t { kRead = 0, kWrite, kCreateRelated, kRequired, kManagerDriven };
 }  // namespace access
 
@@ -25,6 +26,7 @@ namespace errors {
  *
  * The enum values must be kept in sync with the C API.
  */
+// NOLINTNEXTLINE(performance-enum-size): requires binary breaking change
 enum ErrorCode : std::size_t {
   // 0-127 is reserved for C API error codes.
   kBatchElementUnknownError = 128,
@@ -47,6 +49,7 @@ namespace capability::manager {
  * comparison, string lookup, simplifies serialisation, and supports
  * language (especially C) bindings.
  */
+// NOLINTNEXTLINE(performance-enum-size): requires binary breaking change
 enum Capability : std::size_t {
   kEntityReferenceIdentification = 0,
   kManagementPolicyQueries,

--- a/src/openassetio-core/include/openassetio/log/LoggerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/log/LoggerInterface.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2024 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <array>
 
 #include <openassetio/export.h>
@@ -37,6 +37,7 @@ class OPENASSETIO_CORE_EXPORT LoggerInterface {
    * @name Log Severity
    * @{
    */
+  // NOLINTNEXTLINE(performance-enum-size): requires binary breaking change
   enum class Severity { kDebugApi, kDebug, kInfo, kProgress, kWarning, kError, kCritical };
 
   static constexpr std::array kSeverityNames{"debugApi", "debug", "info",    "progress",

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2024 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 
 #pragma once
 
@@ -241,6 +241,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * These capabilities are used by both the host and the middleware to
    * adapt their behaviour.
    */
+  // NOLINTNEXTLINE(performance-enum-size): requires binary breaking change
   enum class Capability : std::underlying_type_t<internal::capability::manager::Capability> {
     /**
      * Manager can inform the host whether a given string matches the

--- a/src/openassetio-core/include/openassetio/trait/property.hpp
+++ b/src/openassetio-core/include/openassetio/trait/property.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2024 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 /**
  * Typedefs for the trait property data stored within specifications.
  */
@@ -64,6 +64,7 @@ using KeySet = std::unordered_set<Key>;
 using TraitId = property::Key;
 
 /// Status of a trait property within a specification.
+// NOLINTNEXTLINE(performance-enum-size): requires binary breaking change
 enum class TraitPropertyStatus { kFound, kMissing, kInvalidValue };
 }  // namespace trait
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-core/src/Context.cpp
+++ b/src/openassetio-core/src/Context.cpp
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
+#include <memory>
+#include <utility>
+
+#include <openassetio/export.h>
 #include <openassetio/Context.hpp>
+#include <openassetio/trait/TraitsData.hpp>
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {

--- a/src/openassetio-core/src/errors/exceptionMessages.cpp
+++ b/src/openassetio-core/src/errors/exceptionMessages.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 
 #include "exceptionMessages.hpp"
 
@@ -9,9 +9,12 @@
 
 #include <fmt/core.h>
 
+#include <openassetio/export.h>
 #include <openassetio/EntityReference.hpp>
 #include <openassetio/access.hpp>
 #include <openassetio/errors/BatchElementError.hpp>
+#include <openassetio/internal.hpp>
+#include <openassetio/trait/collection.hpp>
 #include <openassetio/typedefs.hpp>
 
 #include "../utils/formatter.hpp"
@@ -45,7 +48,7 @@ Str errorCodeName(BatchElementError::ErrorCode code) {
   return "Unknown ErrorCode";
 }
 
-Str createBatchElementExceptionMessage(const BatchElementError& err, size_t index,
+Str createBatchElementExceptionMessage(const BatchElementError& err, std::size_t index,
                                        const std::optional<internal::access::Access> access,
                                        const std::optional<EntityReference>& entityReference,
                                        const std::optional<trait::TraitSet>& traitSet) {

--- a/src/openassetio-core/src/hostApi/EntityReferencePager.cpp
+++ b/src/openassetio-core/src/hostApi/EntityReferencePager.cpp
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2023 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
+#include <exception>
+#include <utility>
 
-#include <openassetio/EntityReference.hpp>
+#include <openassetio/export.h>
 #include <openassetio/hostApi/EntityReferencePager.hpp>
-#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/log/LoggerInterface.hpp>  // NOLINT(*-include-cleaner): needed for logger()
 #include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 
@@ -11,7 +13,7 @@ namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace hostApi {
 
-typename EntityReferencePager::Ptr EntityReferencePager::make(
+EntityReferencePager::Ptr EntityReferencePager::make(
     managerApi::EntityReferencePagerInterfacePtr pagerInterface,
     managerApi::HostSessionPtr hostSession) {
   return EntityReferencePager::Ptr{
@@ -36,7 +38,7 @@ EntityReferencePager::~EntityReferencePager() {
 
 bool EntityReferencePager::hasNext() { return pagerInterface_->hasNext(hostSession_); }
 
-typename EntityReferencePager::Page EntityReferencePager::get() {
+EntityReferencePager::Page EntityReferencePager::get() {
   return pagerInterface_->get(hostSession_);
 }
 

--- a/src/openassetio-core/src/hostApi/HostInterface.cpp
+++ b/src/openassetio-core/src/hostApi/HostInterface.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
+#include <openassetio/export.h>
+#include <openassetio/InfoDictionary.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
-#include <openassetio/typedefs.hpp>
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {

--- a/src/openassetio-core/src/hostApi/Manager.cpp
+++ b/src/openassetio-core/src/hostApi/Manager.cpp
@@ -1,22 +1,31 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2024 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
+#include <fmt/core.h>
 #include <fmt/format.h>
 
+#include <openassetio/export.h>
 #include <openassetio/Context.hpp>
+#include <openassetio/EntityReference.hpp>
+#include <openassetio/InfoDictionary.hpp>
+#include <openassetio/access.hpp>
 #include <openassetio/constants.hpp>
 #include <openassetio/errors/exceptions.hpp>
 #include <openassetio/hostApi/EntityReferencePager.hpp>
 #include <openassetio/hostApi/Manager.hpp>
 #include <openassetio/log/LoggerInterface.hpp>
-#include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/trait/TraitsData.hpp>
+#include <openassetio/trait/collection.hpp>
 #include <openassetio/typedefs.hpp>
 
 namespace openassetio {
@@ -44,7 +53,7 @@ void verifyRequiredCapabilities(const managerApi::ManagerInterfacePtr &interface
   for (const ManagerInterface::Capability capability : kRequiredCapabilities) {
     if (!interface->hasCapability(capability)) {
       missingCapabilities.emplace_back(
-          ManagerInterface::kCapabilityNames[static_cast<size_t>(capability)]);
+          ManagerInterface::kCapabilityNames[static_cast<std::size_t>(capability)]);
     }
   }
 
@@ -53,8 +62,8 @@ void verifyRequiredCapabilities(const managerApi::ManagerInterfacePtr &interface
   }
 
   const std::string msg =
-      fmt::format("Manager implementation for '{}' does not support the required capabilities: {}",
-                  interface->identifier(), fmt::join(missingCapabilities, ", "));
+      format("Manager implementation for '{}' does not support the required capabilities: {}",
+             interface->identifier(), fmt::join(missingCapabilities, ", "));
 
   throw errors::ConfigurationException(msg);
 }
@@ -66,9 +75,9 @@ void verifyRequiredCapabilities(const managerApi::ManagerInterfacePtr &interface
 std::optional<Str> entityReferencePrefixFromInfo(const log::LoggerInterfacePtr &logger,
                                                  const InfoDictionary &info) {
   // Check if the info dict has the prefix key.
-  if (auto iter = info.find(Str{constants::kInfoKey_EntityReferencesMatchPrefix});
+  if (const auto iter = info.find(Str{constants::kInfoKey_EntityReferencesMatchPrefix});
       iter != info.end()) {
-    if (const auto *prefixPtr = std::get_if<openassetio::Str>(&iter->second)) {
+    if (const auto *prefixPtr = std::get_if<Str>(&iter->second)) {
       logger->debugApi(
           fmt::format("Entity reference prefix '{}' provided by manager's info() dict. Subsequent"
                       " calls to isEntityReferenceString will use this prefix rather than call the"
@@ -234,8 +243,8 @@ void Manager::getWithRelationship(const EntityReferences &entityReferences,
                                   const trait::TraitsDataPtr &relationshipTraitsData,
                                   size_t pageSize, const access::RelationsAccess relationsAccess,
                                   const ContextConstPtr &context,
-                                  const Manager::RelationshipQuerySuccessCallback &successCallback,
-                                  const Manager::BatchElementErrorCallback &errorCallback,
+                                  const RelationshipQuerySuccessCallback &successCallback,
+                                  const BatchElementErrorCallback &errorCallback,
                                   const trait::TraitSet &resultTraitSet) {
   if (pageSize == 0) {
     throw errors::InputValidationException{"pageSize must be greater than zero."};
@@ -317,8 +326,8 @@ void Manager::register_(const EntityReferences &entityReferences,
     message += " traits datas.";
     throw errors::InputValidationException{message};
   }
-  return managerInterface_->register_(entityReferences, entityTraitsDatas, publishingAccess,
-                                      context, hostSession_, successCallback, errorCallback);
+  managerInterface_->register_(entityReferences, entityTraitsDatas, publishingAccess, context,
+                               hostSession_, successCallback, errorCallback);
 }
 
 }  // namespace hostApi

--- a/src/openassetio-core/src/hostApi/ManagerConveniences.cpp
+++ b/src/openassetio-core/src/hostApi/ManagerConveniences.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #include <cstddef>
 #include <optional>
 #include <stdexcept>
@@ -15,11 +15,11 @@
 #include <openassetio/access.hpp>
 #include <openassetio/errors/BatchElementError.hpp>
 #include <openassetio/errors/exceptions.hpp>
+#include <openassetio/hostApi/EntityReferencePager.hpp>
 #include <openassetio/hostApi/Manager.hpp>
 #include <openassetio/internal.hpp>
 #include <openassetio/trait/TraitsData.hpp>
 #include <openassetio/trait/collection.hpp>
-#include <openassetio/typedefs.hpp>
 
 #include "../errors/exceptionMessages.hpp"
 

--- a/src/openassetio-core/src/hostApi/ManagerFactory.cpp
+++ b/src/openassetio-core/src/hostApi/ManagerFactory.cpp
@@ -1,22 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
+#include <openassetio/hostApi/ManagerFactory.hpp>
+
 #include <cstdlib>
+#include <exception>
 #include <filesystem>
+#include <string>
 #include <string_view>
+#include <utility>
 
 #include <toml++/toml.h>
 
+#include <openassetio/export.h>
+#include <openassetio/InfoDictionary.hpp>
 #include <openassetio/errors/exceptions.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/hostApi/Manager.hpp>
-#include <openassetio/hostApi/ManagerFactory.hpp>
 #include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
 #include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/managerApi/Host.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/typedefs.hpp>
-#include "openassetio/InfoDictionary.hpp"
 
 namespace {
 constexpr std::string_view kConfigDirVar = "${config_dir}";
@@ -32,7 +37,7 @@ ManagerFactoryPtr ManagerFactory::make(
     HostInterfacePtr hostInterface,
     ManagerImplementationFactoryInterfacePtr managerImplementationFactory,
     log::LoggerInterfacePtr logger) {
-  return openassetio::hostApi::ManagerFactoryPtr{new ManagerFactory{
+  return ManagerFactoryPtr{new ManagerFactory{
       std::move(hostInterface), std::move(managerImplementationFactory), std::move(logger)}};
 }
 
@@ -183,7 +188,7 @@ ManagerPtr ManagerFactory::defaultManagerForInterface(
   const managerApi::HostSessionPtr hostSession =
       managerApi::HostSession::make(managerApi::Host::make(hostInterface), logger);
 
-  ManagerPtr manager = Manager::make(
+  const ManagerPtr manager = Manager::make(
       managerImplementationFactory->instantiate(Identifier(identifier)), hostSession);
 
   manager->initialize(settings);

--- a/src/openassetio-core/src/hostApi/ManagerImplementationFactoryInterface.cpp
+++ b/src/openassetio-core/src/hostApi/ManagerImplementationFactoryInterface.cpp
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2024 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
+#include <utility>
+
+#include <openassetio/export.h>
 #include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
 
 namespace openassetio {

--- a/src/openassetio-core/src/log/ConsoleLogger.cpp
+++ b/src/openassetio-core/src/log/ConsoleLogger.cpp
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
 #include <array>
 #include <cstddef>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 
+#include <openassetio/export.h>
 #include <openassetio/log/ConsoleLogger.hpp>
 #include <openassetio/typedefs.hpp>
 

--- a/src/openassetio-core/src/log/LoggerInterface.cpp
+++ b/src/openassetio-core/src/log/LoggerInterface.cpp
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
-#include <iomanip>
-#include <sstream>
-
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
 #include <openassetio/log/LoggerInterface.hpp>
+
+#include <openassetio/export.h>
+#include <openassetio/typedefs.hpp>
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace log {
 LoggerInterface::~LoggerInterface() = default;
 
-bool LoggerInterface::isSeverityLogged([[maybe_unused]] LoggerInterface::Severity severity) const {
+bool LoggerInterface::isSeverityLogged([[maybe_unused]] const Severity severity) const {
   return true;
 }
 

--- a/src/openassetio-core/src/log/SeverityFilter.cpp
+++ b/src/openassetio-core/src/log/SeverityFilter.cpp
@@ -1,9 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
-#include <cstdlib>
-#include <iostream>
-
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
 #include <openassetio/log/SeverityFilter.hpp>
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <openassetio/export.h>
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/typedefs.hpp>
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -31,20 +37,20 @@ SeverityFilter::SeverityFilter(LoggerInterfacePtr upstreamLogger)
   }
 }
 
-void SeverityFilter::log(Severity severity, const Str& message) {
+void SeverityFilter::log(const Severity severity, const Str& message) {
   if (severity < minSeverity_ || !upstreamLogger_->isSeverityLogged(severity)) {
     return;
   }
   upstreamLogger_->log(severity, message);
 }
 
-void SeverityFilter::setSeverity(LoggerInterface::Severity severity) { minSeverity_ = severity; }
+void SeverityFilter::setSeverity(const Severity severity) { minSeverity_ = severity; }
 
 LoggerInterface::Severity SeverityFilter::getSeverity() const { return minSeverity_; }
 
 LoggerInterfacePtr SeverityFilter::upstreamLogger() const { return upstreamLogger_; }
 
-bool SeverityFilter::isSeverityLogged(LoggerInterface::Severity severity) const {
+bool SeverityFilter::isSeverityLogged(const Severity severity) const {
   return severity >= minSeverity_ && upstreamLogger_->isSeverityLogged(severity);
 }
 }  // namespace log

--- a/src/openassetio-core/src/managerApi/EntityReferencePagerInterface.cpp
+++ b/src/openassetio-core/src/managerApi/EntityReferencePagerInterface.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2023 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
+#include <openassetio/export.h>
 #include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 
 namespace openassetio {

--- a/src/openassetio-core/src/managerApi/Host.cpp
+++ b/src/openassetio-core/src/managerApi/Host.cpp
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
+#include <memory>
+#include <utility>
+
+#include <openassetio/export.h>
+#include <openassetio/InfoDictionary.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/managerApi/Host.hpp>
 #include <openassetio/typedefs.hpp>

--- a/src/openassetio-core/src/managerApi/HostSession.cpp
+++ b/src/openassetio-core/src/managerApi/HostSession.cpp
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <openassetio/managerApi/HostSession.hpp>
+
+#include <memory>
+#include <utility>
+
+#include <openassetio/export.h>
 
 #include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/managerApi/Host.hpp>

--- a/src/openassetio-core/src/managerApi/ManagerInterface.cpp
+++ b/src/openassetio-core/src/managerApi/ManagerInterface.cpp
@@ -1,14 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2023 The Foundry Visionmongers Ltd
-#include <stdexcept>
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
+#include <cstddef>
+#include <utility>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
+#include <openassetio/export.h>
+#include <openassetio/EntityReference.hpp>
+#include <openassetio/InfoDictionary.hpp>
+#include <openassetio/access.hpp>
 #include <openassetio/errors/exceptions.hpp>
 #include <openassetio/hostApi/EntityReferencePager.hpp>
 #include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/trait/TraitsData.hpp>
+#include <openassetio/trait/collection.hpp>
+#include <openassetio/typedefs.hpp>
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -20,7 +27,7 @@ ManagerInterface::ManagerInterface() = default;
   fmt::format(                                                                                    \
       "The '{}' method has not been implemented by the manager. Check manager capability for {} " \
       "by calling `manager.hasCapability`.",                                                      \
-      __func__, ManagerInterface::kCapabilityNames[static_cast<size_t>(capability)])
+      __func__, ManagerInterface::kCapabilityNames[static_cast<std::size_t>(capability)])
 
 InfoDictionary ManagerInterface::info() { return {}; }
 
@@ -42,7 +49,7 @@ StrMap ManagerInterface::updateTerminology([[maybe_unused]] StrMap terms,
 }
 
 InfoDictionary ManagerInterface::settings([[maybe_unused]] const HostSessionPtr& hostSession) {
-  return openassetio::InfoDictionary{};
+  return InfoDictionary{};
 }
 
 void ManagerInterface::flushCaches([[maybe_unused]] const HostSessionPtr& hostSession) {}
@@ -60,8 +67,8 @@ void ManagerInterface::entityExists(
     [[maybe_unused]] const EntityReferences& entityReferences,
     [[maybe_unused]] const ContextConstPtr& context,
     [[maybe_unused]] const HostSessionPtr& hostSession,
-    [[maybe_unused]] const ManagerInterface::ExistsSuccessCallback& successCallback,
-    [[maybe_unused]] const ManagerInterface::BatchElementErrorCallback& errorCallback) {
+    [[maybe_unused]] const ExistsSuccessCallback& successCallback,
+    [[maybe_unused]] const BatchElementErrorCallback& errorCallback) {
   throw errors::NotImplementedException{
       UNIMPLEMENTED_ERROR(ManagerInterface::Capability::kExistenceQueries)};
 }
@@ -71,20 +78,19 @@ void ManagerInterface::entityTraits(
     [[maybe_unused]] const access::EntityTraitsAccess entityTraitsAccess,
     [[maybe_unused]] const ContextConstPtr& context,
     [[maybe_unused]] const HostSessionPtr& hostSession,
-    [[maybe_unused]] const ManagerInterface::EntityTraitsSuccessCallback& successCallback,
-    [[maybe_unused]] const ManagerInterface::BatchElementErrorCallback& errorCallback) {
+    [[maybe_unused]] const EntityTraitsSuccessCallback& successCallback,
+    [[maybe_unused]] const BatchElementErrorCallback& errorCallback) {
   throw errors::NotImplementedException{
       UNIMPLEMENTED_ERROR(ManagerInterface::Capability::kEntityTraitIntrospection)};
 }
 
-void ManagerInterface::resolve(
-    [[maybe_unused]] const EntityReferences& entityReferences,
-    [[maybe_unused]] const trait::TraitSet& traitSet,
-    [[maybe_unused]] access::ResolveAccess resolveAccess,
-    [[maybe_unused]] const ContextConstPtr& context,
-    [[maybe_unused]] const HostSessionPtr& hostSession,
-    [[maybe_unused]] const ManagerInterface::ResolveSuccessCallback& successCallback,
-    [[maybe_unused]] const ManagerInterface::BatchElementErrorCallback& errorCallback) {
+void ManagerInterface::resolve([[maybe_unused]] const EntityReferences& entityReferences,
+                               [[maybe_unused]] const trait::TraitSet& traitSet,
+                               [[maybe_unused]] access::ResolveAccess resolveAccess,
+                               [[maybe_unused]] const ContextConstPtr& context,
+                               [[maybe_unused]] const HostSessionPtr& hostSession,
+                               [[maybe_unused]] const ResolveSuccessCallback& successCallback,
+                               [[maybe_unused]] const BatchElementErrorCallback& errorCallback) {
   throw errors::NotImplementedException{
       UNIMPLEMENTED_ERROR(ManagerInterface::Capability::kResolution)};
 }
@@ -165,26 +171,24 @@ void ManagerInterface::getWithRelationships(
       UNIMPLEMENTED_ERROR(ManagerInterface::Capability::kRelationshipQueries)};
 }
 
-void ManagerInterface::preflight(
-    [[maybe_unused]] const EntityReferences& entityReferences,
-    [[maybe_unused]] const trait::TraitsDatas& traitsHints,
-    [[maybe_unused]] access::PublishingAccess publishingAccess,
-    [[maybe_unused]] const ContextConstPtr& context,
-    [[maybe_unused]] const HostSessionPtr& hostSession,
-    [[maybe_unused]] const ManagerInterface::PreflightSuccessCallback& successCallback,
-    [[maybe_unused]] const ManagerInterface::BatchElementErrorCallback& errorCallback) {
+void ManagerInterface::preflight([[maybe_unused]] const EntityReferences& entityReferences,
+                                 [[maybe_unused]] const trait::TraitsDatas& traitsHints,
+                                 [[maybe_unused]] access::PublishingAccess publishingAccess,
+                                 [[maybe_unused]] const ContextConstPtr& context,
+                                 [[maybe_unused]] const HostSessionPtr& hostSession,
+                                 [[maybe_unused]] const PreflightSuccessCallback& successCallback,
+                                 [[maybe_unused]] const BatchElementErrorCallback& errorCallback) {
   throw errors::NotImplementedException{
       UNIMPLEMENTED_ERROR(ManagerInterface::Capability::kPublishing)};
 }
 
-void ManagerInterface::register_(
-    [[maybe_unused]] const EntityReferences& entityReferences,
-    [[maybe_unused]] const trait::TraitsDatas& entityTraitsDatas,
-    [[maybe_unused]] access::PublishingAccess publishingAccess,
-    [[maybe_unused]] const ContextConstPtr& context,
-    [[maybe_unused]] const HostSessionPtr& hostSession,
-    [[maybe_unused]] const ManagerInterface::RegisterSuccessCallback& successCallback,
-    [[maybe_unused]] const ManagerInterface::BatchElementErrorCallback& errorCallback) {
+void ManagerInterface::register_([[maybe_unused]] const EntityReferences& entityReferences,
+                                 [[maybe_unused]] const trait::TraitsDatas& entityTraitsDatas,
+                                 [[maybe_unused]] access::PublishingAccess publishingAccess,
+                                 [[maybe_unused]] const ContextConstPtr& context,
+                                 [[maybe_unused]] const HostSessionPtr& hostSession,
+                                 [[maybe_unused]] const RegisterSuccessCallback& successCallback,
+                                 [[maybe_unused]] const BatchElementErrorCallback& errorCallback) {
   throw errors::NotImplementedException{
       UNIMPLEMENTED_ERROR(ManagerInterface::Capability::kPublishing)};
 }

--- a/src/openassetio-core/src/pluginSystem/CppPluginSystem.cpp
+++ b/src/openassetio-core/src/pluginSystem/CppPluginSystem.cpp
@@ -1,23 +1,32 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 // Copyright Contributors to the OpenImageIO project.
 // Much of the cross-platform code below is taken and modified from the
 // OpenImageIO project.
 
+#include <algorithm>
+#include <cstddef>
+#include <exception>
+#include <filesystem>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
 #ifdef _WIN32
 #include <windows.h>
 #else
 #include <dlfcn.h>
 #endif
 
-#include <filesystem>
+#include <fmt/core.h>
 
-#include <fmt/format.h>
-
+#include <openassetio/export.h>
 #include <openassetio/errors/exceptions.hpp>
 #include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/pluginSystem/CppPluginSystem.hpp>
 #include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+#include <openassetio/typedefs.hpp>
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -113,7 +122,7 @@ void CppPluginSystem::scan(const std::string_view paths) {
         paths.substr(pathsStartIdx, pathsEndIdx - pathsStartIdx);
 
     // Check the provided path is actually a searchable directory.
-    if (!std::filesystem::is_directory(directoryPath)) {
+    if (!is_directory(directoryPath)) {
       logger_->debug(fmt::format("CppPluginSystem: Skipping as not a directory '{}'",
                                  directoryPath.string()));
       continue;
@@ -137,8 +146,8 @@ void CppPluginSystem::scan(const std::string_view paths) {
   }
 }
 
-openassetio::Identifiers CppPluginSystem::identifiers() const {
-  openassetio::Identifiers result;
+Identifiers CppPluginSystem::identifiers() const {
+  Identifiers result;
   result.reserve(plugins_.size());
   std::transform(begin(plugins_), end(plugins_), std::back_inserter(result),
                  [](const auto& iter) { return iter.first; });
@@ -158,7 +167,7 @@ const CppPluginSystem::PathAndPlugin& CppPluginSystem::plugin(const Identifier& 
 CppPluginSystem::MaybeIdentifierAndPlugin CppPluginSystem::maybeLoadPlugin(
     const std::filesystem::path& filePath) {
   // Check the proposed path is actually a file.
-  if (!std::filesystem::is_regular_file(filePath)) {
+  if (!is_regular_file(filePath)) {
     logger_->debug(fmt::format("CppPluginSystem: Ignoring as it is not a library binary '{}'",
                                filePath.string()));
     return {};
@@ -229,7 +238,7 @@ CppPluginSystem::MaybeIdentifierAndPlugin CppPluginSystem::maybeLoadPlugin(
   }
 
   // Get plugin's unique identifier.
-  openassetio::Identifier identifier;
+  Identifier identifier;
   try {
     identifier = plugin->identifier();
   } catch (const std::exception& exc) {

--- a/src/openassetio-core/src/pluginSystem/CppPluginSystemManagerImplementationFactory.cpp
+++ b/src/openassetio-core/src/pluginSystem/CppPluginSystemManagerImplementationFactory.cpp
@@ -1,25 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #include <openassetio/pluginSystem/CppPluginSystemManagerImplementationFactory.hpp>
 
+#include <algorithm>
 #include <cstdlib>
 #include <memory>
 #include <unordered_map>
 #include <utility>
 
+#include <fmt/core.h>
 #include <fmt/format.h>
 
+#include <openassetio/export.h>
 #include <openassetio/errors/exceptions.hpp>
+#include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
 #include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/pluginSystem/CppPluginSystem.hpp>
 #include <openassetio/pluginSystem/CppPluginSystemManagerPlugin.hpp>
+#include <openassetio/typedefs.hpp>
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace pluginSystem {
 
 CppPluginSystemManagerImplementationFactoryPtr CppPluginSystemManagerImplementationFactory::make(
-    openassetio::Str paths, log::LoggerInterfacePtr logger) {
+    Str paths, log::LoggerInterfacePtr logger) {
   return std::make_shared<CppPluginSystemManagerImplementationFactory>(
       CppPluginSystemManagerImplementationFactory{std::move(paths), std::move(logger)});
 }
@@ -31,7 +36,7 @@ CppPluginSystemManagerImplementationFactoryPtr CppPluginSystemManagerImplementat
 }
 
 CppPluginSystemManagerImplementationFactory::CppPluginSystemManagerImplementationFactory(
-    openassetio::Str paths, log::LoggerInterfacePtr logger)
+    Str paths, log::LoggerInterfacePtr logger)
     : ManagerImplementationFactoryInterface{std::move(logger)}, paths_{std::move(paths)} {
   if (paths_.empty()) {
     this->logger()->log(
@@ -46,8 +51,7 @@ CppPluginSystemManagerImplementationFactory::CppPluginSystemManagerImplementatio
     : CppPluginSystemManagerImplementationFactory{
           // getenv returns nullptr if var not set, which cannot be
           // used to construct a std::string.
-          // False positive in clang-tidy-12:
-          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+          // NOLINTNEXTLINE(*-suspicious-stringview-data-usage)
           [paths = std::getenv(kPluginEnvVar.data())] { return paths ? paths : ""; }(),
           std::move(logger)} {}
 
@@ -59,7 +63,7 @@ Identifiers CppPluginSystemManagerImplementationFactory::identifiers() {
   }
 
   // Get all OpenAssetIO plugins, whether manager plugins or otherwise.
-  openassetio::Identifiers pluginIds = pluginSystem_->identifiers();
+  Identifiers pluginIds = pluginSystem_->identifiers();
 
   // Filter plugins to only those that are manager plugins.
   pluginIds.erase(

--- a/src/openassetio-core/src/pluginSystem/CppPluginSystemManagerPlugin.cpp
+++ b/src/openassetio-core/src/pluginSystem/CppPluginSystemManagerPlugin.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
+#include <openassetio/export.h>
 #include <openassetio/pluginSystem/CppPluginSystemManagerPlugin.hpp>
 
 namespace openassetio {

--- a/src/openassetio-core/src/pluginSystem/CppPluginSystemPlugin.cpp
+++ b/src/openassetio-core/src/pluginSystem/CppPluginSystemPlugin.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
+#include <openassetio/export.h>
 #include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
 
 namespace openassetio {

--- a/src/openassetio-core/src/utils/Regex.cpp
+++ b/src/openassetio-core/src/utils/Regex.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #include "Regex.hpp"
 
 #include <cassert>
@@ -8,7 +8,7 @@
 #include <string_view>
 #include <type_traits>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include <pcre2.h>
 
 #include <openassetio/export.h>
@@ -22,7 +22,7 @@ namespace utils {
 namespace {
 constexpr Str::size_type kErrorMessageMaxLength = 1000;
 
-Str errorCodeToMessage(int errorCode) {
+Str errorCodeToMessage(const int errorCode) {
   Str errorMessage(kErrorMessageMaxLength, '\0');
 
   static_assert(sizeof(Str::value_type) == sizeof(PCRE2_UCHAR8), "PCRE2 char type size mismatch");
@@ -111,7 +111,7 @@ Str Regex::substituteToReduceSize(const std::string_view& subject,
                 "PCRE2 char type size mismatch");
   static_assert(sizeof(Str::value_type) == sizeof(PCRE2_UCHAR8), "PCRE2 char type size mismatch");
 
-  int numSubstitutions =
+  const int numSubstitutions =
       pcre2_substitute(code_, /* regex object */
                               // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
                        reinterpret_cast<PCRE2_SPTR8>(subject.data()), /* subject */
@@ -156,7 +156,7 @@ std::string_view Regex::Match::group(const std::string_view subject,
   // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   assert(groupNum < pcre2_get_ovector_count(data_.get()));
 
-  PCRE2_SIZE* matches = pcre2_get_ovector_pointer(data_.get());
+  const PCRE2_SIZE* matches = pcre2_get_ovector_pointer(data_.get());
 
   // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   const std::size_t startIdx = matches[groupNum * 2];

--- a/src/openassetio-core/src/utils/ostream.cpp
+++ b/src/openassetio-core/src/utils/ostream.cpp
@@ -1,8 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
+#include <ostream>
+
+#include <fmt/core.h>
+
+#include <openassetio/export.h>
 #include <openassetio/Context.hpp>
 #include <openassetio/EntityReference.hpp>
-#include <openassetio/managerApi/HostSession.hpp>
+#include <openassetio/InfoDictionary.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/trait/collection.hpp>
+#include <openassetio/trait/property.hpp>
+#include <openassetio/typedefs.hpp>
 #include <openassetio/utils/ostream.hpp>
 
 #include "formatter.hpp"

--- a/src/openassetio-core/src/utils/path.cpp
+++ b/src/openassetio-core/src/utils/path.cpp
@@ -1,15 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
+#include <openassetio/utils/path.hpp>
+
 #include <memory>
 #include <string_view>
 
+#include <openassetio/export.h>
 #include <openassetio/errors/exceptions.hpp>
 #include <openassetio/typedefs.hpp>
-#include <openassetio/utils/path.hpp>
 
 #include "./path/common.hpp"
 #include "./path/posix.hpp"
+#include "./path/posix/detail.hpp"
 #include "./path/windows.hpp"
+#include "./path/windows/detail.hpp"
+#include "./path/windows/pathTypes.hpp"
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -114,11 +119,13 @@ FileUrlPathConverter::FileUrlPathConverter()
 
 FileUrlPathConverter::~FileUrlPathConverter() = default;
 
-Str FileUrlPathConverter::pathToUrl(std::string_view absolutePath, PathType pathType) const {
+Str FileUrlPathConverter::pathToUrl(const std::string_view absolutePath,
+                                    const PathType pathType) const {
   return impl_->pathToUrl(absolutePath, pathType);
 }
 
-Str FileUrlPathConverter::pathFromUrl(std::string_view fileUrl, PathType pathType) const {
+Str FileUrlPathConverter::pathFromUrl(const std::string_view fileUrl,
+                                      const PathType pathType) const {
   return impl_->pathFromUrl(fileUrl, pathType);
 }
 }  // namespace utils

--- a/src/openassetio-core/src/utils/path/common.cpp
+++ b/src/openassetio-core/src/utils/path/common.cpp
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #include "common.hpp"
 
-#include <fmt/format.h>
+#include <string_view>
 
+#include <ada/url.h>
+#include <fmt/core.h>
+
+#include <openassetio/export.h>
 #include <openassetio/errors/exceptions.hpp>
+#include <openassetio/typedefs.hpp>
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {

--- a/src/openassetio-core/src/utils/path/posix.cpp
+++ b/src/openassetio-core/src/utils/path/posix.cpp
@@ -1,8 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #include "posix.hpp"
 
 #include <cassert>
+#include <string_view>
+
+#include <openassetio/export.h>
+#include <openassetio/typedefs.hpp>
+
+#include "common.hpp"
+#include "posix/detail.hpp"
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -27,7 +34,7 @@ Str FileUrlPathConverter::pathToUrl(const std::string_view& posixPath) const {
   adaUrl.set_host("");
 
   const Str processedPath = [&] {
-    if (auto encodedPath = detail::PosixUrl::maybePercentEncode(posixPath)) {
+    if (const auto encodedPath = detail::PosixUrl::maybePercentEncode(posixPath)) {
       return posixPathHandler.removeTrailingForwardSlashesInPathSegments(*encodedPath);
     }
     return posixPathHandler.removeTrailingForwardSlashesInPathSegments(posixPath);

--- a/src/openassetio-core/src/utils/path/posix.hpp
+++ b/src/openassetio-core/src/utils/path/posix.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
 #include <string_view>
 
@@ -20,8 +20,10 @@ namespace utils::path::posix {
  * to/from a URL.
  */
 struct FileUrlPathConverter {
+  // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
   detail::PosixUrl& urlHandler;
   detail::PosixPath& posixPathHandler;
+  // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 
   /**
    * Convert a POSIX path into a file URL.

--- a/src/openassetio-core/src/utils/path/posix/detail.cpp
+++ b/src/openassetio-core/src/utils/path/posix/detail.cpp
@@ -1,8 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #include "detail.hpp"
 
 #include <cassert>
+#include <optional>
+#include <string_view>
+
+#include <openassetio/export.h>
+#include <openassetio/typedefs.hpp>
+
+#include "../common.hpp"
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {

--- a/src/openassetio-core/src/utils/path/posix/detail.hpp
+++ b/src/openassetio-core/src/utils/path/posix/detail.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
 #include <optional>
 #include <string_view>
@@ -93,7 +93,7 @@ struct PosixUrl {
       charSet[idx] = ada::character_sets::PATH_PERCENT_ENCODE[idx];
     }
     // Augment the %-encode set with additional characters.
-    for (std::uint8_t charCode : {kPercentHex, kBackSlashHex, kColonHex, kVerticalBarHex}) {
+    for (const std::uint8_t charCode : {kPercentHex, kBackSlashHex, kColonHex, kVerticalBarHex}) {
       charSet[charCode / kByteSize] |= static_cast<std::uint8_t>(1 << (charCode % kByteSize));
     }
 

--- a/src/openassetio-core/src/utils/path/windows.cpp
+++ b/src/openassetio-core/src/utils/path/windows.cpp
@@ -1,11 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #include "windows.hpp"
 
 #include <algorithm>
 #include <cassert>
+#include <string_view>
 
 #include <ada.h>
+
+#include <openassetio/export.h>
+#include <openassetio/typedefs.hpp>
+
+#include "common.hpp"
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {

--- a/src/openassetio-core/src/utils/path/windows.hpp
+++ b/src/openassetio-core/src/utils/path/windows.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
 #include <string_view>
 
@@ -27,6 +27,7 @@ struct FileUrlPathConverter {
   /// https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
   static constexpr std::size_t kMaxPath = 259;
 
+  // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
   detail::WindowsUrl& urlHandler;
   detail::DriveLetter& driveLetterHandler;
   detail::UncHost& uncHostHandler;
@@ -36,6 +37,7 @@ struct FileUrlPathConverter {
   pathTypes::UncSharePath& uncSharePathHandler;
   pathTypes::UncUnnormalisedDeviceDrivePath& uncUnnormalisedDeviceDrivePathHandler;
   pathTypes::UncUnnormalisedDeviceSharePath& uncUnnormalisedDeviceSharePathHandler;
+  // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 
   /**
    * Convert a Windows path into a file URL.

--- a/src/openassetio-core/src/utils/path/windows/detail.cpp
+++ b/src/openassetio-core/src/utils/path/windows/detail.cpp
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #include "detail.hpp"
 
 #include <algorithm>
 #include <cassert>
+#include <optional>
+#include <string_view>
+
+#include <openassetio/export.h>
+#include <openassetio/typedefs.hpp>
 
 #include "../common.hpp"
 
@@ -20,7 +25,7 @@ bool WindowsUrl::containsPercentEncodedSlash(const std::string_view& url) const 
 }
 
 std::optional<Str> WindowsUrl::ip6ToValidHostname(const std::string_view& host) const {
-  auto match = ip6HostRegex.match(host);
+  const auto match = ip6HostRegex.match(host);
   if (!match) {
     return std::nullopt;
   }
@@ -38,8 +43,8 @@ bool WindowsUrl::maybePercentEncodeAndAppendTo(const std::string_view& path, Str
   // to a given string if encoding is needed. However, that
   // specialisation is not generated in ada v2.7.4 on MacOS/clang and
   // fails to link. See https://github.com/ada-url/ada/issues/580
-  Str result;
-  if (ada::unicode::percent_encode<false>(path, kPercentEncodeCharacterSet.data(), result)) {
+  if (Str result;
+      ada::unicode::percent_encode<false>(path, kPercentEncodeCharacterSet.data(), result)) {
     appendTo += result;
     return true;
   }
@@ -57,7 +62,7 @@ bool WindowsUrl::setUrlHost(const std::string_view& host, ada::url& url) const {
 // NormalisedPath
 
 std::string_view NormalisedPath::withoutTrailingSlashes(const std::string_view& path) const {
-  auto match = trailingSlashesRegex.match(path);
+  const auto match = trailingSlashesRegex.match(path);
   if (!match) {
     return path;
   }
@@ -65,7 +70,7 @@ std::string_view NormalisedPath::withoutTrailingSlashes(const std::string_view& 
 }
 
 std::string_view NormalisedPath::withoutTrailingDotsAsFile(const std::string_view& path) const {
-  auto match = trailingDotsAsFileRegex.match(path);
+  const auto match = trailingDotsAsFileRegex.match(path);
   if (!match) {
     return path;
   }
@@ -73,7 +78,7 @@ std::string_view NormalisedPath::withoutTrailingDotsAsFile(const std::string_vie
 }
 
 std::string_view NormalisedPath::withoutTrailingDotsInFile(const std::string_view& path) const {
-  auto match = trailingDotsInFileRegex.match(path);
+  const auto match = trailingDotsInFileRegex.match(path);
   if (!match) {
     return path;
   }
@@ -81,7 +86,7 @@ std::string_view NormalisedPath::withoutTrailingDotsInFile(const std::string_vie
 }
 
 std::string_view NormalisedPath::withoutTrailingSpacesAndDots(const std::string_view& path) const {
-  auto match = trailingDotsAndSpacesRegex.match(path);
+  const auto match = trailingDotsAndSpacesRegex.match(path);
   if (!match) {
     return path;
   }

--- a/src/openassetio-core/src/utils/path/windows/detail.hpp
+++ b/src/openassetio-core/src/utils/path/windows/detail.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
 #include <array>
 #include <cstddef>
@@ -53,7 +53,7 @@ struct WindowsUrl {
       charSet[idx] = ada::character_sets::PATH_PERCENT_ENCODE[idx];
     }
     // Augment the %-encode set with additional characters.
-    for (std::uint8_t charCode : {kPercentHex, kColonHex, kVerticalBarHex}) {
+    for (const std::uint8_t charCode : {kPercentHex, kColonHex, kVerticalBarHex}) {
       charSet[charCode / kByteSize] |= static_cast<std::uint8_t>(1 << (charCode % kByteSize));
     }
 

--- a/src/openassetio-core/src/utils/path/windows/pathTypes.cpp
+++ b/src/openassetio-core/src/utils/path/windows/pathTypes.cpp
@@ -1,11 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #include "pathTypes.hpp"
 
-#include <algorithm>
 #include <cassert>
+#include <optional>
+#include <string_view>
+#include <tuple>
+
+#include <openassetio/export.h>
+#include <openassetio/typedefs.hpp>
 
 #include "../common.hpp"
+#include "detail.hpp"
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
@@ -84,7 +90,7 @@ bool UncSharePath::toUrl(const std::string_view& windowsPath, ada::url& url) con
 
 std::optional<detail::UncDetails> UncSharePath::extractUncDetails(
     const std::string_view& path) const {
-  auto pathParts = pathRegex.match(path);
+  const auto pathParts = pathRegex.match(path);
   if (!pathParts) {
     return std::nullopt;
   }
@@ -100,7 +106,7 @@ std::optional<detail::UncDetails> UncSharePath::extractUncDetails(
 std::tuple<std::string_view, std::string_view, std::string_view>
 UncSharePath::extractShareNameAndPath(std::string_view shareNameAndPath) const {
   shareNameAndPath = normalisedPathHandler.withoutTrailingSlashes(shareNameAndPath);
-  auto headAndTail = pathHeadAndTailRegex.match(shareNameAndPath);
+  const auto headAndTail = pathHeadAndTailRegex.match(shareNameAndPath);
   if (!headAndTail) {
     // Share name without path.
     return {shareNameAndPath, {}, shareNameAndPath};
@@ -164,7 +170,7 @@ bool UncUnnormalisedDeviceDrivePath::toUrl(const std::string_view& windowsPath,
 
 std::optional<detail::UncDetails> UncUnnormalisedDeviceDrivePath::extractUncDetails(
     const std::string_view& path) const {
-  auto pathParts = pathRegex.match(path);
+  const auto pathParts = pathRegex.match(path);
   if (!pathParts) {
     return std::nullopt;
   }
@@ -239,7 +245,7 @@ bool UncUnnormalisedDeviceSharePath::toUrl(const std::string_view& windowsPath,
 
 std::optional<detail::UncDetails> UncUnnormalisedDeviceSharePath::extractUncDetails(
     const std::string_view& path) const {
-  auto pathParts = pathRegex.match(path);
+  const auto pathParts = pathRegex.match(path);
   if (!pathParts) {
     return std::nullopt;
   }
@@ -254,7 +260,7 @@ std::optional<detail::UncDetails> UncUnnormalisedDeviceSharePath::extractUncDeta
 std::tuple<std::string_view, std::string_view, std::string_view>
 UncUnnormalisedDeviceSharePath::extractShareNameAndPath(std::string_view shareNameAndPath) const {
   shareNameAndPath = uncUnnormalisedDevicePathHandler.withoutTrailingSlashes(shareNameAndPath);
-  auto headAndTail = pathHeadAndTailRegex.match(shareNameAndPath);
+  const auto headAndTail = pathHeadAndTailRegex.match(shareNameAndPath);
   if (!headAndTail) {
     return {shareNameAndPath, {}, shareNameAndPath};
   }
@@ -287,7 +293,7 @@ void UncUnnormalisedDeviceSharePath::setUrlPath(const detail::UncDetails& uncDet
   }
 }
 
-Str UncUnnormalisedDeviceSharePath::prefixUncSharePath(std::string_view uncSharePath) {
+Str UncUnnormalisedDeviceSharePath::prefixUncSharePath(const std::string_view uncSharePath) {
   Str prefixedPath;
   prefixedPath.reserve(kPrefix.size() + uncSharePath.size() - 2);
   prefixedPath += kPrefix;

--- a/src/openassetio-core/src/utils/path/windows/pathTypes.hpp
+++ b/src/openassetio-core/src/utils/path/windows/pathTypes.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
 #include <optional>
 #include <string_view>
@@ -23,8 +23,10 @@ namespace utils::path::windows::pathTypes {
  * Utility for handling Windows drive paths e.g. `C:\path`.
  */
 struct DrivePath {
+  // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
   detail::DriveLetter& driveLetterHandler;
   detail::NormalisedPath& normalisedPathHandler;
+  // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 
   static constexpr std::size_t kDriveLetterLength = 2;
 

--- a/src/openassetio-core/src/utils/substitute.cpp
+++ b/src/openassetio-core/src/utils/substitute.cpp
@@ -1,17 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
+#include <string_view>
+#include <type_traits>
+#include <variant>
+
 #include <fmt/args.h>
+#include <fmt/core.h>
 #include <fmt/format.h>
 
+#include <openassetio/export.h>
+#include <openassetio/InfoDictionary.hpp>
 #include <openassetio/errors/exceptions.hpp>
+#include <openassetio/typedefs.hpp>
 #include <openassetio/utils/substitute.hpp>
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace utils {
 
-openassetio::Str substitute(const std::string_view input,
-                            const openassetio::InfoDictionary& substitutions) {
+Str substitute(const std::string_view input, const InfoDictionary& substitutions) {
   fmt::dynamic_format_arg_store<fmt::format_context> args;
   args.reserve(substitutions.size(), substitutions.size());
 
@@ -23,7 +30,7 @@ openassetio::Str substitute(const std::string_view input,
         [&args, &substitution](const auto& value) {
           const auto& [key, variantValue] = substitution;
           using T = std::decay_t<decltype(value)>;
-          if constexpr (std::is_same_v<T, openassetio::Str>) {
+          if constexpr (std::is_same_v<T, Str>) {
             args.push_back(fmt::arg(key.c_str(), std::string_view{value}));
           } else {
             args.push_back(fmt::arg(key.c_str(), value));
@@ -33,9 +40,9 @@ openassetio::Str substitute(const std::string_view input,
   }
 
   try {
-    return fmt::vformat(input, args);
+    return vformat(input, args);
   } catch (const fmt::format_error& exc) {
-    throw openassetio::errors::InputValidationException{fmt::format(
+    throw errors::InputValidationException{fmt::format(
         "substitute(): failed to process the input string '{}': {}", input, exc.what())};
   }
 }

--- a/src/openassetio-core/tests/BatchElementErrorTest.cpp
+++ b/src/openassetio-core/tests/BatchElementErrorTest.cpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
-#include <string>
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
 #include <type_traits>
 
 #include <catch2/catch.hpp>

--- a/src/openassetio-core/tests/ContextTest.cpp
+++ b/src/openassetio-core/tests/ContextTest.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
 #include <type_traits>
 
 #include <catch2/catch.hpp>
 
 #include <openassetio/Context.hpp>
+#include <openassetio/typedefs.hpp>
 
 OPENASSETIO_FWD_DECLARE(trait, TraitsData)
 OPENASSETIO_FWD_DECLARE(managerApi, ManagerStateBase)

--- a/src/openassetio-core/tests/EntityReferenceTest.cpp
+++ b/src/openassetio-core/tests/EntityReferenceTest.cpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
-#include <map>
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #include <set>
 #include <unordered_set>
 

--- a/src/openassetio-core/tests/main.cpp
+++ b/src/openassetio-core/tests/main.cpp
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
 #define CATCH_CONFIG_MAIN
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>  // NOLINT(misc-include-cleaner)

--- a/src/openassetio-core/tests/managerApi/HostSessionTest.cpp
+++ b/src/openassetio-core/tests/managerApi/HostSessionTest.cpp
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022-2023 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
+#include <memory>
 #include <type_traits>
-
-#include <openassetio/export.h>
 
 #include <catch2/catch.hpp>
 #include <catch2/trompeloeil.hpp>
+#include <trompeloeil.hpp>
 
+#include <openassetio/export.h>  // NOLINT - cpplint
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/managerApi/Host.hpp>
@@ -19,7 +20,7 @@ namespace {
 /**
  * Mock implementation of a HostInterface
  */
-struct MockHostInterface : trompeloeil::mock_interface<hostApi::HostInterface> {
+struct MockHostInterface final : trompeloeil::mock_interface<hostApi::HostInterface> {
   IMPLEMENT_CONST_MOCK0(identifier);
   IMPLEMENT_CONST_MOCK0(displayName);
 };
@@ -27,7 +28,7 @@ struct MockHostInterface : trompeloeil::mock_interface<hostApi::HostInterface> {
 /**
  * Mock implementation of a LoggerInterface
  */
-struct MockLoggerInterface : trompeloeil::mock_interface<log::LoggerInterface> {
+struct MockLoggerInterface final : trompeloeil::mock_interface<log::LoggerInterface> {
   IMPLEMENT_MOCK2(log);
 };
 

--- a/src/openassetio-core/tests/managerApi/HostTest.cpp
+++ b/src/openassetio-core/tests/managerApi/HostTest.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
 #include <type_traits>
 
 #include <catch2/catch.hpp>
 
 #include <openassetio/managerApi/Host.hpp>
+#include <openassetio/typedefs.hpp>
 
 OPENASSETIO_FWD_DECLARE(hostApi, HostInterface)
 

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/broken/identifierThrowException.cpp
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/broken/identifierThrowException.cpp
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
+#include <memory>
+
 #include <export.h>
+
 #include <openassetio/errors/exceptions.hpp>
 #include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+#include <openassetio/typedefs.hpp>
 
 class ThrowingPlugin : public openassetio::pluginSystem::CppPluginSystemPlugin {
  public:

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/broken/identifierThrowNonException.cpp
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/broken/identifierThrowNonException.cpp
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
+#include <memory>
+
 #include <export.h>
+
 #include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+#include <openassetio/typedefs.hpp>
 
 class ThrowingPlugin : public openassetio::pluginSystem::CppPluginSystemPlugin {
   [[nodiscard]] openassetio::Str identifier() const override { throw 0; }

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/working/genericPlugin.cpp
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/working/genericPlugin.cpp
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 // #include <openassetio_test/export.h>
 #include <memory>
 
 #include <export.h>
 
 #include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+#include "openassetio/typedefs.hpp"
 
 struct Plugin : openassetio::pluginSystem::CppPluginSystemPlugin {
   [[nodiscard]] openassetio::Str identifier() const override {
     return "org.openassetio.test.pluginSystem."
+           // NOLINTNEXTLINE(misc-include-cleaner) - definition provided on command line.
            "resources." OPENASSETIO_CORE_PLUGINSYSTEM_TEST_PLUGIN_ID_SUFFIX;
   }
 };

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/working/managerPlugin.cpp
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/working/managerPlugin.cpp
@@ -1,16 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #include <memory>
 
 #include <export.h>
 
+#include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/pluginSystem/CppPluginSystemManagerPlugin.hpp>
+#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+#include <openassetio/typedefs.hpp>
 
 #include "StubManagerInterface.hpp"
 
 struct Plugin : openassetio::pluginSystem::CppPluginSystemManagerPlugin {
   [[nodiscard]] openassetio::Identifier identifier() const override {
     return "org.openassetio.test.pluginSystem."
+           // NOLINTNEXTLINE(misc-include-cleaner) - definition provided on command line.
            "resources." OPENASSETIO_CORE_PLUGINSYSTEM_TEST_PLUGIN_ID_SUFFIX;
   }
   openassetio::managerApi::ManagerInterfacePtr interface() override {

--- a/src/openassetio-core/tests/pluginSystem/resources/plugins/working/pythonGilCheckManagerPlugin.cpp
+++ b/src/openassetio-core/tests/pluginSystem/resources/plugins/working/pythonGilCheckManagerPlugin.cpp
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #include <memory>
-
-#include <export.h>
 
 #include <Python.h>
 
+#include <export.h>
+
+#include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/pluginSystem/CppPluginSystemManagerPlugin.hpp>
+#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+#include <openassetio/typedefs.hpp>
 
 #include "StubManagerInterface.hpp"
 
@@ -15,8 +18,9 @@ struct Plugin : openassetio::pluginSystem::CppPluginSystemManagerPlugin {
     if (PyGILState_Check()) {
       throw std::runtime_error{"GIL was not released when identifying C++ plugin"};
     }
-    return "org.openassetio.test.pluginSystem."
-           "resources." OPENASSETIO_CORE_PLUGINSYSTEM_TEST_PLUGIN_ID_SUFFIX;
+    return "org.openassetio.test.pluginSystem.resources."
+        // NOLINTNEXTLINE(*-include-cleaner): since defined on command line.
+        OPENASSETIO_CORE_PLUGINSYSTEM_TEST_PLUGIN_ID_SUFFIX;
   }
   openassetio::managerApi::ManagerInterfacePtr interface() override {
     if (PyGILState_Check()) {

--- a/src/openassetio-core/tests/typedefsTest.cpp
+++ b/src/openassetio-core/tests/typedefsTest.cpp
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
 #include <algorithm>
+#include <iterator>
 #include <memory>
 #include <tuple>
+#include <type_traits>
 
 #include <catch2/catch.hpp>
 
@@ -26,6 +28,7 @@
 #include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
 #include <openassetio/pluginSystem/HybridPluginSystemManagerImplementationFactory.hpp>
 #include <openassetio/trait/TraitsData.hpp>
+#include <openassetio/trait/collection.hpp>
 
 namespace {
 

--- a/src/openassetio-core/tests/utils/RegexTest.cpp
+++ b/src/openassetio-core/tests/utils/RegexTest.cpp
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
-#include <fmt/format.h>
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
+#include <cstddef>
+
+#include <fmt/core.h>
 #include <catch2/catch.hpp>
 
 #include <openassetio/errors/exceptions.hpp>
+#include <openassetio/typedefs.hpp>
 
 #include <utils/Regex.hpp>
 
@@ -15,12 +18,13 @@ using openassetio::errors::InputValidationException;
 using openassetio::utils::Regex;
 
 TEST_CASE("Happy path") {
-  Regex regex{"a(.)c"};
-  openassetio::Str text{"abcde"};
+  const Regex regex{"a(.)c"};
+  const openassetio::Str text{"abcde"};
 
-  auto match = regex.match(text);
+  const auto match = regex.match(text);
 
   REQUIRE(match.has_value());
+  // NOLINTNEXTLINE(*-unchecked-optional-access) - checked above.
   CHECK(match->group(text, 1) == "b");
   CHECK(regex.substituteToReduceSize(text, "f") == "fde");
 }
@@ -51,14 +55,14 @@ TEST_CASE("Invalid JIT pattern exception") {
 #endif
 
 TEST_CASE("Invalid match exception") {
-  Regex regex{"(*LIMIT_MATCH=1)((a+)b)+"};
+  const Regex regex{"(*LIMIT_MATCH=1)((a+)b)+"};
   CHECK_THROWS_MATCHES(
       regex.match("abab"), InputValidationException,
       ExceptionMessageMatcher{"Error -47 matching regex to 'abab': match limit exceeded"});
 }
 
 TEST_CASE("Invalid substitution exception") {
-  Regex regex{"a"};
+  const Regex regex{"a"};
   CHECK_THROWS_MATCHES(
       regex.substituteToReduceSize("a", "aa"), InputValidationException,
       ExceptionMessageMatcher{

--- a/src/openassetio-python/bridge/src/python/converter.cpp
+++ b/src/openassetio-python/bridge/src/python/converter.cpp
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
 #include <openassetio/python/converter.hpp>
 
+#include <Python.h>
 #include <pybind11/embed.h>
 
-#include <openassetio/Context.hpp>
+#include <openassetio/export.h>
+#include <openassetio/python/export.h>
 #include <openassetio/errors/exceptions.hpp>
+
+// NOLINTBEGIN(misc-include-cleaner) - false positive unused headers.
+#include <openassetio/Context.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/hostApi/Manager.hpp>
 #include <openassetio/hostApi/ManagerFactory.hpp>
@@ -18,6 +23,7 @@
 #include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/managerApi/ManagerStateBase.hpp>
 #include <openassetio/trait/TraitsData.hpp>
+// NOLINTEND(misc-include-cleaner)
 
 // Private headers
 #include <openassetio/private/python/pointers.hpp>

--- a/src/openassetio-python/bridge/src/python/hostApi.cpp
+++ b/src/openassetio-python/bridge/src/python/hostApi.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
 #include <openassetio/python/hostApi.hpp>
 
-#include <memory>
+#include <utility>
 
 #include <pybind11/embed.h>
 
+#include <openassetio/export.h>
 #include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
 #include <openassetio/log/LoggerInterface.hpp>
 // Private headers

--- a/src/openassetio-python/cmodule/src/ContextBinding.cpp
+++ b/src/openassetio-python/cmodule/src/ContextBinding.cpp
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2024 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <sstream>
+#include <utility>
 
-#include <fmt/format.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -19,8 +19,7 @@ void registerContext(const py::module& mod) {
   using openassetio::ContextPtr;
   using openassetio::managerApi::ManagerStateBasePtr;
   using openassetio::trait::TraitsData;
-  using PyRetainingTraitsDataPtr =
-      openassetio::PyRetainingSharedPtr<openassetio::trait::TraitsData>;
+  using PyRetainingTraitsDataPtr = openassetio::PyRetainingSharedPtr<TraitsData>;
   using PyRetainingManagerStateBasePtr =
       openassetio::PyRetainingSharedPtr<openassetio::managerApi::ManagerStateBase>;
 
@@ -37,7 +36,7 @@ void registerContext(const py::module& mod) {
       // since we must create a new `TraitsData` rather than re-use the
       // same default `TraitsData` instance, where any mutations will
       // persist in the default.
-      .def(py::init([]() { return Context::make(TraitsData::make(), ManagerStateBasePtr{}); }))
+      .def(py::init([] { return Context::make(TraitsData::make(), ManagerStateBasePtr{}); }))
       .def("__str__",
            [](const Context& self) {
              std::ostringstream stringStream;

--- a/src/openassetio-python/cmodule/src/EntityReferenceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/EntityReferenceBinding.cpp
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2024 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <sstream>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 
 #include <openassetio/EntityReference.hpp>
+#include <openassetio/typedefs.hpp>
 #include <openassetio/utils/ostream.hpp>
 
 #include "_openassetio.hpp"

--- a/src/openassetio-python/cmodule/src/_openassetio.cpp
+++ b/src/openassetio-python/cmodule/src/_openassetio.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2024 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 
 #include "_openassetio.hpp"
 
@@ -8,7 +8,7 @@
 // must augment this extension module with test-specific bindings. The
 // static library providing the implementation of this entry point is
 // conditionally linked into this extension module.
-void registerTestUtils(py::module& mod);
+extern void registerTestUtils(py::module& mod);
 #endif
 
 // NOLINTNEXTLINE

--- a/src/openassetio-python/cmodule/src/errors/BatchElementErrorBinding.cpp
+++ b/src/openassetio-python/cmodule/src/errors/BatchElementErrorBinding.cpp
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2024 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <sstream>
-#include <string_view>
 
-#include <fmt/format.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 

--- a/src/openassetio-python/cmodule/src/errors/exceptionsAsserts.cpp
+++ b/src/openassetio-python/cmodule/src/errors/exceptionsAsserts.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2023 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <cstddef>
+#include <tuple>
 #include <utility>
 
 #include <openassetio/errors/exceptions.hpp>

--- a/src/openassetio-python/cmodule/src/errors/exceptionsBinding.cpp
+++ b/src/openassetio-python/cmodule/src/errors/exceptionsBinding.cpp
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023-2024 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #include <cassert>
 #include <cstddef>
 #include <exception>
+#include <string>  // NOLINT(misc-include-cleaner): used in assert().
 #include <string_view>
 #include <unordered_map>
 #include <utility>
 
 #include <pybind11/eval.h>
 #include <pybind11/pybind11.h>
-#include <pyerrors.h>
 
 #include <openassetio/errors/exceptions.hpp>
 
@@ -73,7 +73,9 @@ void setPyException(const Exception &exception,
 
   // Find the Python exception type corresponding to the given C++
   // exception, and construct an instance.
+  // NOLINTNEXTLINE(*-suspicious-stringview-data-usage)
   const py::module_ pyModule = py::module_::import(kErrorsModuleName.data());
+  // NOLINTNEXTLINE(*-suspicious-stringview-data-usage)
   const py::object pyClass = pyModule.attr(pyClassName.data());
   const py::object pyInstance = [&] {
     if constexpr (std::is_same_v<Exception, BatchElementException>) {
@@ -188,6 +190,7 @@ void registerPyExceptionClass(const std::string_view pyClassName, const py::modu
     if constexpr (std::is_same_v<Exception, OpenAssetIOException>) {
       // Specialisation for OpenAssetIOException root base class, which
       // inherits from built-in Python RuntimeError exception.
+      // NOLINTNEXTLINE(*-suspicious-stringview-data-usage)
       return py::exception<void /* unused */>{mod, pyClassName.data(), PyExc_RuntimeError};
     } else if constexpr (std::is_same_v<Exception, BatchElementException>) {
       // Specialisation for BatchElementException, which must be handled
@@ -231,8 +234,9 @@ class BatchElementException(OpenAssetIOException):
       static constexpr std::string_view kPyBaseClassName =
           findPyClassNameOfCppBaseClass<Exception>(CppExceptionsAndPyClassNames::kIndices);
       // Look up the Python base class object.
-      const py::object pyBaseClass = registeredExceptions.at(kPyBaseClassName);
+      const py::object &pyBaseClass = registeredExceptions.at(kPyBaseClassName);
       // Register the exception, inheriting from looked-up base.
+      // NOLINTNEXTLINE(*-suspicious-stringview-data-usage)
       return py::exception<void /* unused */>{mod, pyClassName.data(), pyBaseClass};
     }
   }();

--- a/src/openassetio-python/cmodule/src/errors/exceptionsConverter.hpp
+++ b/src/openassetio-python/cmodule/src/errors/exceptionsConverter.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
 #include <array>
 #include <cstddef>
@@ -29,7 +29,7 @@ template <class... Type>
 struct TypesAndIds {
   static constexpr std::size_t kSize = sizeof...(Type);
   using Types = std::tuple<Type...>;
-  const std::array<std::string_view, kSize> ids;
+  std::array<std::string_view, kSize> ids;
 };
 
 /**
@@ -209,7 +209,7 @@ inline void convertPyExceptionAndThrow(const pybind11::error_already_set &thrown
  * @return Return value of callable, if no exception occurs.
  */
 template <class Fn>
-auto decorateWithExceptionConverter(Fn &&func) {
+auto decorateWithExceptionConverter(const Fn &func) {
   try {
     return func();
   } catch (const pybind11::error_already_set &exc) {

--- a/src/openassetio-python/cmodule/src/hostApi/EntityReferencePagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/EntityReferencePagerBinding.cpp
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
-#include <algorithm>
-
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
-#include <openassetio/Context.hpp>
-#include <openassetio/errors/BatchElementError.hpp>
 #include <openassetio/hostApi/EntityReferencePager.hpp>
+
+// NOLINTBEGIN(misc-include-cleaner) - required for pybind11
 #include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
-#include <openassetio/trait/collection.hpp>
+// NOLINTEND(misc-include-cleaner)
 
 #include "../_openassetio.hpp"
 

--- a/src/openassetio-python/cmodule/src/hostApi/HostInterfaceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/HostInterfaceBinding.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <pybind11/stl.h>
 
+#include <openassetio/export.h>
 #include <openassetio/InfoDictionary.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/typedefs.hpp>

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerFactoryBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerFactoryBinding.cpp
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
+#include <string_view>
+
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
+#include <openassetio/InfoDictionary.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/hostApi/Manager.hpp>
 #include <openassetio/hostApi/ManagerFactory.hpp>
 #include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
 #include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/typedefs.hpp>
 
 #include "../_openassetio.hpp"
 

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerImplementationFactoryInterfaceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerImplementationFactoryInterfaceBinding.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2024 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <pybind11/stl.h>
 
+#include <openassetio/export.h>
 #include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
 #include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>

--- a/src/openassetio-python/cmodule/src/log/LoggerInterfaceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/log/LoggerInterfaceBinding.cpp
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <openassetio/export.h>
 #include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/typedefs.hpp>
 
 #include "../_openassetio.hpp"
 #include "../overrideMacros.hpp"

--- a/src/openassetio-python/cmodule/src/log/SeverityFilterBinding.cpp
+++ b/src/openassetio-python/cmodule/src/log/SeverityFilterBinding.cpp
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include <openassetio/log/SeverityFilter.hpp>
 
-#include "../PyRetainingSharedPtr.hpp"
 #include "../_openassetio.hpp"
 
 void registerSeverityFilter(const py::module& mod) {

--- a/src/openassetio-python/cmodule/src/managerApi/EntityReferencePagerInterfaceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/managerApi/EntityReferencePagerInterfaceBinding.cpp
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
+#include <openassetio/export.h>
 #include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
-#include <openassetio/typedefs.hpp>
 
 #include "../_openassetio.hpp"
 #include "../overrideMacros.hpp"

--- a/src/openassetio-python/cmodule/src/managerApi/HostSessionBinding.cpp
+++ b/src/openassetio-python/cmodule/src/managerApi/HostSessionBinding.cpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <pybind11/stl.h>
 
-#include <openassetio/log/LoggerInterface.hpp>
-#include <openassetio/managerApi/Host.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 
-#include "../PyRetainingSharedPtr.hpp"
+// NOLINTBEGIN(misc-include-cleaner) - required for pybind11
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/managerApi/Host.hpp>
+// NOLINTEND(misc-include-cleaner)
+
 #include "../_openassetio.hpp"
 
 void registerHostSession(const py::module& mod) {

--- a/src/openassetio-python/cmodule/src/managerApi/ManagerInterfaceBinding.cpp
+++ b/src/openassetio-python/cmodule/src/managerApi/ManagerInterfaceBinding.cpp
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2023 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
+#include <cstddef>
+#include <utility>
+
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
+#include <openassetio/export.h>
 #include <openassetio/Context.hpp>
+#include <openassetio/EntityReference.hpp>
 #include <openassetio/InfoDictionary.hpp>
+#include <openassetio/access.hpp>
 #include <openassetio/hostApi/EntityReferencePager.hpp>
 #include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
@@ -14,6 +20,7 @@
 #include <openassetio/trait/collection.hpp>
 #include <openassetio/typedefs.hpp>
 
+#include "../PyRetainingSharedPtr.hpp"
 #include "../_openassetio.hpp"
 #include "../overrideMacros.hpp"
 
@@ -25,7 +32,7 @@ namespace managerApi {
  * Trampoline class required for pybind to bind pure virtual methods
  * and allow C++ -> Python calls via a C++ instance.
  */
-struct PyManagerInterface : ManagerInterface {
+struct PyManagerInterface final : ManagerInterface {
   using ManagerInterface::ManagerInterface;
 
   using PyRetainingManagerStateBasePtr = PyRetainingSharedPtr<ManagerStateBase>;
@@ -100,7 +107,7 @@ struct PyManagerInterface : ManagerInterface {
                                   hostSession, successCallback, errorCallback);
   }
 
-  [[nodiscard]] bool hasCapability(ManagerInterface::Capability capability) override {
+  [[nodiscard]] bool hasCapability(Capability capability) override {
     OPENASSETIO_PYBIND11_OVERRIDE_PURE(bool, ManagerInterface, hasCapability, capability);
   }
 
@@ -139,13 +146,13 @@ struct PyManagerInterface : ManagerInterface {
                                   errorCallback);
   }
 
-  void getWithRelationship(
-      const EntityReferences& entityReferences, const trait::TraitsDataPtr& relationshipTraitsData,
-      const trait::TraitSet& resultTraitSet, size_t pageSize,
-      const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
-      const HostSessionPtr& hostSession,
-      const ManagerInterface::RelationshipQuerySuccessCallback& successCallback,
-      const ManagerInterface::BatchElementErrorCallback& errorCallback) override {
+  void getWithRelationship(const EntityReferences& entityReferences,
+                           const trait::TraitsDataPtr& relationshipTraitsData,
+                           const trait::TraitSet& resultTraitSet, std::size_t pageSize,
+                           const access::RelationsAccess relationsAccess,
+                           const ContextConstPtr& context, const HostSessionPtr& hostSession,
+                           const RelationshipQuerySuccessCallback& successCallback,
+                           const BatchElementErrorCallback& errorCallback) override {
     OPENASSETIO_PYBIND11_OVERRIDE_ARGS(
         void, ManagerInterface, getWithRelationship,
         (entityReferences, relationshipTraitsData, resultTraitSet, pageSize, relationsAccess,
@@ -154,13 +161,13 @@ struct PyManagerInterface : ManagerInterface {
         context, hostSession, RetainCommonPyArgs::forFn(successCallback), errorCallback);
   }
 
-  void getWithRelationships(
-      const EntityReference& entityReference, const trait::TraitsDatas& relationshipTraitsDatas,
-      const trait::TraitSet& resultTraitSet, size_t pageSize,
-      const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
-      const HostSessionPtr& hostSession,
-      const ManagerInterface::RelationshipQuerySuccessCallback& successCallback,
-      const ManagerInterface::BatchElementErrorCallback& errorCallback) override {
+  void getWithRelationships(const EntityReference& entityReference,
+                            const trait::TraitsDatas& relationshipTraitsDatas,
+                            const trait::TraitSet& resultTraitSet, std::size_t pageSize,
+                            const access::RelationsAccess relationsAccess,
+                            const ContextConstPtr& context, const HostSessionPtr& hostSession,
+                            const RelationshipQuerySuccessCallback& successCallback,
+                            const BatchElementErrorCallback& errorCallback) override {
     OPENASSETIO_PYBIND11_OVERRIDE_ARGS(
         void, ManagerInterface, getWithRelationships,
         (entityReference, relationshipTraitsDatas, resultTraitSet, pageSize, relationsAccess,

--- a/src/openassetio-python/cmodule/src/overrideMacros.hpp
+++ b/src/openassetio-python/cmodule/src/overrideMacros.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #pragma once
 #include <pybind11/pybind11.h>
 
@@ -11,7 +11,7 @@
  * Decorate PYBIND11_OVERRIDE_NAME with exception type translation.
  */
 #define OPENASSETIO_PYBIND11_OVERRIDE_NAME(ret_type, cname, name, fn, ...)                      \
-  do {                                                                                          \
+  do { /* NOLINT(cppcoreguidelines-avoid-do-while) */                                           \
     /* Must explicitly specify decorated lambda return type, since    */                        \
     /* PYBIND11_OVERRIDE_IMPL return type can be PyRetainingSharedPtr,*/                        \
     /* which confuses the compiler.                                   */                        \
@@ -46,7 +46,7 @@
  * implementation, if one exists.
  */
 #define OPENASSETIO_PYBIND11_OVERRIDE_ARGS(Ret, Class, Fn, CppArgs, ... /* PyArgs */)     \
-  do {                                                                                    \
+  do { /* NOLINT(cppcoreguidelines-avoid-do-while) */                                     \
     return decorateWithExceptionConverter([&]() -> decltype(Class::Fn CppArgs) {          \
       PYBIND11_OVERRIDE_IMPL(PYBIND11_TYPE(Ret), PYBIND11_TYPE(Class), #Fn, __VA_ARGS__); \
       return Class::Fn CppArgs;                                                           \
@@ -67,7 +67,7 @@
  * until it is fixed upstream.
  */
 #define OPENASSETIO_PYBIND11_OVERRIDE_PURE_NAME(ret_type, cname, name, fn, ...)                 \
-  do {                                                                                          \
+  do { /* NOLINT(cppcoreguidelines-avoid-do-while) */                                           \
     return decorateWithExceptionConverter([&]() -> decltype(cname::fn(__VA_ARGS__)) {           \
       PYBIND11_OVERRIDE_IMPL(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__); \
       const pybind11::gil_scoped_acquire gil{};                                                 \

--- a/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemBinding.cpp
+++ b/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemBinding.cpp
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl/filesystem.h>
 
-#include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/pluginSystem/CppPluginSystem.hpp>
+
+// NOLINTBEGIN(misc-include-cleaner) - required for pybind11
+#include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+// NOLINTEND(misc-include-cleaner)
 
 #include "../_openassetio.hpp"
 

--- a/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemManagerImplementationFactoryBinding.cpp
+++ b/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemManagerImplementationFactoryBinding.cpp
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include <openassetio/log/LoggerInterface.hpp>
-#include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/pluginSystem/CppPluginSystemManagerImplementationFactory.hpp>
+#include <openassetio/typedefs.hpp>
+
+// NOLINTBEGIN(misc-include-cleaner) - required for pybind11
+#include <openassetio/managerApi/ManagerInterface.hpp>
+// NOLINTEND(misc-include-cleaner)
 
 #include "../_openassetio.hpp"
-#include "../overrideMacros.hpp"
 
 void registerCppPluginSystemManagerImplementationFactory(const py::module_& mod) {
   using openassetio::hostApi::ManagerImplementationFactoryInterface;

--- a/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemPluginBinding.cpp
+++ b/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemPluginBinding.cpp
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #include <pybind11/pybind11.h>
 
 #include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
+#include <openassetio/typedefs.hpp>
 
 #include "../_openassetio.hpp"
 #include "../overrideMacros.hpp"

--- a/src/openassetio-python/cmodule/src/pluginSystem/HybridPluginSystemManagerImplementationFactoryBinding.cpp
+++ b/src/openassetio-python/cmodule/src/pluginSystem/HybridPluginSystemManagerImplementationFactoryBinding.cpp
@@ -1,16 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #include <algorithm>
+#include <functional>
+#include <iterator>
+#include <utility>
+#include <vector>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <openassetio/errors/exceptions.hpp>
 #include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
 #include <openassetio/pluginSystem/HybridPluginSystemManagerImplementationFactory.hpp>
 
+#include "../PyRetainingSharedPtr.hpp"
 #include "../_openassetio.hpp"
-#include "../overrideMacros.hpp"
 
 void registerHybridPluginSystemManagerImplementationFactory(const py::module_& mod) {
   using openassetio::hostApi::ManagerImplementationFactoryInterface;

--- a/src/openassetio-python/cmodule/src/trait/TraitsDataBinding.cpp
+++ b/src/openassetio-python/cmodule/src/trait/TraitsDataBinding.cpp
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2024 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #include <optional>
 #include <sstream>
 
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
-#include <fmt/format.h>
-
 #include <openassetio/trait/TraitsData.hpp>
 #include <openassetio/trait/collection.hpp>
+#include <openassetio/trait/property.hpp>
 #include <openassetio/utils/ostream.hpp>
 
 #include "../_openassetio.hpp"

--- a/src/openassetio-python/tests/.clang-tidy
+++ b/src/openassetio-python/tests/.clang-tidy
@@ -1,8 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2013-2022 The Foundry Visionmongers Ltd
+# Copyright 2013-2025 The Foundry Visionmongers Ltd
 
 InheritParentConfig: true
 
-# Disable "cognitive complexity" check: Catch2 test macros trigger this.
+# -readability-function-cognitive-complexity
+#   Catch2 test macros trigger this.
+#
+# -bugprone-chained-comparison:
+#   False positives from Catch2 CHECK macros.
 Checks: >
-    -readability-function-cognitive-complexity
+    -readability-function-cognitive-complexity,
+    -bugprone-chained-comparison,
+

--- a/src/openassetio-python/tests/bridge/python/test_converter.cpp
+++ b/src/openassetio-python/tests/bridge/python/test_converter.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
+#include <tuple>
 
+#include <Python.h>
 #include <pybind11/embed.h>
 
 #include <openassetio/export.h>
@@ -21,7 +23,6 @@
 #include <openassetio/managerApi/Host.hpp>
 #include <openassetio/managerApi/HostSession.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
-#include <openassetio/managerApi/ManagerStateBase.hpp>
 #include <openassetio/trait/TraitsData.hpp>
 
 /*
@@ -49,7 +50,7 @@ SCENARIO("Mutations in one language are reflected in the other") {
 
   GIVEN("A C++ object casted to a Python object") {
     const trait::TraitsDataPtr traitsData = trait::TraitsData::make();
-    PyObject* pyTraitsData = openassetio::python::converter::castToPyObject(traitsData);
+    PyObject* pyTraitsData = python::converter::castToPyObject(traitsData);
     REQUIRE(pyTraitsData != nullptr);
 
     WHEN("data is set via the C++ object") {
@@ -112,7 +113,7 @@ SCENARIO("Casting to PyObject extends object lifetime") {
   GIVEN("A Python object casted from a C++ object") {
     trait::TraitsDataPtr traitsData = trait::TraitsData::make();
     traitsData->addTrait(kTestTraitId);
-    PyObject* pyTraitsData = openassetio::python::converter::castToPyObject(traitsData);
+    PyObject* pyTraitsData = python::converter::castToPyObject(traitsData);
 
     WHEN("C++ reference is destroyed") {
       CHECK(Py_REFCNT(pyTraitsData) == 1);  // Initial condition.
@@ -162,9 +163,9 @@ SCENARIO("Casting to a C++ object binds object lifetime") {
 }
 
 SCENARIO("Attempting to cast from an incorrect Python type") {
-  using openassetio::hostApi::Manager;
-  using openassetio::hostApi::ManagerPtr;
-  namespace converter = openassetio::python::converter;
+  using hostApi::Manager;
+  using hostApi::ManagerPtr;
+  namespace converter = python::converter;
 
   GIVEN("an invalid for casting Python object") {
     // Use pybind to conveniently create a CPython object with a ref count of 1.
@@ -250,14 +251,10 @@ SCENARIO("Error attempting to convert API objects without openassetio module loa
 
 namespace {
 
-namespace hostApi = openassetio::hostApi;
-namespace log = openassetio::log;
-namespace managerApi = openassetio::managerApi;
-
 // clang-format off
 using CastableClasses = std::tuple<
-    openassetio::Context,
-    openassetio::trait::TraitsData,
+    Context,
+    trait::TraitsData,
     hostApi::HostInterface,
     hostApi::Manager,
     hostApi::ManagerFactory,

--- a/src/openassetio-python/tests/bridge/python/test_hostApi.cpp
+++ b/src/openassetio-python/tests/bridge/python/test_hostApi.cpp
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
+#include <memory>
 
 #include <pybind11/pybind11.h>
 #include <catch2/catch.hpp>
 #include <catch2/trompeloeil.hpp>
+#include <trompeloeil.hpp>
 
 #include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
 #include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/python/hostApi.hpp>
+#include <openassetio/typedefs.hpp>
 
 namespace {
 struct MockLogger : trompeloeil::mock_interface<openassetio::log::LoggerInterface> {

--- a/src/openassetio-python/tests/cmodule/resources/_testutils/PyRetainingSharedPtrTest.cpp
+++ b/src/openassetio-python/tests/cmodule/resources/_testutils/PyRetainingSharedPtrTest.cpp
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 /**
  * Bindings used for testing PyRetainingSharedPtr behaviour.
  */
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -11,7 +13,7 @@
 #include <PyRetainingSharedPtr.hpp>
 
 namespace py = pybind11;
-
+namespace {
 /**
  * Base class to be inherited in Python.
  */
@@ -226,8 +228,9 @@ void setSimpleSingleton(std::shared_ptr<SimpleBaseCppType> newSingleton) {
   static std::shared_ptr<SimpleBaseCppType> singleton;
   singleton = std::move(newSingleton);
 }
+}  // namespace
 
-void registerPyRetainingSharedPtrTestTypes(py::module_& mod) {
+extern void registerPyRetainingSharedPtrTestTypes(py::module_& mod) {
   py::class_<SimpleBaseCppType, std::shared_ptr<SimpleBaseCppType>, PySimpleBaseCppType>(
       mod, "SimpleBaseCppType")
       .def(py::init())

--- a/src/openassetio-python/tests/cmodule/resources/_testutils/_testutils.cpp
+++ b/src/openassetio-python/tests/cmodule/resources/_testutils/_testutils.cpp
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 
-void registerPyRetainingSharedPtrTestTypes(py::module_&);
-void registerExceptionThrower(py::module_& mod);
-void registerRunInThread(py::module_& mod);
+extern void registerPyRetainingSharedPtrTestTypes(py::module_&);
+extern void registerExceptionThrower(py::module_& mod);
+extern void registerRunInThread(py::module_& mod);
 
-void registerTestUtils(py::module& mod) {
+extern void registerTestUtils(py::module& mod) {
   py::module_ testutils = mod.def_submodule("_testutils");
   registerPyRetainingSharedPtrTestTypes(testutils);
   registerExceptionThrower(testutils);

--- a/src/openassetio-python/tests/cmodule/resources/_testutils/gilTest.cpp
+++ b/src/openassetio-python/tests/cmodule/resources/_testutils/gilTest.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
+#include <functional>
 #include <future>
 #include <memory>
 #include <utility>
@@ -183,13 +184,13 @@ struct ThreadedCppPluginSystemPlugin : pluginSystem::CppPluginSystemPlugin {
 };
 }  // namespace
 
-void registerRunInThread(py::module_& mod) {
+extern void registerRunInThread(py::module_& mod) {
   mod.def(
       "runCallableInThread",
       [](const py::object& func) {
         std::async(std::launch::async, [&func]() {
           // Callable py::objects need explicit GIL re-acquire.
-          [[maybe_unused]] py::gil_scoped_acquire const gil{};
+          [[maybe_unused]] const py::gil_scoped_acquire gil{};
           func();
         }).get();
       },
@@ -201,7 +202,7 @@ void registerRunInThread(py::module_& mod) {
         std::async(std::launch::async, [&func]() {
           // py::function needs explicit GIL re-acquire, unlike
           // std::function.
-          [[maybe_unused]] py::gil_scoped_acquire const gil{};
+          [[maybe_unused]] const py::gil_scoped_acquire gil{};
           func();
         }).get();
       },


### PR DESCRIPTION
## Description

Closes #1390. Upgrade to the latest available `clang-tidy` and `clang-format` packages at time of writing.

Use `pip` to install these, since the GitHub ubuntu-22.04 runner maxes out at v15, whereas `pip` currently provides up to v19.

Update code to satisfy the new clang-tidy version, mostly adding lots of `#include`s. There are also a handful of non-clang-tidy changes, where CLion flagged some linting issues of its own.

Perhaps worth a shout that, in addition to clang tooling, the version of CMake is bumped to v3.31, so that `generate_export_header()` will add clang-tidy suppression comments to the generated header ([CMake issue](https://discourse.cmake.org/t/the-generateexportheader-should-prevent-clang-tidy-warning/10620)).  This is not reflected in the `cmake_minimum_required()` call in `CMakeLists.txt`, since it's only a requirement when linting.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~

## Reviewer Notes

The changes shouldn't introduce any source or binary incompatibilities, as evidenced (in part) by the ABI diff check CI job.

Any C API changes aren't too important, since the C API is woefully incomplete and needs revisiting as a whole.

See commit message for some details on choices made to satisfy clang-tidy.