### PR TITLE
[Docs] Update API docs URL to docs.openassetio.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ workflows in content creation tooling.
 
 > - 👋 Come chat with us on [ASWF Slack](https://academysoftwarefdn.slack.com/archives/C03Q36QS8N4)
 >   or our [mailing list](https://lists.aswf.io/g/openassetio-discussion).
-> - 🧰 Get started with the [API docs](https://openassetio.github.io/OpenAssetIO),
+> - 🧰 Get started with the [API docs](https://docs.openassetio.org/OpenAssetIO),
 >   Manager plugin [template](https://github.com/OpenAssetIO/Template-OpenAssetIO-Manager-Python),
 >   and [MediaCreation](https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation#readme)
 >   for post-production workflows.
@@ -91,7 +91,7 @@ for a wider range of asset types and publishing workflows.
 
 ## API documentation
 
-The documentation for OpenAssetIO can be found here: [https://openassetio.github.io/OpenAssetIO](https://openassetio.github.io/OpenAssetIO/).
+The documentation for OpenAssetIO can be found here: [https://docs.openassetio.org/OpenAssetIO](https://docs.openassetio.org/OpenAssetIO/).
 
 ## Project status
 

--- a/doc/decisions/DR019-Remove-access-from-the-context.md
+++ b/doc/decisions/DR019-Remove-access-from-the-context.md
@@ -11,9 +11,9 @@
 
 OpenAssetIO forms a bridge between a 'host' (tool or application) and a
 'manager' (asset management system). The [interface to the
-manager](https://openassetio.github.io/OpenAssetIO/classopenassetio_1_1v1_1_1manager_api_1_1_manager_interface.html)
+manager](https://docs.openassetio.org/OpenAssetIO/classopenassetio_1_1v1_1_1manager_api_1_1_manager_interface.html)
 is considered stateless. Its methods are supplied a
-[`Context`](https://openassetio.github.io/OpenAssetIO/classopenassetio_1_1v1_1_1_context.html)
+[`Context`](https://docs.openassetio.org/OpenAssetIO/classopenassetio_1_1v1_1_1_context.html)
 object to correlate disparate calls by the host and encapsulate the
 state of the current session.
 

--- a/doc/decisions/DR023-Versioning-traits-and-specifications-method.md
+++ b/doc/decisions/DR023-Versioning-traits-and-specifications-method.md
@@ -64,7 +64,7 @@ model potential workflows/integrations in the future (GRPC/HTTP), etc.
 However, we do not believe this necessarily excludes any handshake style
 interactions. OpenAssetIO already provides a mechanism to configure
 managers at the beginning of the session with
-[initialize](https://openassetio.github.io/OpenAssetIO/classopenassetio_1_1v1_1_1host_api_1_1_manager.html#aa52c7436ff63ae96e33d7db8d6fd38df).
+[initialize](https://docs.openassetio.org/OpenAssetIO/classopenassetio_1_1v1_1_1host_api_1_1_manager.html#aa52c7436ff63ae96e33d7db8d6fd38df).
 Whilst we agree that state must not be utilized during a session,
 injecting version state before or at initialize time remains a valid
 option.

--- a/examples/host/simpleResolver/README.md
+++ b/examples/host/simpleResolver/README.md
@@ -41,7 +41,7 @@ cd examples/host/simpeResolver
 ```
 
 The CLI doesn't have any configuration options itself, it makes use of
-the [default manager](https://openassetio.github.io/OpenAssetIO/classopenassetio_1_1v1_1_1host_api_1_1_manager_factory.html#a8b6c44543faebcb1b441bbf63c064c76)
+the [default manager](https://docs.openassetio.org/OpenAssetIO/classopenassetio_1_1v1_1_1host_api_1_1_manager_factory.html#a8b6c44543faebcb1b441bbf63c064c76)
 mechanism. We need to tell OpenAssetIO which config file to use:
 
 ```bash
@@ -58,7 +58,7 @@ python -m pip install openassetio-manager-bal
 At this point, we can now use the CLI to resolve entity data.
 The sample library has two entities `bal:///cat` and `bal:///dog`.
 
-The first argument to the CLI is a list of [traits](https://openassetio.github.io/OpenAssetIO/entities_traits_and_specifications.html)
+The first argument to the CLI is a list of [traits](https://docs.openassetio.org/OpenAssetIO/entities_traits_and_specifications.html)
 to resolve for, the second is the entity reference to resolve:
 
 ```bash

--- a/examples/host/simpleResolver/simpleResolver.py
+++ b/examples/host/simpleResolver/simpleResolver.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-#   Copyright 2022-2023 The Foundry Visionmongers Ltd
+#   Copyright 2022-2025 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -172,7 +172,7 @@ def main():
     )
 
     # Initialize the default manager as configured by $OPENASSETIO_DEFAULT_CONFIG
-    # See: https://openassetio.github.io/OpenAssetIO/classopenassetio_1_1v1_1_1host_api_1_1_manager_factory.html#a8b6c44543faebcb1b441bbf63c064c76
+    # See: https://docs.openassetio.org/OpenAssetIO/classopenassetio_1_1v1_1_1host_api_1_1_manager_factory.html#a8b6c44543faebcb1b441bbf63c064c76
     # All API/Manager messaging is channeled through the supplied logger.
     manager = ManagerFactory.defaultManagerForInterface(host_interface, impl_factory, logger)
 

--- a/src/openassetio-python/package/openassetio/__init__.py
+++ b/src/openassetio-python/package/openassetio/__init__.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2013-2024 The Foundry Visionmongers Ltd
+#   Copyright 2013-2025 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ API documentation
 -----------------
 
 The documentation for OpenAssetIO can be found here:
-   https://openassetio.github.io/OpenAssetIO.
+   https://docs.openassetio.org/OpenAssetIO
 """
 import os
 

--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 
 [project.urls]
 Source = "https://github.com/OpenAssetIO/OpenAssetIO"
-Documentation = "https://openassetio.github.io/OpenAssetIO"
+Documentation = "https://docs.openassetio.org/OpenAssetIO"
 Issues = "https://github.com/OpenAssetIO/OpenAssetIO/issues"
 
 [project.readme]


### PR DESCRIPTION
## Description

Closes #1400. ASWF has set up a CNAME record for us for docs.openassetio.org, and this looks more polished.

- [ ] ~~I have updated the release notes.~~
- [x] I have updated all relevant user documentation.

## Reviewer notes

Note that we have a CI job, markdown-link-check, that will check the URLs in markdown files.
