### PR TITLE
[CI] Bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build-vfx-reference-platform.yml
+++ b/.github/workflows/build-vfx-reference-platform.yml
@@ -45,7 +45,7 @@ jobs:
         cmake --install build
 
     - name: Upload archive
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: openassetio-CY2024
         path: openassetio-checkout/build/dist

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -31,10 +31,13 @@ jobs:
           - os: windows-2022
             preamble: call "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64
             shell: cmd
-          # These are the platform build strings provided to
-          # cibuildwheel, with wildcarding. See
-          # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-        python-build: ['cp310*64', 'cp311*64']
+          # Prefixes for the platform build strings provided to
+          # cibuildwheel. The remainder of the string, including
+          # wildcard, is appended when used below. We only specify the
+          # prefix here so that it can also be used in the file name of
+          # the uploaded archive (i.e. wildcard `*` is not allowed).
+          # See https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
+        python-build: ['cp310', 'cp311']
     defaults:
       run:
         # Annoyingly required here since `matrix` isn't available in the
@@ -66,7 +69,7 @@ jobs:
           # performance reasons (although it does help) and more so a
           # single failing python version won't interrupt every other
           # deploy on that platform.
-          CIBW_BUILD: ${{ matrix.python-build }}
+          CIBW_BUILD: ${{ matrix.python-build }}*64
           CIBW_SKIP: '*musllinux* *arm64*'
           # manylinux_2_28 is based on AlmaLinux 8, which uses glibc
           # 2.28 and new libstdc++ ABI.
@@ -77,7 +80,7 @@ jobs:
           # Ensure .pyi stub tests won't be skipped
           OPENASSETIO_TEST_ENABLE_PYTHON_STUBGEN: 1
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: "openassetio-wheels"
+          name: "openassetio-wheels-${{ matrix.config.os }}-${{ matrix.python-build }}"
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
         cmake --install build
 
     - name: Upload archive
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: openassetio-${{ matrix.config.os }}
         path: |
@@ -99,7 +99,7 @@ jobs:
         ! grep -qE "^.*?/src/[^:]+:[0-9]+: ?[a-zA-Z]+: ?.*$" doxygen-log.txt
 
     - name: Expose archive docs artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: doxygen-documentation
         path: doc/doxygen/html

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -26,12 +26,15 @@ jobs:
       # This does however mean that when making a release, you must be
       # sure that the build-wheels job on main has completed
       - name: Download wheels from commit ${{ github.sha }}
-        uses: dawidd6/action-download-artifact@v8
+        uses: dawidd6/action-download-artifact@v9
         with:
           workflow: build-wheels.yml
           workflow_conclusion: success
           commit: ${{ github.sha }}
-          name: openassetio-wheels
+          name: openassetio-wheels.*
+          name_is_regexp: true
+          # Ensure all archives are extracted under the same directory.
+          merge_multiple: true
           path: dist
 
       - name: Upload to TestPyPI
@@ -47,12 +50,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download wheels from commit ${{ github.sha }}
-        uses: dawidd6/action-download-artifact@v8
+        uses: dawidd6/action-download-artifact@v9
         with:
           workflow: build-wheels.yml
           workflow_conclusion: success
           commit: ${{ github.sha }}
-          name: openassetio-wheels
+          name: openassetio-wheels.*
+          name_is_regexp: true
+          # Ensure all archives are extracted under the same directory.
+          merge_multiple: true
           path: dist
 
       - name: Upload to PyPI


### PR DESCRIPTION
`actions/upload-artifact` v3 is now unavailable on GitHub CI and is causing builds to fail, e.g. https://github.com/OpenAssetIO/OpenAssetIO/pull/1443

We had previously skipped a dependabot update due to NodeJS version requirement conflict with the old VFX22 Docker image, see #1232. Since we're now testing on VFX24 this shouldn't be a problem.
