### PR TITLE
Remove docs for UnhandledException

### DIFF
--- a/src/openassetio-core/include/openassetio/errors/exceptions.hpp
+++ b/src/openassetio-core/include/openassetio/errors/exceptions.hpp
@@ -78,9 +78,7 @@ struct OPENASSETIO_CORE_EXPORT NotImplementedException : OpenAssetIOException {
 };
 
 /**
- * Exceptions emitted from manager plugins that are not handled will
- * be converted to this type and re-thrown when the exception passes
- * through the OpenAssetIO middleware.
+ * Currently unused.
  */
 struct OPENASSETIO_CORE_EXPORT UnhandledException : OpenAssetIOException {
   using OpenAssetIOException::OpenAssetIOException;


### PR DESCRIPTION
## Description

Discovered during #1445. This exception type seems to have slipped the net. It was designed for #1072, to be used in middleware classes such as `Manager`, whereby exceptions that are not derived from `OpenAssetIOException` and are thrown from a plugin's method would be caught and transformed into an `UnhandledException` and re-thrown. This was to allow hosts to detect exceptions that are caused by its OpenAssetIO integration.

However, that mechanism was never added, yet `UnhandledException` was added, with a docstring making false claims.

Removing the exception type is a breaking change, as is adding the functionality it was designed for (not to mention it's a lot of work for a potentially undesirable feature). So for now simply blank the erroneous docstring.

- [ ] ~~I have updated the release notes.~~
- [x] I have updated all relevant user documentation.
