### PR TITLE
Fix `PythonPluginSystemManagerPlugin.identifier` method type

### DIFF
--- a/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystemManagerPlugin.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystemManagerPlugin.py
@@ -46,8 +46,8 @@ class PythonPluginSystemManagerPlugin(PythonPluginSystemPlugin):
     attribute called 'plugin', that holds a class derived from this.
     """
 
-    @staticmethod
-    def identifier():
+    @classmethod
+    def identifier(cls):
         """
         Returns an identifier to uniquely identify the plug-in.
         Generally, this should be the identifier used by the manager.


### PR DESCRIPTION
## Description

Discovered during #1445. The base class `identifier` method is a class method, but it was defined as a static method in `PythonPluginSystemManagerPlugin`.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~
