### PR TITLE
Refactor plugin systems for re-usability

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,16 @@ Release Notes
 v1.0.0-rc.x.x
 ---------------
 
-_This release remains source compatible for both hosts and managers._
+_This release may break source compatibility for Python hosts, see
+breaking changes section for more details._
+
+## Breaking changes
+
+- Modified signature of `PythonPluginSystem.scan()` to accept
+  alternative top-level variables names as module hooks. This class is
+  primarily an internal implementation detail, so this change will only
+  break advanced downstream use-cases.
+  [#1445](https://github.com/OpenAssetIO/OpenAssetIO/issues/1445)
 
 ## New features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,8 +4,8 @@ Release Notes
 v1.0.0-rc.x.x
 ---------------
 
-_This release may break source compatibility for Python hosts, see
-breaking changes section for more details._
+_This release may break source compatibility for Python and C++ hosts,
+see breaking changes section for more details._
 
 ## Breaking changes
 
@@ -14,6 +14,12 @@ breaking changes section for more details._
   arguments to parametrise search path and entry point usage. This class
   is primarily an internal implementation detail, so the change will
   only break advanced downstream use-cases.
+  [#1445](https://github.com/OpenAssetIO/OpenAssetIO/issues/1445)
+
+- Modified signature of `CppPluginSystem.scan()` to accept alternative
+  top-level variables names as module hooks. This class is primarily an
+  internal implementation detail, so this change will only break
+  advanced downstream use-cases.
   [#1445](https://github.com/OpenAssetIO/OpenAssetIO/issues/1445)
 
 ## New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,16 +16,10 @@ see breaking changes section for more details._
   only break advanced downstream use-cases.
   [#1445](https://github.com/OpenAssetIO/OpenAssetIO/issues/1445)
 
-- Modified signature of `CppPluginSystem.scan()` to accept alternative
-  top-level variables names as module hooks. This class is primarily an
-  internal implementation detail, so this change will only break
-  advanced downstream use-cases.
-  [#1445](https://github.com/OpenAssetIO/OpenAssetIO/issues/1445)
-
-- Modified signature of `CppPluginSystem.scan()` to accept a validator
-  callback to provide an additional filter when loading plugins. This
-  class is primarily an internal implementation detail, so this change
-  will only break advanced downstream use-cases.
+- Modified signature of `CppPluginSystem.scan()` to accept more
+  arguments to further parametrise search path usage. This class is
+  primarily an internal implementation detail, so this change will only
+  break advanced downstream use-cases.
   [#1445](https://github.com/OpenAssetIO/OpenAssetIO/issues/1445)
 
 ## New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,10 +9,11 @@ breaking changes section for more details._
 
 ## Breaking changes
 
-- Modified signature of `PythonPluginSystem.scan()` to accept
-  alternative top-level variables names as module hooks. This class is
-  primarily an internal implementation detail, so this change will only
-  break advanced downstream use-cases.
+- Modified `PythonPluginSystem.scan()` method to search Python
+  distribution entry point hooks as well as scan given paths. Added
+  arguments to parametrise search path and entry point usage. This class
+  is primarily an internal implementation detail, so the change will
+  only break advanced downstream use-cases.
   [#1445](https://github.com/OpenAssetIO/OpenAssetIO/issues/1445)
 
 ## New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,12 @@ see breaking changes section for more details._
   advanced downstream use-cases.
   [#1445](https://github.com/OpenAssetIO/OpenAssetIO/issues/1445)
 
+- Modified signature of `CppPluginSystem.scan()` to accept a validator
+  callback to provide an additional filter when loading plugins. This
+  class is primarily an internal implementation detail, so this change
+  will only break advanced downstream use-cases.
+  [#1445](https://github.com/OpenAssetIO/OpenAssetIO/issues/1445)
+
 ## New features
 
 - Added `defaultEntityReference` overloads for convenience, providing

--- a/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystem.hpp
+++ b/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystem.hpp
@@ -2,6 +2,7 @@
 // Copyright 2024-2025 The Foundry Visionmongers Ltd
 #pragma once
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -58,6 +59,15 @@ class OPENASSETIO_CORE_EXPORT CppPluginSystem {
   void reset();
 
   /**
+   * Callback provided to @ref scan to provide further validation.
+   *
+   * A return value of empty optional signals that the plugin is OK.
+   * A return value of a string signals that the plugin is not OK and
+   * the string provides the reason.
+   */
+  using ValidationCallback = std::function<std::optional<Str>(const CppPluginSystemPluginPtr&)>;
+
+  /**
    * Searches the supplied paths for plugin modules.
    *
    * Paths are searched left-to-right, but only the first instance of
@@ -86,8 +96,13 @@ class OPENASSETIO_CORE_EXPORT CppPluginSystem {
    *
    * @param moduleHookName The name of the entry point function to scan
    * for and execute within discovered files.
+   *
+   * @param validationCallback A callback that will be given a candidate
+   * CppPluginSystemPtr and should return an empty optional if the
+   * plugin is valid, or a reason string if not valid.
    */
-  void scan(std::string_view paths, std::string_view moduleHookName);
+  void scan(std::string_view paths, std::string_view moduleHookName,
+            const ValidationCallback& validationCallback);
 
   /**
    * Returns the identifiers known to the plugin system.
@@ -117,7 +132,8 @@ class OPENASSETIO_CORE_EXPORT CppPluginSystem {
   /// Attempt to load a plugin at a given path, returning nullopt on
   /// failure.
   MaybeIdentifierAndPlugin maybeLoadPlugin(const std::filesystem::path& filePath,
-                                           std::string_view moduleHookName);
+                                           std::string_view moduleHookName,
+                                           const ValidationCallback& validationCallback);
 
   /// Private constructor. See @ref make.
   explicit CppPluginSystem(log::LoggerInterfacePtr logger);

--- a/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystem.hpp
+++ b/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystem.hpp
@@ -78,6 +78,9 @@ class OPENASSETIO_CORE_EXPORT CppPluginSystem {
    * @note Precedence order is undefined for plugins sharing the
    * same identifier within the same directory.
    *
+   * If the given paths string and the given environment variable both
+   * contain search paths, then only the paths string is used.
+   *
    * Each given directory is scanned for shared libraries that expose a
    * given hook function (with C linkage), which is expected to return a
    * @ref PluginFactory function pointer, which when called returns an
@@ -92,7 +95,12 @@ class OPENASSETIO_CORE_EXPORT CppPluginSystem {
    *
    * @param paths A list of paths to search, delimited by operating
    * system specific path separator (i.e. `:` for POSIX, `;` for
-   * Windows).
+   * Windows). Leave blank to search paths given by the environment
+   * variable specified in @p pathsEnvVar.
+   *
+   * @param pathsEnvVar An environment variable name containing paths
+   * formatted as described in @p paths. Paths from this environment
+   * variable are ignored if @p paths is non-empty.
    *
    * @param moduleHookName The name of the entry point function to scan
    * for and execute within discovered files.
@@ -101,7 +109,7 @@ class OPENASSETIO_CORE_EXPORT CppPluginSystem {
    * CppPluginSystemPtr and should return an empty optional if the
    * plugin is valid, or a reason string if not valid.
    */
-  void scan(std::string_view paths, std::string_view moduleHookName,
+  void scan(std::string_view paths, std::string_view pathsEnvVar, std::string_view moduleHookName,
             const ValidationCallback& validationCallback);
 
   /**

--- a/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystem.hpp
+++ b/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystem.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #pragma once
 #include <filesystem>
 #include <memory>
@@ -68,11 +68,10 @@ class OPENASSETIO_CORE_EXPORT CppPluginSystem {
    * @note Precedence order is undefined for plugins sharing the
    * same identifier within the same directory.
    *
-   * Each given directory is scanned for shared libraries that expose an
-   * `openassetioPlugin` entry point function (with C linkage), which is
-   * expected to return a @ref PluginFactory function pointer, which
-   * when called returns an instantiated (subclass of) @ref
-   * CppPluginSystemPlugin.
+   * Each given directory is scanned for shared libraries that expose a
+   * given hook function (with C linkage), which is expected to return a
+   * @ref PluginFactory function pointer, which when called returns an
+   * instantiated (subclass of) @ref CppPluginSystemPlugin.
    *
    * Discovered plugins are registered by their exposed identifier, and
    * subsequent registrations with the same identifier will be skipped.
@@ -84,8 +83,11 @@ class OPENASSETIO_CORE_EXPORT CppPluginSystem {
    * @param paths A list of paths to search, delimited by operating
    * system specific path separator (i.e. `:` for POSIX, `;` for
    * Windows).
+   *
+   * @param moduleHookName The name of the entry point function to scan
+   * for and execute within discovered files.
    */
-  void scan(std::string_view paths);
+  void scan(std::string_view paths, std::string_view moduleHookName);
 
   /**
    * Returns the identifiers known to the plugin system.
@@ -114,7 +116,8 @@ class OPENASSETIO_CORE_EXPORT CppPluginSystem {
       std::optional<std::pair<openassetio::Identifier, CppPluginSystemPluginPtr>>;
   /// Attempt to load a plugin at a given path, returning nullopt on
   /// failure.
-  MaybeIdentifierAndPlugin maybeLoadPlugin(const std::filesystem::path& filePath);
+  MaybeIdentifierAndPlugin maybeLoadPlugin(const std::filesystem::path& filePath,
+                                           std::string_view moduleHookName);
 
   /// Private constructor. See @ref make.
   explicit CppPluginSystem(log::LoggerInterfacePtr logger);

--- a/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystemManagerImplementationFactory.hpp
+++ b/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystemManagerImplementationFactory.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
 #include <filesystem>
 #include <optional>
@@ -52,6 +52,8 @@ class OPENASSETIO_CORE_EXPORT CppPluginSystemManagerImplementationFactory
 
   /// Environment variable to read the plugin search path from.
   static constexpr std::string_view kPluginEnvVar = "OPENASSETIO_PLUGIN_PATH";
+  /// Name of entry point function to locate within discovered paths.
+  static constexpr std::string_view kModuleHookName = "openassetioPlugin";
 
   /**
    * Construct a new instance.

--- a/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystemPlugin.hpp
+++ b/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystemPlugin.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #pragma once
 
 #include <openassetio/export.h>
@@ -38,18 +38,18 @@ class OPENASSETIO_CORE_EXPORT CppPluginSystemPlugin {
 
 /**
  * Function pointer to a factory that produces instances of
- * @ref CppPluginSystemPlugin wrapped in a shared_ptr.
+ * @ref CppPluginSystemPlugin wrapped in a `shared_ptr`.
  *
- * A pointer to such a function must be returned from an exposed
- * `openassetioPlugin` entry point function (with C linkage) from a
- * plugin shared library binary. This function pointer is then called to
- * get the @ref CppPluginSystemPlugin instance.
+ * A pointer to such a function must be returned from an exposed entry
+ * point function (with C linkage) from a plugin shared library binary.
+ * This function pointer is then called to get the @ref
+ * CppPluginSystemPlugin instance.
  *
  * This two-step process is required to work around Windows disallowing
- * C linkage functions from returning C++ types. That is, the
- * `openassetioPlugin` entry point with C linkage returns a raw pointer
- * (to a function). The returned PluginFactory function pointer can then
- * point to a C++ linkage function, which is allowed to return a
+ * C linkage functions from returning C++ types. That is, the entry
+ * point with C linkage returns a raw pointer (to a function). The
+ * returned PluginFactory function pointer can then point to a C++
+ * linkage function, which is allowed to return a
  * CppPluginSystemPluginPtr on Windows.
  *
  * Exception behaviour varies by platform for functions called via

--- a/src/openassetio-core/src/hostApi/ManagerFactory.cpp
+++ b/src/openassetio-core/src/hostApi/ManagerFactory.cpp
@@ -164,7 +164,7 @@ ManagerPtr ManagerFactory::defaultManagerForInterface(
         settings.insert({Str{key}, val.as_boolean()->get()});
       } else {
         throw errors::ConfigurationException(
-            fmt::format("Unsupported value type for '{}'.", key.str()));
+            fmt::format("Error parsing config file. Unsupported value type for '{}'.", key.str()));
       }
     }
   }

--- a/src/openassetio-core/src/pluginSystem/CppPluginSystem.cpp
+++ b/src/openassetio-core/src/pluginSystem/CppPluginSystem.cpp
@@ -300,7 +300,7 @@ CppPluginSystem::MaybeIdentifierAndPlugin CppPluginSystem::maybeLoadPlugin(
 
   // Ensure it's not already been registered.
   if (const auto iter = plugins_.find(identifier); iter != plugins_.end()) {
-    logger_->debug(
+    logger_->warning(
         fmt::format("CppPluginSystem: Skipping '{}' defined in '{}'. Already registered by '{}'",
                     identifier, filePath.string(), iter->second.first.string()));
     plugin.reset();  // Must destroy _before_ closing lib.

--- a/src/openassetio-core/src/pluginSystem/CppPluginSystemManagerImplementationFactory.cpp
+++ b/src/openassetio-core/src/pluginSystem/CppPluginSystemManagerImplementationFactory.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <memory>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 
@@ -59,7 +60,7 @@ Identifiers CppPluginSystemManagerImplementationFactory::identifiers() {
   if (!pluginSystem_) {
     // Lazy load plugins.
     pluginSystem_ = CppPluginSystem::make(logger());
-    pluginSystem_->scan(paths_);
+    pluginSystem_->scan(paths_, kModuleHookName);
   }
 
   // Get all OpenAssetIO plugins, whether manager plugins or otherwise.
@@ -94,7 +95,7 @@ managerApi::ManagerInterfacePtr CppPluginSystemManagerImplementationFactory::ins
   if (!pluginSystem_) {
     // Lazy load plugins.
     pluginSystem_ = CppPluginSystem::make(logger());
-    pluginSystem_->scan(paths_);
+    pluginSystem_->scan(paths_, kModuleHookName);
   }
   const auto& [path, plugin] = pluginSystem_->plugin(identifier);
 

--- a/src/openassetio-core/src/pluginSystem/CppPluginSystemManagerImplementationFactory.cpp
+++ b/src/openassetio-core/src/pluginSystem/CppPluginSystemManagerImplementationFactory.cpp
@@ -2,18 +2,15 @@
 // Copyright 2024-2025 The Foundry Visionmongers Ltd
 #include <openassetio/pluginSystem/CppPluginSystemManagerImplementationFactory.hpp>
 
-#include <algorithm>
 #include <cstdlib>
 #include <memory>
+#include <optional>
 #include <string_view>
-#include <unordered_map>
 #include <utility>
 
 #include <fmt/core.h>
-#include <fmt/format.h>
 
 #include <openassetio/export.h>
-#include <openassetio/errors/exceptions.hpp>
 #include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
 #include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/pluginSystem/CppPluginSystem.hpp>
@@ -23,6 +20,18 @@
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace pluginSystem {
+
+namespace {
+
+const CppPluginSystem::ValidationCallback kCheckIsManagerPlugin{
+    [](const CppPluginSystemPluginPtr& plugin) -> std::optional<Str> {
+      if (!std::dynamic_pointer_cast<CppPluginSystemManagerPlugin>(plugin)) {
+        return "It is not a manager plugin (CppPluginSystemManagerPlugin).";
+      }
+      return std::nullopt;
+    }};
+
+}  // namespace
 
 CppPluginSystemManagerImplementationFactoryPtr CppPluginSystemManagerImplementationFactory::make(
     Str paths, log::LoggerInterfacePtr logger) {
@@ -60,34 +69,10 @@ Identifiers CppPluginSystemManagerImplementationFactory::identifiers() {
   if (!pluginSystem_) {
     // Lazy load plugins.
     pluginSystem_ = CppPluginSystem::make(logger());
-    pluginSystem_->scan(paths_, kModuleHookName);
+    pluginSystem_->scan(paths_, kModuleHookName, kCheckIsManagerPlugin);
   }
 
-  // Get all OpenAssetIO plugins, whether manager plugins or otherwise.
-  Identifiers pluginIds = pluginSystem_->identifiers();
-
-  // Filter plugins to only those that are manager plugins.
-  pluginIds.erase(
-      std::remove_if(
-          begin(pluginIds), end(pluginIds),
-          [&](const auto& identifier) {
-            const auto& [path, plugin] = pluginSystem_->plugin(identifier);
-
-            auto managerPlugin = std::dynamic_pointer_cast<CppPluginSystemManagerPlugin>(plugin);
-
-            if (!managerPlugin) {
-              logger()->log(
-                  log::LoggerInterface::Severity::kWarning,
-                  fmt::format(
-                      "Plugin '{}' from '{}' is not a manager plugin as it cannot be cast to a"
-                      " CppPluginSystemManagerPlugin",
-                      identifier, path.string()));
-            }
-
-            return !managerPlugin;
-          }),
-      end(pluginIds));
-  return pluginIds;
+  return pluginSystem_->identifiers();
 }
 
 managerApi::ManagerInterfacePtr CppPluginSystemManagerImplementationFactory::instantiate(
@@ -95,20 +80,16 @@ managerApi::ManagerInterfacePtr CppPluginSystemManagerImplementationFactory::ins
   if (!pluginSystem_) {
     // Lazy load plugins.
     pluginSystem_ = CppPluginSystem::make(logger());
-    pluginSystem_->scan(paths_, kModuleHookName);
+    pluginSystem_->scan(paths_, kModuleHookName, kCheckIsManagerPlugin);
   }
   const auto& [path, plugin] = pluginSystem_->plugin(identifier);
 
-  auto managerPlugin = std::dynamic_pointer_cast<CppPluginSystemManagerPlugin>(plugin);
+  // Should definitely be a manager plugin, as validated by
+  // `kCheckIsManagerPlugin`. We use the exception-throwing version of
+  // dynamic_cast just to be extra safe.
+  auto& managerPlugin = dynamic_cast<CppPluginSystemManagerPlugin&>(*plugin);
 
-  if (!managerPlugin) {
-    throw errors::InputValidationException{
-        fmt::format("Plugin '{}' from '{}' is not a manager plugin as it cannot be cast to a"
-                    " CppPluginSystemManagerPlugin",
-                    identifier, path.string())};
-  }
-
-  return managerPlugin->interface();
+  return managerPlugin.interface();
 }
 }  // namespace pluginSystem
 }  // namespace OPENASSETIO_CORE_ABI_VERSION

--- a/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemBinding.cpp
+++ b/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemBinding.cpp
@@ -26,8 +26,9 @@ void registerCppPluginSystem(const py::module_ &mod) {
       .def(py::init(RetainCommonPyArgs::forFn<&CppPluginSystem::make>()),
            py::arg("logger").none(false))
       .def("reset", &CppPluginSystem::reset)
-      .def("scan", &CppPluginSystem::scan, py::arg("paths"), py::arg("moduleHookName"),
-           py::arg("validationCallback"), py::call_guard<py::gil_scoped_release>{})
+      .def("scan", &CppPluginSystem::scan, py::arg("paths"), py::arg("pathsEnvVar"),
+           py::arg("moduleHookName"), py::arg("validationCallback"),
+           py::call_guard<py::gil_scoped_release>{})
       .def("identifiers", &CppPluginSystem::identifiers)
       .def("plugin", &CppPluginSystem::plugin, py::arg("identifier"));
 }

--- a/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemBinding.cpp
+++ b/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemBinding.cpp
@@ -25,7 +25,7 @@ void registerCppPluginSystem(const py::module_ &mod) {
       .def(py::init(RetainCommonPyArgs::forFn<&CppPluginSystem::make>()),
            py::arg("logger").none(false))
       .def("reset", &CppPluginSystem::reset)
-      .def("scan", &CppPluginSystem::scan, py::arg("paths"),
+      .def("scan", &CppPluginSystem::scan, py::arg("paths"), py::arg("moduleHookName"),
            py::call_guard<py::gil_scoped_release>{})
       .def("identifiers", &CppPluginSystem::identifiers)
       .def("plugin", &CppPluginSystem::plugin, py::arg("identifier"));

--- a/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemBinding.cpp
+++ b/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemBinding.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024-2025 The Foundry Visionmongers Ltd
+#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl/filesystem.h>
@@ -26,7 +27,7 @@ void registerCppPluginSystem(const py::module_ &mod) {
            py::arg("logger").none(false))
       .def("reset", &CppPluginSystem::reset)
       .def("scan", &CppPluginSystem::scan, py::arg("paths"), py::arg("moduleHookName"),
-           py::call_guard<py::gil_scoped_release>{})
+           py::arg("validationCallback"), py::call_guard<py::gil_scoped_release>{})
       .def("identifiers", &CppPluginSystem::identifiers)
       .def("plugin", &CppPluginSystem::plugin, py::arg("identifier"));
 }

--- a/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemManagerImplementationFactoryBinding.cpp
+++ b/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemManagerImplementationFactoryBinding.cpp
@@ -24,6 +24,8 @@ void registerCppPluginSystemManagerImplementationFactory(const py::module_& mod)
       mod, "CppPluginSystemManagerImplementationFactory", py::is_final())
       .def_readonly_static("kPluginEnvVar",
                            &CppPluginSystemManagerImplementationFactory::kPluginEnvVar)
+      .def_readonly_static("kModuleHookName",
+                           &CppPluginSystemManagerImplementationFactory::kModuleHookName)
       .def(py::init(
                RetainCommonPyArgs::forFn<py::overload_cast<openassetio::Str, LoggerInterfacePtr>(
                    &CppPluginSystemManagerImplementationFactory::make)>()),

--- a/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemPluginBinding.cpp
+++ b/src/openassetio-python/cmodule/src/pluginSystem/CppPluginSystemPluginBinding.cpp
@@ -3,27 +3,14 @@
 #include <pybind11/pybind11.h>
 
 #include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
-#include <openassetio/typedefs.hpp>
 
 #include "../_openassetio.hpp"
-#include "../overrideMacros.hpp"
-
-namespace {
-using openassetio::pluginSystem::CppPluginSystemPlugin;
-struct PyCppPluginSystemPlugin : CppPluginSystemPlugin {
-  [[nodiscard]] openassetio::Identifier identifier() const override {
-    OPENASSETIO_PYBIND11_OVERRIDE_PURE(openassetio::Identifier, CppPluginSystemPlugin, identifier,
-                                       /* no args */);
-  }
-};
-}  // namespace
 
 void registerCppPluginSystemPlugin(const py::module_ &mod) {
   using openassetio::pluginSystem::CppPluginSystemPlugin;
 
-  py::class_<CppPluginSystemPlugin, PyCppPluginSystemPlugin, CppPluginSystemPlugin::Ptr>(
-      mod, "CppPluginSystemPlugin")
-      .def(py::init())
+  py::class_<CppPluginSystemPlugin, CppPluginSystemPlugin::Ptr>(mod, "CppPluginSystemPlugin",
+                                                                py::is_final())
       .def("identifier", &CppPluginSystemPlugin::identifier,
            py::call_guard<py::gil_scoped_release>{});
 }

--- a/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystem.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystem.py
@@ -257,7 +257,7 @@ class PythonPluginSystem(object):
         """
         identifier = cls.identifier()
         if identifier in self.__map:
-            self.__logger.debug(
+            self.__logger.warning(
                 f"PythonPluginSystem: Skipping class '{cls}' defined in '{path}'. "
                 f"Already registered by '{self.__paths[identifier]}'"
             )

--- a/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystemManagerImplementationFactory.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystemManagerImplementationFactory.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2013-2022 The Foundry Visionmongers Ltd
+#   Copyright 2013-2025 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -72,6 +72,10 @@ class PythonPluginSystemManagerImplementationFactory(ManagerImplementationFactor
     ## discovered plugins.
     kPackageEntryPointGroup = "openassetio.manager_plugin"
 
+    ## The name of the top-level variable that references the plugin
+    ## class.
+    kModuleHookName = "openassetioPlugin"
+
     def __init__(self, logger, paths=None, disableEntryPointsPlugins=None):
         """
         Creates a new factory. The factory scans for plugins lazily on
@@ -122,12 +126,14 @@ class PythonPluginSystemManagerImplementationFactory(ManagerImplementationFactor
         # point plugins
 
         if self.__paths:
-            self.__pluginManager.scan(self.__paths)
+            self.__pluginManager.scan(self.__paths, self.kModuleHookName)
 
         if self.__disableEntryPointsPlugins:
             self._logger.debug("Entry point based plugins are disabled")
         else:
-            self.__pluginManager.scan_entry_points(self.kPackageEntryPointGroup)
+            self.__pluginManager.scan_entry_points(
+                self.kPackageEntryPointGroup, self.kModuleHookName
+            )
 
     def identifiers(self):
         """

--- a/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystemManagerImplementationFactory.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystemManagerImplementationFactory.py
@@ -19,8 +19,6 @@ A single-class module, providing the
 PythonPluginSystemManagerImplementationFactory class.
 """
 
-import os
-
 from ..hostApi import ManagerImplementationFactoryInterface
 
 from .PythonPluginSystem import PythonPluginSystem
@@ -97,13 +95,7 @@ class PythonPluginSystemManagerImplementationFactory(ManagerImplementationFactor
         super(PythonPluginSystemManagerImplementationFactory, self).__init__(logger)
 
         self.__pluginManager = None
-
-        if paths is None:
-            paths = os.environ.get(self.kPluginEnvVar, "")
         self.__paths = paths
-
-        if disableEntryPointsPlugins is None:
-            disableEntryPointsPlugins = os.environ.get(self.kDisableEntryPointsEnvVar, False)
         self.__disableEntryPointsPlugins = disableEntryPointsPlugins
 
     def __scan(self):
@@ -113,27 +105,14 @@ class PythonPluginSystemManagerImplementationFactory(ManagerImplementationFactor
         """
         # Construct this here, so we have this even if we early out
         self.__pluginManager = PythonPluginSystem(self._logger)
-
-        if not self.__paths and self.__disableEntryPointsPlugins:
-            self._logger.log(
-                self._logger.Severity.kWarning,
-                "No search paths specified and entry point plugins are disabled, no plugins "
-                f"will load - check ${self.kPluginEnvVar} is set.",
-            )
-            return
-
-        # We scan custom paths first, so they take precedence over entry
-        # point plugins
-
-        if self.__paths:
-            self.__pluginManager.scan(self.__paths, self.kModuleHookName)
-
-        if self.__disableEntryPointsPlugins:
-            self._logger.debug("Entry point based plugins are disabled")
-        else:
-            self.__pluginManager.scan_entry_points(
-                self.kPackageEntryPointGroup, self.kModuleHookName
-            )
+        self.__pluginManager.scan(
+            self.__paths,
+            self.kPluginEnvVar,
+            self.kPackageEntryPointGroup,
+            self.kDisableEntryPointsEnvVar,
+            self.__disableEntryPointsPlugins,
+            self.kModuleHookName,
+        )
 
     def identifiers(self):
         """

--- a/src/openassetio-python/tests/cmodule/gil/test_cpppluginsystem_gil.py
+++ b/src/openassetio-python/tests/cmodule/gil/test_cpppluginsystem_gil.py
@@ -32,6 +32,10 @@ from openassetio.managerApi import ManagerInterface
 from openassetio.pluginSystem import CppPluginSystem, CppPluginSystemManagerImplementationFactory
 
 
+def noop(_):
+    return None
+
+
 class Test_CppPluginSystem_gil:
     """
     Check that the GIL is released in the CppPluginSystem bindings,
@@ -66,7 +70,9 @@ class Test_CppPluginSystem_gil:
         the_cpp_gil_check_module_hook,
         a_cpp_plugin_system,
     ):
-        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook)
+        a_cpp_plugin_system.scan(
+            the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook, noop
+        )
 
     def test_identifiers(
         self,
@@ -75,7 +81,9 @@ class Test_CppPluginSystem_gil:
         the_cpp_gil_check_module_hook,
         a_cpp_plugin_system,
     ):
-        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook)
+        a_cpp_plugin_system.scan(
+            the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook, noop
+        )
 
         assert a_cpp_plugin_system.identifiers() == [the_cpp_gil_check_plugin_identifier]
 
@@ -85,7 +93,9 @@ class Test_CppPluginSystem_gil:
         the_cpp_gil_check_module_hook,
         a_cpp_plugin_system,
     ):
-        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook)
+        a_cpp_plugin_system.scan(
+            the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook, noop
+        )
         a_cpp_plugin_system.reset()
 
     def test_plugin(
@@ -95,7 +105,9 @@ class Test_CppPluginSystem_gil:
         the_cpp_gil_check_module_hook,
         a_cpp_plugin_system,
     ):
-        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook)
+        a_cpp_plugin_system.scan(
+            the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook, noop
+        )
 
         _path, _plugin = a_cpp_plugin_system.plugin(the_cpp_gil_check_plugin_identifier)
 

--- a/src/openassetio-python/tests/cmodule/gil/test_cpppluginsystem_gil.py
+++ b/src/openassetio-python/tests/cmodule/gil/test_cpppluginsystem_gil.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2024 The Foundry Visionmongers Ltd
+#   Copyright 2024-2025 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -63,35 +63,39 @@ class Test_CppPluginSystem_gil:
     def test_scan(
         self,
         the_cpp_gil_check_plugin_path,
+        the_cpp_gil_check_module_hook,
         a_cpp_plugin_system,
     ):
-        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path)
+        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook)
 
     def test_identifiers(
         self,
         the_cpp_gil_check_plugin_identifier,
         the_cpp_gil_check_plugin_path,
+        the_cpp_gil_check_module_hook,
         a_cpp_plugin_system,
     ):
-        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path)
+        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook)
 
         assert a_cpp_plugin_system.identifiers() == [the_cpp_gil_check_plugin_identifier]
 
     def test_reset(
         self,
         the_cpp_gil_check_plugin_path,
+        the_cpp_gil_check_module_hook,
         a_cpp_plugin_system,
     ):
-        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path)
+        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook)
         a_cpp_plugin_system.reset()
 
     def test_plugin(
         self,
         the_cpp_gil_check_plugin_identifier,
         the_cpp_gil_check_plugin_path,
+        the_cpp_gil_check_module_hook,
         a_cpp_plugin_system,
     ):
-        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path)
+        a_cpp_plugin_system.scan(the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook)
 
         _path, _plugin = a_cpp_plugin_system.plugin(the_cpp_gil_check_plugin_identifier)
 
@@ -156,6 +160,11 @@ def a_cpp_plugin_impl_factory(the_cpp_gil_check_plugin_path, a_threaded_logger_i
     return CppPluginSystemManagerImplementationFactory(
         the_cpp_gil_check_plugin_path, a_threaded_logger_interface
     )
+
+
+@pytest.fixture(scope="session")
+def the_cpp_gil_check_module_hook():
+    return "openassetioPlugin"
 
 
 @pytest.fixture(scope="session")

--- a/src/openassetio-python/tests/cmodule/gil/test_cpppluginsystem_gil.py
+++ b/src/openassetio-python/tests/cmodule/gil/test_cpppluginsystem_gil.py
@@ -23,51 +23,13 @@ import sysconfig
 # pylint: disable=redefined-outer-name,protected-access
 # pylint: disable=invalid-name,c-extension-no-member
 # pylint: disable=missing-class-docstring,missing-function-docstring
-from unittest import mock
 
 import openassetio
 import pytest
 
 # pylint: disable=no-name-in-module
-from openassetio import _openassetio
 from openassetio.managerApi import ManagerInterface
-from openassetio.pluginSystem import (
-    CppPluginSystem,
-    CppPluginSystemPlugin,
-    CppPluginSystemManagerImplementationFactory,
-)
-
-
-class Test_CppPluginSystemPlugin_gil:
-    """
-    Check all methods release the GIL during C++ function body
-    execution.
-
-    See docstring for similar test under `gil/Test_ManagerInterface.py`
-    for details on how these tests are structured.
-    """
-
-    def test_all_methods_covered(self, find_unimplemented_test_cases):
-        """
-        Ensure this test class covers all methods.
-        """
-        unimplemented = find_unimplemented_test_cases(CppPluginSystemPlugin, self)
-
-        if unimplemented:
-            print("\nSome test cases not implemented. Method templates can be found below:\n")
-            for method in unimplemented:
-                print(
-                    f"""
-    def test_{method}(self, a_threaded_cpp_plugin):
-        a_threaded_cpp_plugin.{method}()
-"""
-                )
-
-        assert unimplemented == []
-
-    def test_identifier(self, mock_cpp_plugin, a_threaded_cpp_plugin):
-        mock_cpp_plugin.mock.identifier.return_value = "something"
-        a_threaded_cpp_plugin.identifier()
+from openassetio.pluginSystem import CppPluginSystem, CppPluginSystemManagerImplementationFactory
 
 
 class Test_CppPluginSystem_gil:
@@ -194,30 +156,6 @@ def a_cpp_plugin_impl_factory(the_cpp_gil_check_plugin_path, a_threaded_logger_i
     return CppPluginSystemManagerImplementationFactory(
         the_cpp_gil_check_plugin_path, a_threaded_logger_interface
     )
-
-
-@pytest.fixture
-def a_threaded_cpp_plugin(mock_cpp_plugin):
-    return _openassetio._testutils.gil.wrapInThreadedCppPluginSystemPlugin(mock_cpp_plugin)
-
-
-@pytest.fixture
-def mock_cpp_plugin():
-    return MockCppPluginSystemPlugin()
-
-
-class MockCppPluginSystemPlugin(CppPluginSystemPlugin):
-    """
-    `CppPluginSystemPlugin` implementation that delegates all
-     calls to a public `Mock` instance.
-    """
-
-    def __init__(self):
-        super().__init__()
-        self.mock = mock.create_autospec(CppPluginSystemPlugin, spec_set=True, instance=True)
-
-    def identifier(self):
-        return self.mock.identifier()
 
 
 @pytest.fixture(scope="session")

--- a/src/openassetio-python/tests/cmodule/gil/test_cpppluginsystem_gil.py
+++ b/src/openassetio-python/tests/cmodule/gil/test_cpppluginsystem_gil.py
@@ -71,7 +71,7 @@ class Test_CppPluginSystem_gil:
         a_cpp_plugin_system,
     ):
         a_cpp_plugin_system.scan(
-            the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook, noop
+            the_cpp_gil_check_plugin_path, "", the_cpp_gil_check_module_hook, noop
         )
 
     def test_identifiers(
@@ -82,7 +82,7 @@ class Test_CppPluginSystem_gil:
         a_cpp_plugin_system,
     ):
         a_cpp_plugin_system.scan(
-            the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook, noop
+            the_cpp_gil_check_plugin_path, "", the_cpp_gil_check_module_hook, noop
         )
 
         assert a_cpp_plugin_system.identifiers() == [the_cpp_gil_check_plugin_identifier]
@@ -94,7 +94,7 @@ class Test_CppPluginSystem_gil:
         a_cpp_plugin_system,
     ):
         a_cpp_plugin_system.scan(
-            the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook, noop
+            the_cpp_gil_check_plugin_path, "", the_cpp_gil_check_module_hook, noop
         )
         a_cpp_plugin_system.reset()
 
@@ -106,7 +106,7 @@ class Test_CppPluginSystem_gil:
         a_cpp_plugin_system,
     ):
         a_cpp_plugin_system.scan(
-            the_cpp_gil_check_plugin_path, the_cpp_gil_check_module_hook, noop
+            the_cpp_gil_check_plugin_path, "", the_cpp_gil_check_module_hook, noop
         )
 
         _path, _plugin = a_cpp_plugin_system.plugin(the_cpp_gil_check_plugin_identifier)

--- a/src/openassetio-python/tests/cmodule/resources/_testutils/gilTest.cpp
+++ b/src/openassetio-python/tests/cmodule/resources/_testutils/gilTest.cpp
@@ -14,7 +14,6 @@
 #include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/managerApi/EntityReferencePagerInterface.hpp>
 #include <openassetio/managerApi/ManagerInterface.hpp>
-#include <openassetio/pluginSystem/CppPluginSystemPlugin.hpp>
 
 /*
  * Hack trompeloeil to make use of its internals, but provide our own
@@ -170,18 +169,6 @@ struct ThreadedManagerImplFactory : hostApi::ManagerImplementationFactoryInterfa
   IMPLEMENT_MOCK1(instantiate);
 };
 
-namespace pluginSystem = openassetio::pluginSystem;
-
-struct ThreadedCppPluginSystemPlugin : pluginSystem::CppPluginSystemPlugin {
-  using Base = pluginSystem::CppPluginSystemPlugin;
-  static Ptr make(Ptr wrapped) {
-    return std::make_shared<ThreadedCppPluginSystemPlugin>(std::move(wrapped));
-  }
-  explicit ThreadedCppPluginSystemPlugin(Ptr wrapped) : wrapped_{std::move(wrapped)} {}
-  Ptr wrapped_;
-
-  IMPLEMENT_CONST_MOCK0(identifier);
-};
 }  // namespace
 
 extern void registerRunInThread(py::module_& mod) {
@@ -235,5 +222,4 @@ extern void registerRunInThread(py::module_& mod) {
   gil.def("wrapInThreadedHostInterface", &ThreadedHostInterface::make);
   gil.def("wrapInThreadedLoggerInterface", &ThreadedLoggerInterface::make);
   gil.def("wrapInThreadedManagerImplFactory", &ThreadedManagerImplFactory::make);
-  gil.def("wrapInThreadedCppPluginSystemPlugin", &ThreadedCppPluginSystemPlugin::make);
 }

--- a/src/openassetio-python/tests/package/hostApi/test_managerfactory.py
+++ b/src/openassetio-python/tests/package/hostApi/test_managerfactory.py
@@ -237,7 +237,8 @@ class Test_ManagerFactory_defaultManagerForInterface:
         mock_logger,
     ):
         with pytest.raises(
-            errors.ConfigurationException, match="Unsupported value type for 'a_dict'."
+            errors.ConfigurationException,
+            match="Error parsing config file. Unsupported value type for 'a_dict'.",
         ):
             if use_env_var_for_config_file:
                 ManagerFactory.defaultManagerForInterface(

--- a/src/openassetio-python/tests/package/pluginSystem/conftest.py
+++ b/src/openassetio-python/tests/package/pluginSystem/conftest.py
@@ -20,6 +20,7 @@ Helper fixtures for testing the Python plugin system
 # pylint: disable=invalid-name
 
 import os
+import re
 import sysconfig
 
 import openassetio
@@ -138,3 +139,20 @@ def the_cpp_plugins_root_path():
             os.getenv("OPENASSETIO_TEST_CPP_PLUGINS_SUBDIR", "plugin-env-var-not-set"),
         )
     )
+
+
+class RegexMatch:
+    """
+    Argument matcher to match strings by regular expression.
+    """
+
+    def __init__(self, pattern):
+        self.__pattern = pattern
+
+    def __eq__(self, text):
+        return bool(re.search(self.__pattern, text))
+
+
+@pytest.fixture(scope="session")
+def regex_matcher():
+    return RegexMatch

--- a/src/openassetio-python/tests/package/pluginSystem/conftest.py
+++ b/src/openassetio-python/tests/package/pluginSystem/conftest.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2013-2022 The Foundry Visionmongers Ltd
+#   Copyright 2013-2025 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -24,6 +24,11 @@ import sysconfig
 
 import openassetio
 import pytest
+
+
+@pytest.fixture
+def the_manager_plugin_module_hook():
+    return "openassetioPlugin"
 
 
 @pytest.fixture

--- a/src/openassetio-python/tests/package/pluginSystem/resources/pathB/packagedPlugin/PackagePlugin.py
+++ b/src/openassetio-python/tests/package/pluginSystem/resources/pathB/packagedPlugin/PackagePlugin.py
@@ -2,18 +2,12 @@
 Provides a test PythonPluginSystemPlugin implementation.
 """
 
-from openassetio.pluginSystem import PythonPluginSystemManagerPlugin
+from openassetio.pluginSystem import PythonPluginSystemPlugin
 
 
-class PackageManagerPlugin(PythonPluginSystemManagerPlugin):
+class PackagePlugin(PythonPluginSystemPlugin):
     # pylint: disable=missing-class-docstring
 
     @classmethod
     def identifier(cls):
         return "org.openassetio.test.pluginSystem.resources.pluginB"
-
-    @classmethod
-    def interface(cls):
-        # This is nonsense, but allows us to check where this was
-        # loaded from in precedence checks.
-        return {"file": __file__}

--- a/src/openassetio-python/tests/package/pluginSystem/resources/pathB/packagedPlugin/__init__.py
+++ b/src/openassetio-python/tests/package/pluginSystem/resources/pathB/packagedPlugin/__init__.py
@@ -5,8 +5,8 @@ Provides a test PythonPluginSystemPlugin implemented within a package.
 # pylint gets upset, but this is fine due to
 # the way the plugin system loads plugins.
 # pylint: disable=import-error
-from .PackagePlugin import PackageManagerPlugin
+from .PackagePlugin import PackagePlugin
 
 
 # pylint: disable=invalid-name
-openassetioPlugin = PackageManagerPlugin
+openassetioPlugin = PackagePlugin

--- a/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystem.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystem.py
@@ -201,7 +201,7 @@ class Test_CppPluginSystem_scan:
 
         assert "pathA" in path.parts
         mock_logger.mock.log.assert_any_call(
-            mock_logger.Severity.kDebug,
+            mock_logger.Severity.kWarning,
             f"CppPluginSystem: Skipping '{plugin_a_identifier}' defined in '{path_c_lib}'."
             f" Already registered by '{path_a_lib}'",
         )
@@ -218,7 +218,7 @@ class Test_CppPluginSystem_scan:
 
         assert "pathC" in path.parts
         mock_logger.mock.log.assert_any_call(
-            mock_logger.Severity.kDebug,
+            mock_logger.Severity.kWarning,
             f"CppPluginSystem: Skipping '{plugin_a_identifier}' defined in '{path_a_lib}'."
             f" Already registered by '{path_c_lib}'",
         )
@@ -260,7 +260,7 @@ class Test_CppPluginSystem_scan:
 
         # Confidence check that we hit the expected code path.
         mock_logger.mock.log.assert_any_call(
-            mock_logger.Severity.kDebug,
+            mock_logger.Severity.kWarning,
             f"CppPluginSystem: Skipping '{plugin_a_identifier}' defined in '{path_a_lib}'."
             f" Already registered by '{path_c_lib}'",
         )
@@ -348,7 +348,7 @@ class Test_CppPluginSystem_scan:
         )
 
         mock_logger.mock.log.assert_any_call(
-            mock_logger.Severity.kDebug,
+            mock_logger.Severity.kWarning,
             f"CppPluginSystem: Skipping '{plugin_a_identifier}' defined in '{path_a_lib}'."
             f" Already registered by '{symlink_path_a_lib}'",
         )

--- a/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystemmanagerimplementationfactory.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystemmanagerimplementationfactory.py
@@ -78,23 +78,6 @@ class Test_CppPluginSystemManagerImplementationFactory_lazy_scanning:
         factory = CppPluginSystemManagerImplementationFactory(mock_logger)
         assert factory.identifiers() == [plugin_a_identifier]
 
-    def test_when_path_arg_set_then_overrides_path_env(
-        self,
-        the_cpp_plugins_root_path,
-        plugin_b_identifier,
-        mock_logger,
-        monkeypatch,
-    ):
-        monkeypatch.setenv(
-            CppPluginSystemManagerImplementationFactory.kPluginEnvVar,
-            os.path.join(the_cpp_plugins_root_path, "managerA"),
-        )
-
-        factory = CppPluginSystemManagerImplementationFactory(
-            paths=os.path.join(the_cpp_plugins_root_path, "managerB"), logger=mock_logger
-        )
-        assert factory.identifiers() == [plugin_b_identifier]
-
     def test_when_paths_empty_then_returns_empty_list(self, mock_logger):
         plugin_paths = ""
         factory = CppPluginSystemManagerImplementationFactory(

--- a/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystemmanagerimplementationfactory.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystemmanagerimplementationfactory.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2013-2024 The Foundry Visionmongers Ltd
+#   Copyright 2013-2025 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -40,6 +40,11 @@ class Test_CppPluginSystemManagerImplementationFactory_kPluginEnvVar:
         assert (
             CppPluginSystemManagerImplementationFactory.kPluginEnvVar == "OPENASSETIO_PLUGIN_PATH"
         )
+
+
+class Test_CppPluginSystemManagerImplementationFactory_kModuleHookName:
+    def test_exposes_module_hook_name_with_expected_value(self):
+        assert CppPluginSystemManagerImplementationFactory.kModuleHookName == "openassetioPlugin"
 
 
 class Test_CppPluginSystemManagerImplementationFactory_lazy_scanning:

--- a/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystemplugin.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystemplugin.py
@@ -1,0 +1,36 @@
+#
+#   Copyright 2025 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+These tests check the structure of the CppPluginSystemPlugin base
+class.
+"""
+# pylint: disable=missing-class-docstring,invalid-name,missing-function-docstring
+import inspect
+
+import pytest
+
+from openassetio.pluginSystem import CppPluginSystemPlugin
+
+
+class Test_CppPluginSystemPlugin_init:
+    def test_raises_TypeError(self):
+        with pytest.raises(TypeError, match="No constructor defined!"):
+            CppPluginSystemPlugin()
+
+
+class Test_CppPluginSystemPlugin_identifier:
+    def test_method_exists(self):
+        assert inspect.isroutine(CppPluginSystemPlugin.identifier)

--- a/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystem.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystem.py
@@ -21,22 +21,254 @@ These tests check the functionality of the PythonPluginSystem class.
 # pylint: disable=missing-class-docstring,missing-function-docstring
 
 import os
-import sys
 from typing import List
+from unittest import mock
 
 import pytest
 
 from openassetio import errors
 from openassetio.log import ConsoleLogger
-from openassetio.pluginSystem import PythonPluginSystem
+from openassetio.pluginSystem import PythonPluginSystem, PythonPluginSystemPlugin
 
 
-# We use this entry point to allow us to share test resources with
-# the implementation factory tests.
+# Entry point group used by the stub plugins in the `resources`
+# directory.
 PLUGIN_ENTRY_POINT_GROUP = "openassetio.manager_plugin"
 
 
 class Test_PythonPluginSystem_scan:
+
+    def test_when_no_paths_and_entry_point_disabled_by_arg_then_nothing_scanned_and_warning_logged(
+        self,
+        a_plugin_system_with_mocked_scanning,
+        mock_logger,
+        a_paths_env_var,
+        an_entry_point_group_name,
+        a_disable_entry_point_env_var,
+        a_module_hook_name,
+    ):
+        a_plugin_system_with_mocked_scanning.scan(
+            "",
+            a_paths_env_var,
+            an_entry_point_group_name,
+            a_disable_entry_point_env_var,
+            True,
+            a_module_hook_name,
+        )
+
+        a_plugin_system_with_mocked_scanning.scan_paths.assert_not_called()
+        a_plugin_system_with_mocked_scanning.scan_entry_points.assert_not_called()
+
+        mock_logger.mock.log.assert_any_call(
+            mock_logger.Severity.kWarning,
+            "PythonPluginSystem: No search paths specified and entry point plugins are disabled,"
+            f" no plugins will load - check ${a_paths_env_var} is set.",
+        )
+
+    def test_when_no_paths_and_entry_point_disabled_by_env_then_nothing_scanned_and_warning_logged(
+        self,
+        a_plugin_system_with_mocked_scanning,
+        mock_logger,
+        monkeypatch,
+        a_paths_env_var,
+        an_entry_point_group_name,
+        a_disable_entry_point_env_var,
+        a_module_hook_name,
+    ):
+        monkeypatch.setenv(a_disable_entry_point_env_var, "1")
+
+        a_plugin_system_with_mocked_scanning.scan(
+            "",
+            a_paths_env_var,
+            an_entry_point_group_name,
+            a_disable_entry_point_env_var,
+            None,
+            a_module_hook_name,
+        )
+
+        a_plugin_system_with_mocked_scanning.scan_paths.assert_not_called()
+        a_plugin_system_with_mocked_scanning.scan_entry_points.assert_not_called()
+
+        mock_logger.mock.log.assert_any_call(
+            mock_logger.Severity.kWarning,
+            "PythonPluginSystem: No search paths specified and entry point plugins are disabled,"
+            f" no plugins will load - check ${a_paths_env_var} is set.",
+        )
+
+    def test_when_paths_then_env_var_not_used(
+        self,
+        a_plugin_system_with_mocked_scanning,
+        monkeypatch,
+        a_paths_env_var,
+        an_entry_point_group_name,
+        a_disable_entry_point_env_var,
+        a_module_hook_name,
+    ):
+        monkeypatch.setenv(a_paths_env_var, "/some/other/path")
+
+        a_plugin_system_with_mocked_scanning.scan(
+            "/some/path",
+            a_paths_env_var,
+            an_entry_point_group_name,
+            a_disable_entry_point_env_var,
+            None,
+            a_module_hook_name,
+        )
+
+        a_plugin_system_with_mocked_scanning.scan_paths.assert_called_once_with(
+            "/some/path", a_module_hook_name
+        )
+
+    def test_when_no_paths_then_env_var_used(
+        self,
+        a_plugin_system_with_mocked_scanning,
+        monkeypatch,
+        a_paths_env_var,
+        an_entry_point_group_name,
+        a_disable_entry_point_env_var,
+        a_module_hook_name,
+    ):
+        monkeypatch.setenv(a_paths_env_var, "/some/other/path")
+
+        a_plugin_system_with_mocked_scanning.scan(
+            "",
+            a_paths_env_var,
+            an_entry_point_group_name,
+            a_disable_entry_point_env_var,
+            None,
+            a_module_hook_name,
+        )
+
+        a_plugin_system_with_mocked_scanning.scan_paths.assert_called_once_with(
+            "/some/other/path", a_module_hook_name
+        )
+
+    def test_when_entry_point_then_entry_points_scanned(
+        self,
+        a_plugin_system_with_mocked_scanning,
+        a_paths_env_var,
+        an_entry_point_group_name,
+        a_disable_entry_point_env_var,
+        a_module_hook_name,
+    ):
+        a_plugin_system_with_mocked_scanning.scan(
+            "",
+            a_paths_env_var,
+            an_entry_point_group_name,
+            a_disable_entry_point_env_var,
+            None,
+            a_module_hook_name,
+        )
+
+        a_plugin_system_with_mocked_scanning.scan_entry_points.assert_called_once_with(
+            an_entry_point_group_name, a_module_hook_name
+        )
+
+    def test_when_entry_point_disabled_by_arg_then_entry_points_not_scanned(
+        self,
+        a_plugin_system_with_mocked_scanning,
+        mock_logger,
+        a_paths_env_var,
+        an_entry_point_group_name,
+        a_disable_entry_point_env_var,
+        a_module_hook_name,
+    ):
+        a_plugin_system_with_mocked_scanning.scan(
+            "/some/path",
+            a_paths_env_var,
+            an_entry_point_group_name,
+            a_disable_entry_point_env_var,
+            True,
+            a_module_hook_name,
+        )
+
+        a_plugin_system_with_mocked_scanning.scan_entry_points.assert_not_called()
+        mock_logger.mock.log.assert_any_call(
+            mock_logger.Severity.kDebug,
+            "Entry point based plugins are disabled",
+        )
+
+    def test_when_entry_point_disabled_by_env_then_entry_points_not_scanned(
+        self,
+        a_plugin_system_with_mocked_scanning,
+        mock_logger,
+        monkeypatch,
+        a_paths_env_var,
+        an_entry_point_group_name,
+        a_disable_entry_point_env_var,
+        a_module_hook_name,
+    ):
+        monkeypatch.setenv(a_disable_entry_point_env_var, "1")
+
+        a_plugin_system_with_mocked_scanning.scan(
+            "/some/path",
+            a_paths_env_var,
+            an_entry_point_group_name,
+            a_disable_entry_point_env_var,
+            True,
+            a_module_hook_name,
+        )
+
+        a_plugin_system_with_mocked_scanning.scan_entry_points.assert_not_called()
+        mock_logger.mock.log.assert_any_call(
+            mock_logger.Severity.kDebug,
+            "Entry point based plugins are disabled",
+        )
+
+    def test_when_entry_point_disabled_by_env_but_enabled_by_arg_then_entry_points_scanned(
+        self,
+        a_plugin_system_with_mocked_scanning,
+        monkeypatch,
+        a_paths_env_var,
+        an_entry_point_group_name,
+        a_disable_entry_point_env_var,
+        a_module_hook_name,
+    ):
+        monkeypatch.setenv(a_disable_entry_point_env_var, "1")
+
+        a_plugin_system_with_mocked_scanning.scan(
+            "/some/path",
+            a_paths_env_var,
+            an_entry_point_group_name,
+            a_disable_entry_point_env_var,
+            False,
+            a_module_hook_name,
+        )
+
+        a_plugin_system_with_mocked_scanning.scan_entry_points.assert_called_once_with(
+            an_entry_point_group_name, a_module_hook_name
+        )
+
+    def test_when_paths_and_entry_point_then_paths_scanned_first(
+        self,
+        a_plugin_system_with_mocked_scanning,
+        a_paths_env_var,
+        an_entry_point_group_name,
+        a_disable_entry_point_env_var,
+        a_module_hook_name,
+    ):
+        calls = mock.Mock()
+        calls.attach_mock(a_plugin_system_with_mocked_scanning.scan_paths, "scan_paths")
+        calls.attach_mock(
+            a_plugin_system_with_mocked_scanning.scan_entry_points, "scan_entry_points"
+        )
+
+        a_plugin_system_with_mocked_scanning.scan(
+            "/some/path",
+            a_paths_env_var,
+            an_entry_point_group_name,
+            a_disable_entry_point_env_var,
+            False,
+            a_module_hook_name,
+        )
+
+        assert calls.mock_calls == [
+            mock.call.scan_paths("/some/path", a_module_hook_name),
+            mock.call.scan_entry_points(an_entry_point_group_name, a_module_hook_name),
+        ]
+
+
+class Test_PythonPluginSystem_scan_paths:
     def test_when_path_contains_a_module_plugin_definition_then_it_is_loaded(
         self,
         a_plugin_system,
@@ -44,7 +276,7 @@ class Test_PythonPluginSystem_scan:
         a_python_module_plugin_path,
         plugin_a_identifier,
     ):
-        a_plugin_system.scan(a_python_module_plugin_path, the_manager_plugin_module_hook)
+        a_plugin_system.scan_paths(a_python_module_plugin_path, the_manager_plugin_module_hook)
         assert a_plugin_system.identifiers() == [
             plugin_a_identifier,
         ]
@@ -56,7 +288,7 @@ class Test_PythonPluginSystem_scan:
         a_python_package_plugin_path,
         plugin_b_identifier,
     ):
-        a_plugin_system.scan(a_python_package_plugin_path, the_manager_plugin_module_hook)
+        a_plugin_system.scan_paths(a_python_package_plugin_path, the_manager_plugin_module_hook)
         assert a_plugin_system.identifiers() == [
             plugin_b_identifier,
         ]
@@ -73,7 +305,7 @@ class Test_PythonPluginSystem_scan:
         combined_path = os.pathsep.join(
             [a_python_package_plugin_path, a_python_module_plugin_path]
         )
-        a_plugin_system.scan(combined_path, the_manager_plugin_module_hook)
+        a_plugin_system.scan_paths(combined_path, the_manager_plugin_module_hook)
 
         expected_identifiers = set([plugin_b_identifier, plugin_a_identifier])
         assert set(a_plugin_system.identifiers()) == expected_identifiers
@@ -85,7 +317,7 @@ class Test_PythonPluginSystem_scan:
         a_deprecated_plugin_path,
         deprecated_plugin_identifier,
     ):
-        a_plugin_system.scan(a_deprecated_plugin_path, the_manager_plugin_module_hook)
+        a_plugin_system.scan_paths(a_deprecated_plugin_path, the_manager_plugin_module_hook)
         assert a_plugin_system.identifiers() == [
             deprecated_plugin_identifier,
         ]
@@ -95,7 +327,7 @@ class Test_PythonPluginSystem_scan:
     ):
         deprecated_plugin_path = os.path.join(a_deprecated_plugin_path, "deprecatedPlugin.py")
         plugin_system = PythonPluginSystem(mock_logger)
-        plugin_system.scan(a_deprecated_plugin_path, the_manager_plugin_module_hook)
+        plugin_system.scan_paths(a_deprecated_plugin_path, the_manager_plugin_module_hook)
         mock_logger.mock.log.assert_any_call(
             mock_logger.Severity.kWarning,
             "PythonPluginSystem: Use of top-level 'plugin' variable is deprecated, "
@@ -113,14 +345,14 @@ class Test_PythonPluginSystem_scan:
         path_a = os.path.join(the_python_resources_directory_path, "pathA")
         path_c = os.path.join(the_python_resources_directory_path, "pathC")
 
-        a_plugin_system.scan(
+        a_plugin_system.scan_paths(
             moduleHookName=the_manager_plugin_module_hook, paths=os.pathsep.join((path_a, path_c))
         )
         assert "pathA" in a_plugin_system.plugin(plugin_a_identifier).__file__
 
         a_plugin_system.reset()
 
-        a_plugin_system.scan(
+        a_plugin_system.scan_paths(
             moduleHookName=the_manager_plugin_module_hook, paths=os.pathsep.join((path_c, path_a))
         )
         assert "pathC" in a_plugin_system.plugin(plugin_a_identifier).__file__
@@ -133,7 +365,9 @@ class Test_PythonPluginSystem_scan:
         plugin_b_identifier,
         plugin_a_identifier,
     ):
-        a_plugin_system.scan(a_python_plugin_path_with_symlinks, the_manager_plugin_module_hook)
+        a_plugin_system.scan_paths(
+            a_python_plugin_path_with_symlinks, the_manager_plugin_module_hook
+        )
 
         expected_identifiers = set([plugin_b_identifier, plugin_a_identifier])
         assert set(a_plugin_system.identifiers()) == expected_identifiers
@@ -147,10 +381,10 @@ class Test_PythonPluginSystem_scan:
         plugin_b_identifier,
         plugin_a_identifier,
     ):
-        a_plugin_system.scan(
+        a_plugin_system.scan_paths(
             moduleHookName=the_manager_plugin_module_hook, paths=a_python_package_plugin_path
         )
-        a_plugin_system.scan(
+        a_plugin_system.scan_paths(
             moduleHookName=the_manager_plugin_module_hook, paths=a_python_module_plugin_path
         )
 
@@ -161,7 +395,7 @@ class Test_PythonPluginSystem_scan:
         self, the_manager_plugin_module_hook, broken_python_plugins_path, mock_logger
     ):
         plugin_system = PythonPluginSystem(mock_logger)
-        plugin_system.scan(broken_python_plugins_path, the_manager_plugin_module_hook)
+        plugin_system.scan_paths(broken_python_plugins_path, the_manager_plugin_module_hook)
 
         assert not plugin_system.identifiers()
         missing_plugin_path = os.path.join(broken_python_plugins_path, "missing_plugin.py")
@@ -202,8 +436,7 @@ class Test_PythonPluginSystem_scan_entry_points:
         entry_point_plugin_identifier,
         monkeypatch,
     ):
-        path_with_plugin = [an_entry_point_package_plugin_root] + sys.path
-        monkeypatch.setattr(sys, "path", path_with_plugin)
+        monkeypatch.syspath_prepend(an_entry_point_package_plugin_root)
 
         assert (
             a_plugin_system.scan_entry_points(
@@ -213,11 +446,51 @@ class Test_PythonPluginSystem_scan_entry_points:
         )
         assert a_plugin_system.identifiers() == [entry_point_plugin_identifier]
 
+    def test_when_entry_point_plugin_identifier_already_used_then_skipped(
+        self,
+        the_manager_plugin_module_hook,
+        an_entry_point_package_plugin_root,
+        entry_point_plugin_identifier,
+        mock_logger,
+        monkeypatch,
+    ):
+        # setup
+
+        plugin_system = PythonPluginSystem(mock_logger)
+        monkeypatch.syspath_prepend(an_entry_point_package_plugin_root)
+
+        # Register a plugin that conflicts with the plugin discovered
+        # at the entry point.
+        class ExpectedPlugin(PythonPluginSystemPlugin):
+            @classmethod
+            def identifier(cls):
+                return entry_point_plugin_identifier
+
+        plugin_system.register(ExpectedPlugin, "/some/plugin/path")
+
+        # action
+
+        plugin_system.scan_entry_points(PLUGIN_ENTRY_POINT_GROUP, the_manager_plugin_module_hook)
+
+        # confirm
+
+        actual_plugin = plugin_system.plugin(entry_point_plugin_identifier)
+        assert actual_plugin is ExpectedPlugin
+
+        entry_point_plugin_init = os.path.join(
+            an_entry_point_package_plugin_root, "packaged_plugin", "__init__.py"
+        )
+        mock_logger.mock.log.assert_any_call(
+            mock_logger.Severity.kDebug,
+            f"PythonPluginSystem: Skipping class"
+            f" '<class 'packaged_plugin.PackagePlugin.PackagePlugin'>' defined in"
+            f" '{entry_point_plugin_init}'. Already registered by '/some/plugin/path'",
+        )
+
     def test_when_plugins_broken_then_skipped_with_expected_errors(
         self, the_manager_plugin_module_hook, broken_python_plugins_path, mock_logger, monkeypatch
     ):
-        path_with_plugin = [broken_python_plugins_path] + sys.path
-        monkeypatch.setattr(sys, "path", path_with_plugin)
+        monkeypatch.syspath_prepend(broken_python_plugins_path)
 
         plugin_system = PythonPluginSystem(mock_logger)
         plugin_system.scan_entry_points(PLUGIN_ENTRY_POINT_GROUP, the_manager_plugin_module_hook)
@@ -256,12 +529,46 @@ def a_plugin_system(a_logger):
     return PythonPluginSystem(a_logger)
 
 
+@pytest.fixture
+def a_plugin_system_with_mocked_scanning(mock_logger, monkeypatch):
+    plugin_system = PythonPluginSystem(mock_logger)
+    monkeypatch.setattr(
+        plugin_system, "scan_paths", mock.create_autospec(spec=plugin_system.scan_paths)
+    )
+    monkeypatch.setattr(
+        plugin_system,
+        "scan_entry_points",
+        mock.create_autospec(spec=plugin_system.scan_entry_points),
+    )
+    return plugin_system
+
+
 # We use a real logger vs a mock, as it makes debugging test failures
 # easier as it surfaces any actual in-flight errors from the plugin
 # system.
 @pytest.fixture
 def a_logger():
     return ConsoleLogger()
+
+
+@pytest.fixture
+def a_paths_env_var():
+    return "test_pythonpluginsystem_PATHS_ENV_VAR"
+
+
+@pytest.fixture
+def a_disable_entry_point_env_var():
+    return "test_pythonpluginsystem_DISABLE_ENTRY_POINT_ENV_VAR"
+
+
+@pytest.fixture
+def an_entry_point_group_name():
+    return "some_entry_point"
+
+
+@pytest.fixture
+def a_module_hook_name():
+    return "some_hook"
 
 
 class StringContaining:

--- a/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystem.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystem.py
@@ -481,7 +481,7 @@ class Test_PythonPluginSystem_scan_entry_points:
             an_entry_point_package_plugin_root, "packaged_plugin", "__init__.py"
         )
         mock_logger.mock.log.assert_any_call(
-            mock_logger.Severity.kDebug,
+            mock_logger.Severity.kWarning,
             f"PythonPluginSystem: Skipping class"
             f" '<class 'packaged_plugin.PackagePlugin.PackagePlugin'>' defined in"
             f" '{entry_point_plugin_init}'. Already registered by '/some/plugin/path'",

--- a/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystemmanagerimplementationfactory.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystemmanagerimplementationfactory.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2013-2022 The Foundry Visionmongers Ltd
+#   Copyright 2013-2025 The Foundry Visionmongers Ltd
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -22,11 +22,16 @@ ManagerImplementationFactoryInterface implementation.
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 # pylint: disable=use-implicit-booleaness-not-comparison
+import sys
+from unittest import mock
 
 import pytest
 
 from openassetio.log import ConsoleLogger
-from openassetio.pluginSystem import PythonPluginSystemManagerImplementationFactory
+from openassetio.pluginSystem import (
+    PythonPluginSystemManagerImplementationFactory,
+    PythonPluginSystem,
+)
 
 
 class Test_PythonPluginSystemManagerImplementationFactory:
@@ -55,122 +60,110 @@ class Test_PythonPluginSystemManagerImplementationFactory:
 
 
 class Test_PythonPluginSystemManagerImplementationFactory_init:
-    def test_when_no_args_or_env_vars_then_entry_point_plugins_loaded(
-        self,
-        prepended_sys_path_with_entry_point_plugin,
-        entry_point_plugin_identifier,
-    ):
+    def test_when_no_paths_then_paths_not_scanned(self, mock_plugin_system):
         factory = PythonPluginSystemManagerImplementationFactory(ConsoleLogger())
-        assert factory.identifiers() == [entry_point_plugin_identifier]
 
-    def test_when_no_paths_and_entry_points_disabled_then_warning_logged(
-        self, mock_logger, monkeypatch
-    ):
-        expected_msg = (
-            "No search paths specified and entry point plugins are disabled, no plugins will "
-            f"load - check ${PythonPluginSystemManagerImplementationFactory.kPluginEnvVar} is set."
-        )
-        expected_severity = mock_logger.Severity.kWarning
+        factory.identifiers()
 
-        monkeypatch.delenv(
-            PythonPluginSystemManagerImplementationFactory.kPluginEnvVar, raising=False
-        )
-
-        factory = PythonPluginSystemManagerImplementationFactory(
-            mock_logger, disableEntryPointsPlugins=True
-        )
-        # Plugins are scanned lazily when first requested
-        assert factory.identifiers() == []
-        mock_logger.mock.log.assert_called_once_with(expected_severity, expected_msg)
-
-    def test_when_no_args_and_entry_points_disabled_env_then_entry_point_not_loaded(
-        self, prepended_sys_path_with_entry_point_plugin, monkeypatch
-    ):
-        monkeypatch.setenv(
-            PythonPluginSystemManagerImplementationFactory.kDisableEntryPointsEnvVar, "1"
-        )
-        monkeypatch.delenv(
-            PythonPluginSystemManagerImplementationFactory.kPluginEnvVar, raising=False
-        )
-
-        factory = PythonPluginSystemManagerImplementationFactory(ConsoleLogger())
-        assert factory.identifiers() == []
-
-    def test_when_no_args_and_path_env_then_path_plugins_loaded(
-        self,
-        a_python_module_plugin_path,
-        plugin_a_identifier,
-        monkeypatch,
-    ):
-        monkeypatch.setenv(
+        mock_plugin_system.scan.assert_called_once_with(
+            None,
             PythonPluginSystemManagerImplementationFactory.kPluginEnvVar,
-            a_python_module_plugin_path,
+            PythonPluginSystemManagerImplementationFactory.kPackageEntryPointGroup,
+            PythonPluginSystemManagerImplementationFactory.kDisableEntryPointsEnvVar,
+            None,
+            PythonPluginSystemManagerImplementationFactory.kModuleHookName,
         )
-        factory = PythonPluginSystemManagerImplementationFactory(ConsoleLogger())
-        assert factory.identifiers() == [plugin_a_identifier]
 
-    def test_when_path_arg_set_then_overrides_path_env(
-        self,
-        a_python_module_plugin_path,
-        a_python_package_plugin_path,
-        plugin_b_identifier,
-        mock_logger,
-        monkeypatch,
-    ):
-        monkeypatch.setenv(
+    def test_when_paths_then_paths_scanned(self, mock_plugin_system):
+        factory = PythonPluginSystemManagerImplementationFactory(
+            ConsoleLogger(), paths="/some/path"
+        )
+
+        factory.identifiers()
+
+        mock_plugin_system.scan.assert_called_once_with(
+            "/some/path",
             PythonPluginSystemManagerImplementationFactory.kPluginEnvVar,
-            a_python_module_plugin_path,
+            PythonPluginSystemManagerImplementationFactory.kPackageEntryPointGroup,
+            PythonPluginSystemManagerImplementationFactory.kDisableEntryPointsEnvVar,
+            None,
+            PythonPluginSystemManagerImplementationFactory.kModuleHookName,
         )
 
-        factory = PythonPluginSystemManagerImplementationFactory(
-            paths=a_python_package_plugin_path, logger=mock_logger
-        )
-        assert factory.identifiers() == [
-            plugin_b_identifier,
-        ]
-
-    def test_when_entry_points_disable_arg_set_then_overrides_entry_points_disable_env(
-        self,
-        prepended_sys_path_with_entry_point_plugin,
-        entry_point_plugin_identifier,
-        mock_logger,
-        monkeypatch,
+    def test_when_entry_points_disabled_arg_then_arg_passed_to_plugin_system(
+        self, mock_plugin_system
     ):
-        monkeypatch.setenv(
-            PythonPluginSystemManagerImplementationFactory.kDisableEntryPointsEnvVar, "1"
-        )
+        disable_entry_points = mock.Mock()
+
         factory = PythonPluginSystemManagerImplementationFactory(
-            disableEntryPointsPlugins=False, logger=mock_logger
+            ConsoleLogger(), disableEntryPointsPlugins=disable_entry_points
         )
-        assert factory.identifiers() == [
-            entry_point_plugin_identifier,
-        ]
 
-    def test_when_paths_empty_then_returns_empty_list(self, mock_logger):
+        factory.identifiers()
 
-        plugin_paths = ""
-        factory = PythonPluginSystemManagerImplementationFactory(
-            paths=plugin_paths, logger=mock_logger
+        mock_plugin_system.scan.assert_called_once_with(
+            None,
+            PythonPluginSystemManagerImplementationFactory.kPluginEnvVar,
+            PythonPluginSystemManagerImplementationFactory.kPackageEntryPointGroup,
+            PythonPluginSystemManagerImplementationFactory.kDisableEntryPointsEnvVar,
+            disable_entry_points,
+            PythonPluginSystemManagerImplementationFactory.kModuleHookName,
         )
-        assert factory.identifiers() == []
 
-    def test_when_duplicate_identifiers_path_selected_over_entry_point(
-        self,
-        prepended_sys_path_with_entry_point_plugin,
-        a_python_package_plugin_path,
-        plugin_b_identifier,
-        mock_logger,
+
+class Test_PythonPluginSystemManagerImplementationFactory_identifiers:
+    def test_lazy_scans_for_plugins_before_returning_identifiers(
+        self, mock_plugin_system, mock_logger
     ):
-        factory = PythonPluginSystemManagerImplementationFactory(
-            mock_logger, paths=a_python_package_plugin_path, disableEntryPointsPlugins=False
-        )
+        factory = PythonPluginSystemManagerImplementationFactory(mock_logger)
+        calls = mock.Mock()
+        calls.attach_mock(mock_plugin_system.scan, "scan")
+        calls.attach_mock(mock_plugin_system.identifiers, "identifiers")
 
-        assert factory.identifiers() == [
-            plugin_b_identifier,
+        first_identifiers = factory.identifiers()
+        second_identifiers = factory.identifiers()
+
+        assert calls.method_calls == [
+            mock.call.scan(mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY),
+            mock.call.identifiers(),
+            mock.call.identifiers(),
         ]
-        assert a_python_package_plugin_path in factory.instantiate(plugin_b_identifier)["file"]
+        assert first_identifiers == second_identifiers
+        assert first_identifiers == mock_plugin_system.identifiers.return_value
+
+
+class Test_PythonPluginSystemManagerImplementationFactory_instantiate:
+    def test_lazy_scans_for_plugins_before_instantiating(self, mock_plugin_system, mock_logger):
+        factory = PythonPluginSystemManagerImplementationFactory(mock_logger)
+        calls = mock.Mock()
+        calls.attach_mock(mock_plugin_system.scan, "scan")
+        calls.attach_mock(mock_plugin_system.plugin, "plugin")
+
+        factory.instantiate("first_id")
+        factory.instantiate("second_id")
+
+        assert calls.method_calls == [
+            mock.call.scan(mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY),
+            mock.call.plugin("first_id"),
+            mock.call.plugin("second_id"),
+        ]
+
+    def test_returns_instance_created_by_plugin(self, mock_plugin_system, mock_logger):
+        factory = PythonPluginSystemManagerImplementationFactory(mock_logger)
+
+        instance = factory.instantiate("some_identifier")
+
+        mock_plugin_system.plugin.assert_called_once_with("some_identifier")
+        mock_plugin_system.plugin.return_value.interface.assert_called_once_with()
+        assert instance is mock_plugin_system.plugin.return_value.interface.return_value
 
 
 @pytest.fixture
-def prepended_sys_path_with_entry_point_plugin(an_entry_point_package_plugin_root, monkeypatch):
-    monkeypatch.syspath_prepend(an_entry_point_package_plugin_root)
+def mock_plugin_system(monkeypatch):
+    plugin_system = mock.create_autospec(spec=PythonPluginSystem)
+    monkeypatch.setattr(
+        sys.modules[PythonPluginSystemManagerImplementationFactory.__module__],
+        "PythonPluginSystem",
+        plugin_system,
+    )
+    return plugin_system.return_value

--- a/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystemmanagerimplementationfactory.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystemmanagerimplementationfactory.py
@@ -48,6 +48,11 @@ class Test_PythonPluginSystemManagerImplementationFactory:
             == "openassetio.manager_plugin"
         )
 
+    def test_exposes_module_hook_with_expected_value(self):
+        assert (
+            PythonPluginSystemManagerImplementationFactory.kModuleHookName == "openassetioPlugin"
+        )
+
 
 class Test_PythonPluginSystemManagerImplementationFactory_init:
     def test_when_no_args_or_env_vars_then_entry_point_plugins_loaded(


### PR DESCRIPTION
## Description

Part of #1445. In preparation for adding new types of plugin (i.e. UI delegates), refactor the C++ and Python plugin systems to move more logic into the common `CppPluginSystem` and `PythonPluginSystem` utility classes.

These changes do require a breaking change to the `CppPluginSystem` and `PythonPluginSystem` APIs. However, except for extremely unlikely advanced use-cases, these classes are an implementation detail, so changing their API should not cause any downstream breakages.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.
