### PR TITLE
Add "isPython" to `HostInterface.info()`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,12 @@ _This release remains source compatible for both hosts and managers._
 
 ## Improvements
 
+- Added a new constant `kInfoKey_IsPython` (`"isPython"`), and used in
+  the Python `HostInterface.info()` base class implementation, allowing
+  managers to detect if the host they're interacting with is written in
+  Python.
+  [#1445](https://github.com/OpenAssetIO/OpenAssetIO/issues/1445)
+
 - Added operators and hash functions to the `EntityReference` type, in
   both C++ and Python, such that `EntityReference` objects can be used
   as keys in associative containers (e.g. `dict`/`std::unordered_map`).

--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -803,6 +803,7 @@ INPUT                  = ./src \
                          ../../src/openassetio-core/include \
                          ../../src/openassetio-python/bridge/include \
                          ../../src/openassetio-python/package/openassetio/hostApi/terminology.py \
+                         ../../src/openassetio-python/package/openassetio/hostApi/HostInterface.py \
                          ../../src/openassetio-python/package/openassetio/pluginSystem \
                          ../../src/openassetio-python/package/openassetio/test \
 

--- a/src/openassetio-core/include/openassetio/constants.hpp
+++ b/src/openassetio-core/include/openassetio/constants.hpp
@@ -32,6 +32,17 @@ namespace constants {
 inline constexpr std::string_view kInfoKey_SmallIcon = "smallIcon";
 inline constexpr std::string_view kInfoKey_Icon = "icon";
 
+/**
+ * Indicate that the callee is written primarily in Python.
+ *
+ * OpenAssetIO is a mostly seamless dual-language library, but for some
+ * access patterns it may be necessary for callers to be aware that the
+ * callee is written in Python to ensure correct behaviour.
+ *
+ * @see @ref hostApi.HostInterface.info "HostInterface.info".
+ */
+inline constexpr std::string_view kInfoKey_IsPython = "isPython";
+
 // Entity Reference Properties
 
 /**

--- a/src/openassetio-core/include/openassetio/hostApi/HostInterface.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/HostInterface.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #pragma once
 
 #include <memory>
@@ -92,9 +92,18 @@ class OPENASSETIO_CORE_EXPORT HostInterface {
 
   /**
    * Returns other information that may be useful about this Host.
-   * This can contain arbitrary key/value pairs. Managers never rely
-   * directly on any particular keys being set here, but the
-   * information may be useful for diagnostic or debugging purposes.
+   *
+   * This can contain arbitrary key/value pairs.
+   *
+   * The default implementation gives an empty dictionary. The Python
+   * base class implementation adds @ref
+   * constants.kInfoKey_IsPython - see @ref
+   * openassetio.hostApi.HostInterface.HostInterface "Python
+   * HostInterface".
+   *
+   * Otherwise, managers never rely directly on any particular keys
+   * being set here, but the information may be useful for diagnostic or
+   * debugging purposes.
    * For example:
    *
    * { 'version' : '1.1v3' }

--- a/src/openassetio-python/cmodule/src/constantsBinding.cpp
+++ b/src/openassetio-python/cmodule/src/constantsBinding.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 
@@ -12,4 +12,5 @@ void registerConstants(const py::module_ &mod) {
   mod.attr("kInfoKey_SmallIcon") = openassetio::constants::kInfoKey_SmallIcon;
   mod.attr("kInfoKey_EntityReferencesMatchPrefix") =
       openassetio::constants::kInfoKey_EntityReferencesMatchPrefix;
+  mod.attr("kInfoKey_IsPython") = openassetio::constants::kInfoKey_IsPython;
 }

--- a/src/openassetio-python/package/openassetio/hostApi/HostInterface.py
+++ b/src/openassetio-python/package/openassetio/hostApi/HostInterface.py
@@ -1,0 +1,44 @@
+#
+#   Copyright 2025 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+@namespace openassetio.hostApi.HostInterface
+A single-class module, providing the HostInterface class.
+"""
+
+from .. import constants
+from .. import _openassetio  # pylint: disable=no-name-in-module
+
+
+__all__ = ["HostInterface"]
+
+
+class HostInterface(_openassetio.hostApi.HostInterface):
+    """
+    Python base class augmenting the C++ abstract base class.
+
+    @see @fqref{hostApi.HostInterface} "HostInterface".
+    """
+
+    def info(self):
+        """
+        Override base class implementation to add
+        @fqref{constants.kInfoKey_IsPython} "kInfoKey_IsPython".
+
+        @see @fqref{hostApi.HostInterface.info} "HostInterface.info".
+        """
+        out = super().info()
+        out[constants.kInfoKey_IsPython] = True
+        return out

--- a/src/openassetio-python/package/openassetio/hostApi/__init__.py
+++ b/src/openassetio-python/package/openassetio/hostApi/__init__.py
@@ -25,8 +25,9 @@ see @ref openassetio.managerApi.
 
 from .. import _openassetio  # pylint: disable=no-name-in-module
 
+from .HostInterface import HostInterface
+
 Manager = _openassetio.hostApi.Manager
 ManagerFactory = _openassetio.hostApi.ManagerFactory
-HostInterface = _openassetio.hostApi.HostInterface
 ManagerImplementationFactoryInterface = _openassetio.hostApi.ManagerImplementationFactoryInterface
 EntityReferencePager = _openassetio.hostApi.EntityReferencePager

--- a/src/openassetio-python/tests/cmodule/resources/_testutils/CMakeLists.txt
+++ b/src/openassetio-python/tests/cmodule/resources/_testutils/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(
     PyRetainingSharedPtrTest.cpp
     errorsTest.cpp
     gilTest.cpp
+    HostInterfaceTest.cpp
 )
 
 # Give access to private headers.

--- a/src/openassetio-python/tests/cmodule/resources/_testutils/HostInterfaceTest.cpp
+++ b/src/openassetio-python/tests/cmodule/resources/_testutils/HostInterfaceTest.cpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Foundry Visionmongers Ltd
+#include <memory>
+
+#include <pybind11/pybind11.h>
+
+#include <openassetio/hostApi/HostInterface.hpp>
+#include <openassetio/typedefs.hpp>
+
+namespace py = pybind11;
+
+class StubHostInterface final : public openassetio::hostApi::HostInterface {
+ public:
+  [[nodiscard]] openassetio::Identifier identifier() const override {
+    return "org.openassetio.host.stub";
+  }
+  [[nodiscard]] openassetio::Str displayName() const override { return "Stub Host"; }
+};
+
+extern void registerCreateHostInterface(py::module& mod) {
+  using openassetio::hostApi::HostInterfacePtr;
+
+  mod.def("createCppHostInterface",
+          []() -> HostInterfacePtr { return std::make_shared<StubHostInterface>(); });
+}

--- a/src/openassetio-python/tests/cmodule/resources/_testutils/_testutils.cpp
+++ b/src/openassetio-python/tests/cmodule/resources/_testutils/_testutils.cpp
@@ -7,10 +7,12 @@ namespace py = pybind11;
 extern void registerPyRetainingSharedPtrTestTypes(py::module_&);
 extern void registerExceptionThrower(py::module_& mod);
 extern void registerRunInThread(py::module_& mod);
+extern void registerCreateHostInterface(py::module_& mod);
 
 extern void registerTestUtils(py::module& mod) {
   py::module_ testutils = mod.def_submodule("_testutils");
   registerPyRetainingSharedPtrTestTypes(testutils);
   registerExceptionThrower(testutils);
   registerRunInThread(testutils);
+  registerCreateHostInterface(testutils);
 }

--- a/src/openassetio-python/tests/cmodule/test_HostInterface.py
+++ b/src/openassetio-python/tests/cmodule/test_HostInterface.py
@@ -1,0 +1,31 @@
+#
+#   Copyright 2025 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# pylint: disable=missing-class-docstring,missing-function-docstring
+# pylint: disable=invalid-name,protected-access
+"""
+Tests for the Python bindings of the HostInterface class.
+"""
+from openassetio import constants
+from openassetio import _openassetio  # pylint: disable=no-name-in-module
+
+
+class Test_HostInterface_info:
+    def test_when_implemented_in_cpp_then_info_does_not_have_isPython(self):
+        host_interface = _openassetio._testutils.createCppHostInterface()
+
+        info = host_interface.info()
+
+        assert constants.kInfoKey_IsPython not in info

--- a/src/openassetio-python/tests/package/hostApi/test_hostinterface.py
+++ b/src/openassetio-python/tests/package/hostApi/test_hostinterface.py
@@ -21,6 +21,7 @@ Tests that cover the openassetio.hostApi.HostInterface class.
 # pylint: disable=missing-class-docstring,missing-function-docstring
 import pytest
 
+from openassetio import constants
 from openassetio.hostApi import HostInterface
 
 
@@ -34,6 +35,13 @@ class Test_HostInterface_displayName:
     def test_is_pure_virtual(self, an_unimplemented_host_interface):
         with pytest.raises(RuntimeError, match="Tried to call pure virtual function"):
             an_unimplemented_host_interface.displayName()
+
+
+class Test_HostInterface_info:
+    def test_default_implementation_has_default_values(self, an_unimplemented_host_interface):
+        info = an_unimplemented_host_interface.info()
+
+        assert info == {constants.kInfoKey_IsPython: True}
 
 
 @pytest.fixture

--- a/src/openassetio-python/tests/package/test_constants.py
+++ b/src/openassetio-python/tests/package/test_constants.py
@@ -26,3 +26,4 @@ def test():
     assert constants.kInfoKey_SmallIcon == "smallIcon"
     assert constants.kInfoKey_Icon == "icon"
     assert constants.kInfoKey_EntityReferencesMatchPrefix == "entityReferencesMatchPrefix"
+    assert constants.kInfoKey_IsPython == "isPython"


### PR DESCRIPTION
## Description

Part of #1445. OpenAssetIO is a mostly seamless dual-language library, but for some access patterns it may be necessary for managers to be aware that the host is written in Python to ensure correct behaviour.

For example, UI delegation may require UI elements to be passed to the host as Python object wrappers around native UI elements.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.
