### PR TITLE
[CI] Add a suppression for GNU Make web link fail

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -2,6 +2,9 @@
   "ignorePatterns": [
     {
       "pattern": "^https://www.ftrack.com"
+    },
+    {
+      "pattern": "^https://www.gnu.org"
     }
   ]
 }


### PR DESCRIPTION
## Description

For a few weeks now the `https://www.gnu.org/software/make` link in `docs/doxygen/README.md` frequently fails the `markdown-link-check` CI job with

```
 ERROR: 1 dead links found!
[✖] https://www.gnu.org/software/make/ → Status: 0
```

That link invariably works when tried locally, yet fails most (but not all) of the time when `markdown-link-check` tries it on a GitHub runner.

So simply add a suppression for `https://www.gnu.org`.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~
