### PR TITLE
Reduce severity of CppPluginSystem search path warning

### DIFF
--- a/src/openassetio-core/tests/CMakeLists.txt
+++ b/src/openassetio-core/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(openassetio-core-cpp-test-exe
     managerApi/HostTest.cpp
     managerApi/HostSessionTest.cpp
     managerApi/ManagerStateBaseTest.cpp
+    pluginSystem/CppPluginSystemTest.cpp
 )
 
 target_link_libraries(

--- a/src/openassetio-core/tests/pluginSystem/CppPluginSystemTest.cpp
+++ b/src/openassetio-core/tests/pluginSystem/CppPluginSystemTest.cpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Foundry Visionmongers Ltd
+#include <memory>
+
+#include <catch2/catch.hpp>
+#include <catch2/trompeloeil.hpp>
+#include <trompeloeil.hpp>
+
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/pluginSystem/CppPluginSystem.hpp>
+
+namespace {
+/**
+ * Mock implementation of a LoggerInterface
+ */
+struct MockLoggerInterface final : trompeloeil::mock_interface<openassetio::log::LoggerInterface> {
+  IMPLEMENT_MOCK2(log);
+};
+}  // namespace
+
+SCENARIO("CppPluginSystem::scan") {
+  GIVEN("a CppPluginSystem") {
+    auto logger = std::make_shared<MockLoggerInterface>();
+    auto cppPluginSystem = openassetio::pluginSystem::CppPluginSystem::make(logger);
+
+    using trompeloeil::_;
+    ALLOW_CALL(*logger, log(_, _));
+
+    WHEN("scan() called with uninitialised arguments") {
+      cppPluginSystem->scan({}, {}, {}, {});
+
+      THEN("no segfault") { CHECK(cppPluginSystem->identifiers().empty()); }
+    }
+  }
+}

--- a/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystem.py
+++ b/src/openassetio-python/package/openassetio/pluginSystem/PythonPluginSystem.py
@@ -98,7 +98,7 @@ class PythonPluginSystem(object):
             disableEntryPoints = os.environ.get(disableEntryPointsEnvVar, False)
 
         if not paths and disableEntryPoints:
-            self.__logger.warning(
+            self.__logger.debug(
                 "PythonPluginSystem: No search paths specified and entry point plugins are"
                 f" disabled, no plugins will load - check ${pathsEnvVar} is set.",
             )

--- a/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystem.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystem.py
@@ -40,8 +40,8 @@ class Test_CppPluginSystem_scan:
         a_plugin_system.scan("", a_plugin_path_env_var, "some_hook", noop)
 
         mock_logger.mock.log.assert_any_call(
-            mock_logger.Severity.kWarning,
-            "No search paths specified, no plugins will load - check"
+            mock_logger.Severity.kDebug,
+            "CppPluginSystem: No search paths specified, no plugins will load - check"
             f" ${a_plugin_path_env_var} is set",
         )
 

--- a/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystemmanagerimplementationfactory.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_cpppluginsystemmanagerimplementationfactory.py
@@ -50,10 +50,10 @@ class Test_CppPluginSystemManagerImplementationFactory_kModuleHookName:
 class Test_CppPluginSystemManagerImplementationFactory_lazy_scanning:
     def test_when_no_paths_then_warning_logged(self, mock_logger, monkeypatch):
         expected_msg = (
-            "No search paths specified, no plugins will load - check"
+            "CppPluginSystem: No search paths specified, no plugins will load - check"
             f" ${CppPluginSystemManagerImplementationFactory.kPluginEnvVar} is set"
         )
-        expected_severity = mock_logger.Severity.kWarning
+        expected_severity = mock_logger.Severity.kDebug
 
         monkeypatch.delenv(
             CppPluginSystemManagerImplementationFactory.kPluginEnvVar, raising=False

--- a/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystem.py
+++ b/src/openassetio-python/tests/package/pluginSystem/test_pythonpluginsystem.py
@@ -60,7 +60,7 @@ class Test_PythonPluginSystem_scan:
         a_plugin_system_with_mocked_scanning.scan_entry_points.assert_not_called()
 
         mock_logger.mock.log.assert_any_call(
-            mock_logger.Severity.kWarning,
+            mock_logger.Severity.kDebug,
             "PythonPluginSystem: No search paths specified and entry point plugins are disabled,"
             f" no plugins will load - check ${a_paths_env_var} is set.",
         )
@@ -90,7 +90,7 @@ class Test_PythonPluginSystem_scan:
         a_plugin_system_with_mocked_scanning.scan_entry_points.assert_not_called()
 
         mock_logger.mock.log.assert_any_call(
-            mock_logger.Severity.kWarning,
+            mock_logger.Severity.kDebug,
             "PythonPluginSystem: No search paths specified and entry point plugins are disabled,"
             f" no plugins will load - check ${a_paths_env_var} is set.",
         )


### PR DESCRIPTION
## Description

~~Closes # (issue)~~

Typically, a host application will want to enable both Python and C++ manager plugins (via the Hybrid plugin system).

Python plugins support either `OPENASSETIO_PLUGIN_PATH` environment variable or Python entry-point plugins
(`importlib.metadata.entry_points)`. C++ plugins only support `OPENASSETIO_PLUGIN_PATH`.

We would like to warn the user when there is no possibility of loading a manager plugin, because neither entry-point nor
`OPENASSETIO_PLUGIN_PATH` is configured.

Conversely, we do _not_ want to issue this warning if one of these mechanisms is available.

However, we had a situation where, if `OPENASSETIO_PLUGIN_PATH` is not set, because the user expects a Python entry-point plugin to be used instead, then the C++ plugin system would still warn that no plugins will load. In addition, the log message did not identify that it was coming from the `CppPluginSystem`, like other logs do.

So update the C++ log message to prefix with `CppPluginSystem`, making it consistent with all other logs.

Also reduce the severity of the logs of both Python and C++ plugin systems down to `kDebug`, since in general the fact that one plugin system cannot find a plugin does not mean that all plugin systems will fail, and so we should not be spamming the user's logs with warnings.

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~

## Reviewer Notes

Noticed this whilst working on some updates to KatanaOpenAssetIO.
