### PR TITLE
Fix a few out-of-date docs

### DIFF
--- a/src/openassetio-core/include/openassetio/errors/BatchElementError.hpp
+++ b/src/openassetio-core/include/openassetio/errors/BatchElementError.hpp
@@ -81,11 +81,12 @@ class BatchElementError final {
 
     /**
      * Error code used when the reference is valid, but the supplied
-     * @ref Context access is invalid for the operation. A common
-     * example of this would be resolving a read-only entity with a
-     * write access Context, or during @ref glossary_preflight or @ref
-     * glossary_register when the target entity s read-only and does not
-     * support updating.
+     * access mode is invalid for the operation.
+     *
+     * A common example of this would be resolving a read-only entity
+     * with a write access mode, or during @ref glossary_preflight or
+     * @ref glossary_register when the target entity s read-only and
+     * does not support updating.
      */
     kEntityAccessError = internal::errors::kBatchElementEntityAccessError,
 

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -2808,10 +2808,10 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * "ErrorCodes"). The callback will be called on the same thread
    * that initiated the call to `register`.
    *
-   * @throws std::out_of_range If @p entityReferences and
-   * @p entityTraitsDatas are not lists of the same length.
-   * Other exceptions may be raised for fatal runtime errors, for
-   * example server communication failure.
+   * @throws errors.InputValidationException If @p entityReferences
+   * and @p entityTraitsDatas are not lists of the same length. Other
+   * exceptions may be raised for fatal runtime errors, for example
+   * server communication failure.
    *
    * @throws errors.NotImplementedException Thrown when this method is
    * not implemented by the manager. Check that this method is

--- a/src/openassetio-core/include/openassetio/utils/path.hpp
+++ b/src/openassetio-core/include/openassetio/utils/path.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #pragma once
 #include <cstdint>
 #include <memory>
@@ -35,9 +35,10 @@ enum class PathType : std::uint8_t {
  * an instance can be used to process any number of URLs/paths.
  *
  * Conversion of Windows UNC paths to file URLs is supported, including
- * `\\?\` device paths. However, conversion of file URLs back to Windows
- * paths only supports drive paths or standard UNC share paths, not
- * device paths.
+ * `\\?\` device paths. Conversion of file URLs back to Windows
+ * paths will prefer drive paths or standard UNC share paths, but will
+ * promote to a device path if the path is longer than the Windows
+ * MAX_PATH limit.
  *
  * Some corner cases that may be technically valid are not currently
  * supported, and will result in an exception if detected. E.g.
@@ -96,9 +97,9 @@ class OPENASSETIO_CORE_EXPORT FileUrlPathConverter {
   /**
    * Construct a path from a file URL.
    *
-   * Note that long Windows paths may exceed the Windows MAX_PATH limit.
-   * Working around this, e.g. by transforming the path to a UNC device
-   * path (`\\?\C:\` or `\\?\UNC\host\share`), is left up to the caller.
+   * Note that long Windows paths that exceed the Windows MAX_PATH limit
+   * will be returned as a UNC device path (`\\?\C:\` or
+   * `\\?\UNC\host\share`).
    *
    * @param fileUrl URL to convert.
    *

--- a/src/openassetio-core/src/utils/Regex.hpp
+++ b/src/openassetio-core/src/utils/Regex.hpp
@@ -20,12 +20,6 @@ namespace utils {
  * Regular expression compilation, matching and caching.
  *
  * Wraps PCRE2, using its JIT compilation and matching functions.
- *
- * Instances of this class are _not_ thread-safe. Use a separate
- * instance per thread.
- *
- * As well as the regex object itself, matches are cached for subsequent
- * querying.
  */
 class Regex {
  public:


### PR DESCRIPTION
## Description

Closes #1179. Plus sundry other docs fixes.

`kEntityAccessError` still referred to `Context.access`, which was removed in #1054.

The exception raised, when `register()` is called with mismatched entity reference and traits data list lengths, was changed from `std::out_of_range` to our custom `InputValidationException` in #1071.

Windows `FileUrlPathConverter.pathFromUrl()` handling for `file://` URLs that, when decoded to a file path, exceeds the Windows MAX_PATH limit, was changed in #1257 to automatically convert to UNC device path style `\\?\`.

The `Regex` PCRE2 wrapper class, when initially written, was stateful and so not thread-safe. However, that was changed upon review (https://github.com/OpenAssetIO/OpenAssetIO/pull/1246#discussion_r1465151326), but the docstring was not updated to reflect that.


- [ ] ~~I have updated the release notes.~~
- [x] I have updated all relevant user documentation.
