### PR TITLE
[CI] Add markdown-link-check-suppression for lists.aswf.io

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -5,6 +5,9 @@
     },
     {
       "pattern": "^https://www.gnu.org"
+    },
+    {
+      "pattern": "^https://lists.aswf.io"
     }
   ]
 }


### PR DESCRIPTION
The lists.aswf.io link in the README has been consistently failing the markdown-link-check CI job for several days with

> [✖] https://lists.aswf.io/g/openassetio-discussion → Status: 403

i.e. a "Forbidden" error. The link works fine in a local browser and in `curl`, so it must be that GitHub runners are blocked, somehow.

So add a suppression to stop this from failing CI.
