### PR TITLE
1103 ensure pragma once is at top of files

### DIFF
--- a/src/openassetio-core-c/src/managerApi/CManagerInterfaceAdapter.hpp
+++ b/src/openassetio-core-c/src/managerApi/CManagerInterfaceAdapter.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2024 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <string>
 
 #include <openassetio/c/export.h>

--- a/src/openassetio-core-c/tests/StringViewReporting.hpp
+++ b/src/openassetio-core-c/tests/StringViewReporting.hpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2024 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 /**
  * Comparison and stream operators to simplify asserting and reporting
  * of StringView instances during tests.
  */
 #pragma once
+
 #include <openassetio/c/StringView.h>
 #include <openassetio/c/namespace.h>
 

--- a/src/openassetio-core/include/openassetio/Context.hpp
+++ b/src/openassetio-core/include/openassetio/Context.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2022 The Foundry Visionmongers Ltd
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <memory>
 
 #include <openassetio/export.h>

--- a/src/openassetio-core/include/openassetio/constants.hpp
+++ b/src/openassetio-core/include/openassetio/constants.hpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023-2025 The Foundry Visionmongers Ltd
-#pragma once
 /**
  * @file
  *
  * Defines common keys for lookup in manager information dictionaries.
  */
+#pragma once
+
 #include <string_view>
 
 #include <openassetio/export.h>

--- a/src/openassetio-core/include/openassetio/hostApi/EntityReferencePager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/EntityReferencePager.hpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2023 The Foundry Visionmongers Ltd
-
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #pragma once
 
 #include <openassetio/EntityReference.hpp>

--- a/src/openassetio-core/include/openassetio/internal.hpp
+++ b/src/openassetio-core/include/openassetio/internal.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 /**

--- a/src/openassetio-core/include/openassetio/log/LoggerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/log/LoggerInterface.hpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2025 The Foundry Visionmongers Ltd
+#pragma once
+
 #include <array>
 
 #include <openassetio/export.h>
 #include <openassetio/typedefs.hpp>
 
-#pragma once
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 /**

--- a/src/openassetio-core/include/openassetio/log/SeverityFilter.hpp
+++ b/src/openassetio-core/include/openassetio/log/SeverityFilter.hpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
+#pragma once
 
 #include <openassetio/export.h>
 #include <openassetio/log/LoggerInterface.hpp>
 
-#pragma once
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
 namespace log {

--- a/src/openassetio-core/include/openassetio/macros.hpp
+++ b/src/openassetio-core/include/openassetio/macros.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2025 The Foundry Visionmongers Ltd
 #pragma once
+
 /**
  * Forward declare a shared_ptr for a given class.
  *

--- a/src/openassetio-core/include/openassetio/managerApi/EntityReferencePagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/EntityReferencePagerInterface.hpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2013-2023 The Foundry Visionmongers Ltd
-
+// Copyright 2013-2025 The Foundry Visionmongers Ltd
 #pragma once
 
 #include <vector>

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2025 The Foundry Visionmongers Ltd
-
 #pragma once
 
 #include <functional>

--- a/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystem.hpp
+++ b/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystem.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <filesystem>
 #include <functional>
 #include <memory>

--- a/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystemManagerImplementationFactory.hpp
+++ b/src/openassetio-core/include/openassetio/pluginSystem/CppPluginSystemManagerImplementationFactory.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <filesystem>
 #include <optional>
 #include <unordered_map>

--- a/src/openassetio-core/include/openassetio/pluginSystem/HybridPluginSystemManagerImplementationFactory.hpp
+++ b/src/openassetio-core/include/openassetio/pluginSystem/HybridPluginSystemManagerImplementationFactory.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <vector>
 
 #include <openassetio/export.h>

--- a/src/openassetio-core/include/openassetio/utils/path.hpp
+++ b/src/openassetio-core/include/openassetio/utils/path.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <cstdint>
 #include <memory>
 #include <string_view>

--- a/src/openassetio-core/include/openassetio/utils/substitute.hpp
+++ b/src/openassetio-core/include/openassetio/utils/substitute.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <string_view>
 
 #include <openassetio/export.h>

--- a/src/openassetio-core/src/utils/Regex.hpp
+++ b/src/openassetio-core/src/utils/Regex.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <cstddef>
 #include <memory>
 #include <optional>

--- a/src/openassetio-core/src/utils/path/common.hpp
+++ b/src/openassetio-core/src/utils/path/common.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2023 The Foundry Visionmongers Ltd
+// Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <string_view>
 
 #include <ada.h>

--- a/src/openassetio-core/src/utils/path/posix.hpp
+++ b/src/openassetio-core/src/utils/path/posix.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <string_view>
 
 #include <openassetio/export.h>

--- a/src/openassetio-core/src/utils/path/posix/detail.hpp
+++ b/src/openassetio-core/src/utils/path/posix/detail.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <optional>
 #include <string_view>
 

--- a/src/openassetio-core/src/utils/path/windows.hpp
+++ b/src/openassetio-core/src/utils/path/windows.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <string_view>
 
 #include <openassetio/export.h>

--- a/src/openassetio-core/src/utils/path/windows/detail.hpp
+++ b/src/openassetio-core/src/utils/path/windows/detail.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <array>
 #include <cstddef>
 #include <cstdint>

--- a/src/openassetio-core/src/utils/path/windows/pathTypes.hpp
+++ b/src/openassetio-core/src/utils/path/windows/pathTypes.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <optional>
 #include <string_view>
 #include <tuple>

--- a/src/openassetio-python/bridge/include/openassetio/python/hostApi.hpp
+++ b/src/openassetio-python/bridge/include/openassetio/python/hostApi.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <openassetio/export.h>
 #include <openassetio/python/export.h>
 #include <openassetio/typedefs.hpp>

--- a/src/openassetio-python/bridge/include/openassetio/python/ui/hostApi.hpp
+++ b/src/openassetio-python/bridge/include/openassetio/python/ui/hostApi.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 The Foundry Visionmongers Ltd
+// Copyright 2024-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <openassetio/export.h>
 #include <openassetio/python/export.h>
 #include <openassetio/typedefs.hpp>

--- a/src/openassetio-python/cmodule/src/PyRetainingSharedPtr.hpp
+++ b/src/openassetio-python/cmodule/src/PyRetainingSharedPtr.hpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
-#pragma once
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
 /**
  * Defines PyRetainingSharedPtr, a custom `shared_ptr` that keeps the Python
  * instance alive whilst the associated C++ instance is alive.
@@ -10,6 +9,8 @@
  * The solution was inspired by
  * https://github.com/pybind/pybind11/issues/1546
  */
+#pragma once
+
 #include <functional>
 #include <memory>
 #include <type_traits>

--- a/src/openassetio-python/cmodule/src/errors/exceptionsConverter.hpp
+++ b/src/openassetio-python/cmodule/src/errors/exceptionsConverter.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <array>
 #include <cstddef>
 #include <string>

--- a/src/openassetio-python/cmodule/src/overrideMacros.hpp
+++ b/src/openassetio-python/cmodule/src/overrideMacros.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <pybind11/pybind11.h>
 
 #include "./errors/exceptionsConverter.hpp"

--- a/src/openassetio-python/private/include/openassetio/private/python/pointers.hpp
+++ b/src/openassetio-python/private/include/openassetio/private/python/pointers.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 The Foundry Visionmongers Ltd
+// Copyright 2022-2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <memory>
 #include <utility>
 

--- a/src/openassetio-ui/include/openassetio/ui/managerApi/UIDelegateInterface.hpp
+++ b/src/openassetio-ui/include/openassetio/ui/managerApi/UIDelegateInterface.hpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2025 The Foundry Visionmongers Ltd
-
 #pragma once
 
 #include <functional>

--- a/src/openassetio-ui/include/openassetio/ui/pluginSystem/CppPluginSystemUIDelegateImplementationFactory.hpp
+++ b/src/openassetio-ui/include/openassetio/ui/pluginSystem/CppPluginSystemUIDelegateImplementationFactory.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <filesystem>
 #include <optional>
 #include <unordered_map>

--- a/src/openassetio-ui/include/openassetio/ui/pluginSystem/HybridPluginSystemUIDelegateImplementationFactory.hpp
+++ b/src/openassetio-ui/include/openassetio/ui/pluginSystem/HybridPluginSystemUIDelegateImplementationFactory.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2025 The Foundry Visionmongers Ltd
 #pragma once
+
 #include <vector>
 
 #include <openassetio/export.h>


### PR DESCRIPTION
## Description

Closes #1103.

This PR ensures the `#pragma once` directive is at the top of all headers in `src`. (For this, I used a scope in CLion to filter for `.h` and `.hpp` files and checked them one by one.)

There are also nitpicky changes to make the spacing around `#pragma once` consistent (`#pragma once` now occurs on the line directly below the copyright comment and any file docstring and a newline follows after `#pragma once` before any `#include` declarations).

- [ ] I have updated the release notes.
- [ ] I have updated all relevant user documentation.

## Reviewer Notes

There are two commits: one moves `#pragma once` and the second tweaks whitespace.

Since this is small, does anything need updating per the checkboxes above?

## Test Instructions

I have test failures on my machine but they failed the same way before and after my changes. (They look to be because my Python version and something else with my environment/machine is slightly off, which I had discussed in Slack with @feltech.)