### PR TITLE
Add project docs as per ASWF guidelines

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -8,6 +8,9 @@
     },
     {
       "pattern": "^https://lists.aswf.io"
+    },
+    {
+      "pattern": "^https://www.blender.org"
     }
   ]
 }

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of conduct
+
+The OpenAssetIO project abides by Linux Foundation's code of conduct,
+which you can read in full
+[here](https://lfprojects.org/policies/code-of-conduct).
+
+To report incidents or to appeal reports of incidents, send email to
+the Manager of LF Projects at manager@lfprojects.org.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing to OpenAssetIO
+
+Please see the docs under [doc/contributing](doc/contributing) for
+guidelines on contributing to OpenAssetIO. In particular:
+
+* [PROCESS.md](doc/contributing/PROCESS.md) provides a high-level
+  overview of the contribution process.
+* [COMMITS.md](doc/contributing/COMMITS.md) describes how to structure
+  commits messages.
+* [PULL_REQUESTS.md](doc/contributing/PULL_REQUESTS.md) describes the
+  code submission process.
+* [CODING_STANDARDS.md](doc/contributing/CODING_STANDARDS.md) and
+  [CODING_STYLE.md](doc/contributing/CODING_STYLE.md) describe how to
+  work with the codebase.
+* [CHANGES.md](doc/contributing/CHANGES.md) describes how to update the
+  release notes.
+* [CODE_REVIEWS.md](doc/contributing/CODE_REVIEWS.md) describes how to
+  participate in code reviews.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,109 @@
+# OpenAssetIO project governance
+
+OpenAssetIO is a project of the
+[Academy Software Foundation](https://www.aswf.io/) and relies on the
+ASWF governance policies, supported by the Linux Foundation.
+
+The OpenAssetIO project maintains a Technical Steering Committee (TSC),
+which has final authority over the project. As defined in the project
+charter, TSC responsibilities include, but are not limited to:
+
+- Discussions, seeking consensus, and where necessary, voting on
+  technical matters relating to OpenAssetIO that affect multiple
+  projects.
+- Maintenance and administration of the OpenAssetIO GitHub repository.
+- Coordinating technical direction of the project.
+- Coordinating marketing, events, and communications regarding
+  OpenAssetIO.
+
+Within the TSC there are two key subgroups: **Voting Members**, who take
+on formal responsibilities for maintaining the OpenAssetIO project and
+vote when decisions are required; and **Stakeholders**, who represent
+specific teams and companies in the industry and speak on their behalf
+in OpenAssetIO discussions.
+
+### Voting members
+
+These committee members are responsible for contributing actively to the
+OpenAssetIO project, whether it's in the form of developing code,
+improving the specification and documentation, reviewing pull requests
+on GitHub, or assisting teams with their OpenAssetIO integrations.
+Although we expect most decisions to be unanimous across the OpenAssetIO
+TSC, for decisions where a formal vote is required, a majority of voting
+members is required to move forward with a change.
+
+Within the voting members of the TSC are two elected leadership roles.
+Any voting TSC member can express interest in serving in a role, or
+nominate another member to serve. There are no term limits, and one
+person may hold multiple roles simultaneously. Should a TSC member
+resign from a leadership role before their term is complete, a successor
+shall be elected through the standard nomination and voting process to
+complete the remainder of the term. The leadership roles are:
+
+- **Chair**: This position acts as the project manager, organizing
+  meetings and providing oversight to project administration.
+- **TAC Representative**: This position represents the OpenAssetIO
+  project in meetings of the Technical Advisory Council of the ASWF.
+
+The current Voting Members of the OpenAssetIO TSC are:
+
+- David Feltell - Foundry **(Chair)**
+- Rob Fanner - Foundry **(TAC Representative)**
+- Ondřej Samohel - Ynput
+- Matt Daw - MovieLabs
+- Peri Friend - Foundry
+
+### Stakeholders
+
+These committee members represent teams or companies that are closely
+aligned with the OpenAssetIO project, and have a strong interest in how
+it evolves going forward. Stakeholders speak on behalf of their team or
+company in OpenAssetIO discussions, providing the breadth of
+perspectives that is required to guide the project. Most new committee
+members start in this category, and it doesn't require a commitment on
+their part to contribute to or maintain the OpenAssetIO project, though
+they are encouraged to do so.
+
+### TSC nomination and succession
+
+Any proposal for additional members of the TSC may be submitted by
+reaching out to a current TSC member on Slack or raising the issue at a
+TSC meeting. New TSC members are accepted or rejected by majority vote
+of the TSC.
+
+If a TSC member is for an extended period not regularly participating or
+performing the responsibilities expected of TSC members, the TSC may by
+majority vote request an alternate TSC member be submitted by that
+organization, or remove the inactive member from the TSC.
+
+A member of the TSC may nominate a successor in the event that such
+member decides to leave the TSC, and the TSC shall confirm or reject
+such nomination by a vote. In the event that the departing member's
+nomination for successor is rejected by vote of the TSC, the departing
+member shall be entitled to continue nominating successors until one
+such successor is confirmed by vote of the TSC. If the departing member
+fails or is unable to nominate a successor, the TSC may nominate one on
+the departing member's behalf.
+
+Voting TSC membership is presumed to be retained by the individual even
+if they change employers. The TSC may take action to ensure that
+organizational stakeholder representation not become severely
+disproportionate, for example by urging an organization that loses its
+sole TSC representative to nominate a new member, or to limit the total
+number of members from any one organization if too many members all move
+to the same organization.
+
+### TSC meetings
+
+All meetings of the TSC are intended to be open to the public, except
+where there is a reasonable need for privacy. The TSC meets regularly in
+a video conference call, at a cadence deemed appropriate by the TSC. The
+TSC Chair moderates the meeting, or appoints another TSC member to
+moderate in his or her absence. Scheduling and connection details may be
+found in the public [ASWF Meeting Calendar](https://www.aswf.io/meeting-calendar/).
+
+Prior to each TSC meeting, the meeting chair will share the agenda with
+the TSC members and broader community on the OpenAssetIO channel of the
+ASWF Slack. TSC members can also add items to this agenda before the
+start of each meeting. The meeting chair is responsible for ensuring
+that minutes are taken and posted on Slack.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+# Release process for OpenAssetIO
+
+Please see the relevant section in
+[doc/contributing/PROCESS.md](doc/contributing/PROCESS.md#release-process).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,62 +1,74 @@
 # Roadmap
 
-The OpenAssetIO project is working towards an initial v1.0.0 release of
-the core API.
+The OpenAssetIO project has reached a stable v1 release of the core API.
 
-We are looking for early adopters who can help fine tune its final form,
-and validate key design choices, and help flesh out asset types and
-their properties.
-
-The project is functional, and moving forward we expect minimal churn in
-the API itself as we complete the implementation of language specific
-features.
+However, there are still several features planned for the core API, and
+the broader ecosystem remains at in a broadly beta-level state of
+maturity.
 
 This roadmap is influenced by community prioritisation exercises. The
 results of which are available
 [here](https://docs.google.com/spreadsheets/d/1ARGfLIbBg58rGTAgjcvr9DbmsXKTdQKO3BC_M3RQ_w4/edit#gid=0).
 
-## Y23 Q3: v1.0.0b1
+## Milestones
 
-**Released October 27th**
+Each project in the OpenAssetIO ecosystem makes use of GitHub milestones
+to track proposed features and their release targets.
 
-Milestone: [here](https://github.com/OpenAssetIO/OpenAssetIO/milestone/1)
+Features and other improvements are placed into a SemVer-labeled
+milestone based on a combination of priority and how breaking the change
+is likely to be (see the
+[versioning strategy](./README.md#versioning-strategy)).
 
-This release will support resolution and publishing of entities in batch
-and interactive context, along with relationship discovery.
+Links to the milestones for various projects can be found below.
 
-**Hosts:** C++, Python
-**Managers:** Python
+* [OpenAssetIO](https://github.com/OpenAssetIO/OpenAssetIO/milestones)
+* [OpenAssetIO-MediaCreation](https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation/milestones)
+* [TraitGen](https://github.com/OpenAssetIO/OpenAssetIO-TraitGen/milestones)
+* [usdOpenAssetIOResolver](https://github.com/OpenAssetIO/usdOpenAssetIOResolver/milestones)
+* [OpenAssetIO-Manager-BAL](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/milestones)
 
-- [x] Migration to the [Trait based API](https://github.com/OpenAssetIO/OpenAssetIO/blob/main/doc/decisions/DR007-Hierarchical-or-compositional-traits-for-specifications.md).
-- [x] Migration to batch-centric API.
-- [x] Migration of core API methods to C++.
-- [x] Sundry breaking changes and tech-debt cleanup.
+## Current status
 
-## Y24 Q1
+The core OpenAssetIO API has reached a stable v1 release.
 
-**Backlog:** [here](https://github.com/orgs/OpenAssetIO/projects/1/views/8)
+The API is available in both C++ and Python and is designed to support
+dual-language hosts.
 
-This release will provide additional introspection methods and
-debugging functionality, along with language parity between Hosts and
-Managers.
+The core API supports asset resolution, publishing, and relationships
+via _entity references_.
 
-**Hosts:** C++, Python
-**Managers:** C++, Python
+The manager plugin system supports Python and C++ and hybrid Python/C++
+plugins, configured either programmatically or through a TOML
+configuration file, along with environment variables.
 
-- [ ] Trait/Specification versioning support
-- [ ] Debug trace logging support.
-- [x] Entity introspection API methods.
-- [x] C++ Plugin System
-- [x] Hybrid C++/Python manager bridge.
+OpenAssetIO additionally supports UI delegation through a separate
+plugin system. Participating hosts may allow asset managers to replace
+elements of their UI. A typical example is to present an asset browser
+in place of a file browser.
 
-## Y24 onwards
-- Read-through cache mix-ins.
-- Migrate landing page/examples to [OpenAssetIO-MediaCreation](https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation)
-- UI Layer
-- Auth related error codes.
-- Entity change notification/tracking.
-- C API for FFIs or compiler isolation.
-- Out-of-process Python
-- Advanced workflow topics:
-  - Transactions
-  - Permissions
+Information is carried across the API as OpenAssetIO _traits_. This
+system has proven popular and effective. The OpenAssetIO-MediaCreation
+repository contains community-defined traits providing categories/tags
+and metadata for common VFX entities. They will continuously expand to
+cover broader use cases as they arise.
+
+The ecosystem of known host applications and manager plugins can be
+found in the [examples](./examples/README.md) doc.
+
+## Future plans - 2025/2026
+
+The priority is now to encourage adoption and solicit feedback.
+
+Despite the longer-term benefits that would be realised, early-adopters
+on the *host* side are faced with a leap of faith if there is limited
+manager support, and likewise *asset managers*/*studios* may also face
+this leap of faith if there is limited host support.
+
+Part of the project plan is therefore to lower these barriers for
+early-adopters by providing more official integrations and integration
+examples, whether directly on the project or via collaboration.
+
+In parallel, the main development focus for the various OpenAssetIO
+projects is to achieve their v1.0.0 release milestone. See the
+milestones (above) for details.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,34 @@
+# Getting help
+
+There are a few ways to connect with the OpenAssetIO project:
+
+- Join the [#openassetio](https://academysoftwarefdn.slack.com/archives/C03Q36QS8N4)
+  Slack channel. This is the preferred way to get quick responses.
+- Add yourself to the [openassetio-discussion](https://lists.aswf.io/g/openassetio-discussion)
+  mailing list.
+- Create a new GitHub [issue](https://github.com/OpenAssetIO/OpenAssetIO/issues).
+
+## How to ask for help
+
+If you have trouble installing, building, or using OpenAssetIO, but
+there's not yet reason to suspect you've encountered a genuine bug,
+start by posting a question to the Slack channel or mailing list. This
+is the place for question such has "How do I...".
+
+## How to report a bug or request an enhancement
+
+OpenAssetIO manages bugs and enhancements using the GitHub
+[issue](https://github.com/OpenAssetIO/OpenAssetIO/issues)
+tracker. The issue template will guide you on making an effective
+report.
+
+## How to report a security vulnerability
+
+If you think you've found a potential vulnerability in OpenAssetIO,
+please email openassetio-tsc@lists.aswf.io to responsibly disclose it
+to the project maintainers.
+
+## Contributing a fix
+
+Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) to make a project
+contribution.

--- a/doc/contributing/PROCESS.md
+++ b/doc/contributing/PROCESS.md
@@ -43,8 +43,8 @@ Trusted Committers. The steps are:
 We have a few golden rules for commits to release branches:
 
 - All code should follow the project coding standards.
-- `main` and maintenance branches should always be functional, once we
-  pass pre-release, they must always be release ready.
+- `main` and maintenance branches should always be functional, they must
+  always be release ready.
 - Commits should form meaningful atomic units of change. The build
   should never be (intentionally) broken between commits merged to
   release branches.
@@ -127,16 +127,17 @@ To make a new OpenAssetIO release, follow this procedure.
 
 - Create a work branch in a forked repository.
 - Update [`RELEASE_NOTES.md`](../../RELEASE_NOTES.md) version placeholder
-  to be the concrete release number. (For example, change v1.0.0-alpha.x
-  to v1.0.0-alpha.5).
+  to be the concrete release number. (For example, change v1.0.x
+  to v1.0.1).
 - Update version numbers in :
   - [pyproject.toml](../../src/openassetio-python/pyproject.toml)
     (under `[project]` section).
   - [version.hpp.in](../../cmake/templates/include/openassetio/version.hpp.in)
-    (for changes to/from pre-releases only, at the top).
+    (for changes to/from pre-releases only, append the pre-release tag
+    to `OPENASSETIO_VERSION_STRING`).
   - [test_version.py](../../src/openassetio-python/tests/package/test_version.py)
     (at the top).
-  - [CMakeLists.txt](../../CMakeLists.txt) 
+  - [CMakeLists.txt](../../CMakeLists.txt)
     (an argument to `project()`, no need to update for a pre-release
     increment).
 - If there is an ABI change (major release), update
@@ -169,8 +170,8 @@ To make a new OpenAssetIO release, follow this procedure.
 - Now the codebase is all set up, create a [new Release](https://github.com/OpenAssetIO/OpenAssetIO/releases/new)
   in GitHub.
   - Set the tag to be the version number with a `v` prefix, eg
-    `v1.0.0-alpha.5`, you should be creating a new tag.
-  - Set the title to be the same as the tag, eg `v1.0.0-alpha.5`.
+    `v1.0.1`, you should be creating a new tag.
+  - Set the title to be the same as the tag, eg `v1.0.1`.
   - Copy the release notes for this release into the description:
     - Do not include the version title.
     - Remove line wrapping from the release notes, each note

--- a/examples/README.md
+++ b/examples/README.md
@@ -71,6 +71,12 @@ plugin allows OpenAssetIO entity references to be recognised within
 OTIO documents, and resolved to their file path when the document is
 loaded.
 
+### ComyUI OpenAssetIO nodes
+
+The [ComfyUI plugin](https://github.com/OpenAssetIO/OpenAssetIO-ComfyUI)
+adds custom nodes for ingest and publishing of assets via OpenAssetIO
+entity references, rather than file paths.
+
 ## External projects
 
 ### Nuke
@@ -79,6 +85,15 @@ loaded.
 industry-leading commercial compositing tool by Foundry. As of
 version [15.1](https://campaigns.foundry.com/products/nuke-family/whats-new),
 Nuke has built-in support for OpenAssetIO as a headline feature.
+
+### Katana AssetAPI shim plugin
+
+[Katana](https://www.foundry.com/products/katana) is a commercial look
+development and lighting tool by Foundry. It is natively asset-aware
+through its AssetAPI, which inspired the design of OpenAssetIO. The
+[KatanaOpenAssetIO](https://github.com/TheFoundryVisionmongers/KatanaOpenAssetIO)
+project adapts the Katana AssetAPI to the OpenAssetIO API, allowing
+OpenAssetIO manager plugins to be used within Katana.
 
 ### Ayon manager plugin
 


### PR DESCRIPTION
## Description

In preparation for the project moving to the ASWF incubation phase, add various docs at the root level covering project governance and contribution guidelines, as listed in the annual review slide template (available [here](https://tac.aswf.io/process/review_cycle.html)) listing requirements for an Incubation stage project.

- [ ] ~~I have updated the release notes.~~
- [x] I have updated all relevant user documentation.

