### PR TITLE
Add an ADOPTERS document

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,5 @@
+# Adopters
+
+OpenAssetIO has a growing list of adopters in industry, both public and
+private. For known publicised adopters and other examples of OpenAssetIO
+in use, see the list of [examples](examples/README.md).


### PR DESCRIPTION
In preparation for acceptance for the ASWF Incubation project stage, add the last remaining requirement with respect to documentation add an ADOPTERS file, which simply points to the pre-existing examples README (see https://tac.aswf.io/process/lifecycle.html#incubation-stage).
