### PR TITLE
[Python] Support Python 3.13

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -37,7 +37,8 @@ jobs:
           # prefix here so that it can also be used in the file name of
           # the uploaded archive (i.e. wildcard `*` is not allowed).
           # See https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-        python-build: ['cp310', 'cp311', 'cp312']
+        python-build: ['cp310', 'cp311', 'cp312', 'cp313']
+
     defaults:
       run:
         # Annoyingly required here since `matrix` isn't available in the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,17 @@
 Release Notes
 =============
 
+vX.X.X
+------
+
+_This release remains source and binary compatible_
+
+## Improvements
+
+- Added Python 3.13 to the CI build matrix (and hence deployment to
+  PyPI).
+  [#1487](https://github.com/OpenAssetIO/OpenAssetIO/issues/1487)
+
 v1.0.1
 ------
 

--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -117,7 +117,7 @@ if (OPENASSETIO_ENABLE_PYTHON)
         ${OPENASSETIO_PYTHON_VENV_EXE} -m pip install --upgrade
         # Pin core packages to give some basic reproducibility across
         # environments.
-        setuptools==49.0 pip==22.2.2
+        setuptools==82.0.1 pip==26.0.1
     )
 
     # Add a top-level Python environment creation convenience build

--- a/src/openassetio-python/private/include/openassetio/private/python/pointers.hpp
+++ b/src/openassetio-python/private/include/openassetio/private/python/pointers.hpp
@@ -10,6 +10,10 @@
 
 #include <openassetio/export.h>
 
+#if PY_VERSION_HEX < 0x030d0000  // Check if the python version is less than 3.13
+#define Py_IsFinalizing _Py_IsFinalizing
+#endif
+
 namespace py = pybind11;
 
 namespace openassetio {
@@ -47,9 +51,9 @@ Ptr createPyRetainingPtr(const py::object& pyInstance,
   // Custom deleter for shared_ptr below.
   const auto deleter = [](py::object* pyObjectPtr) {
     // Note: Technically we have a race condition here with
-    // _Py_IsFinalizing if multiple threads are involved, but that is a
+    // Py_IsFinalizing if multiple threads are involved, but that is a
     // corner case of a corner case, and difficult to solve.
-    if (_Py_IsFinalizing()) {
+    if (Py_IsFinalizing()) {
       // If the Python interpreter is gone, clear the internal PyObject*
       // so pybind11 won't attempt to clean it up.
       pyObjectPtr->release();

--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Object Brokering",
     "Topic :: System :: Distributed Computing",


### PR DESCRIPTION
## Description

Closes #1487.

Python 3.13 is required by VFX Reference Platform CY26. Currently the source does not compile because `_Py_IsFinalizing` has been made part of the stable ABI and renamed to `Py_IsFinalizing`. We update the references to the new name and maintain compatibility with older Python versions using a macro.

The tests pin specific setuptools and pip versions that are not compatible with Python 3.13, so also update those to allow tests to be run against the new Python version.

Update the CI to build Python 3.13 wheels, but do not update the toolchain or MacOS minimum deployment target in line with CY26. In particular GCC14 is only officially available from 24.04 which would further bring the glibc version out of alignment with the reference platform. Note that the wheels are built with `manylinux_2_28` by `cibuildwheel` on Linux, which is GCC14 and glibc 2.28 compatible anyway.

- [x] I have updated the release notes.
- [x] I have updated all relevant user documentation.