### PR TITLE
Reorder Manager pybind overload registrations

### DIFF
--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -127,6 +127,22 @@ void registerManager(const py::module& mod) {
           },
           py::arg("traitSet"), py::arg("defaultEntityReferenceAccess"),
           py::arg("context").none(false), py::call_guard<py::gil_scoped_release>{})
+      .def("defaultEntityReference",
+           py::overload_cast<const trait::TraitSet&, access::DefaultEntityAccess,
+                             const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::defaultEntityReference),
+           py::arg("traitSet"), py::arg("defaultEntityReferenceAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("defaultEntityReference",
+           py::overload_cast<const trait::TraitSet&, access::DefaultEntityAccess,
+                             const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::defaultEntityReference),
+           py::arg("traitSet"), py::arg("defaultEntityReferenceAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
       .def(
           "defaultEntityReference",
           [](Manager& self, const trait::TraitSets& traitSets,
@@ -137,17 +153,17 @@ void registerManager(const py::module& mod) {
           py::arg("traitSets"), py::arg("defaultEntityReferenceAccess"),
           py::arg("context").none(false), py::call_guard<py::gil_scoped_release>{})
       .def("defaultEntityReference",
-           py::overload_cast<const trait::TraitSet&, access::DefaultEntityAccess,
+           py::overload_cast<const trait::TraitSets&, access::DefaultEntityAccess,
                              const ContextConstPtr&,
                              const Manager::BatchElementErrorPolicyTag::Variant&>(
                &Manager::defaultEntityReference),
-           py::arg("traitSet"), py::arg("defaultEntityReferenceAccess"),
+           py::arg("traitSets"), py::arg("defaultEntityReferenceAccess"),
            py::arg("context").none(false), py::arg("errorPolicyTag"),
            py::call_guard<py::gil_scoped_release>{})
       .def("defaultEntityReference",
            py::overload_cast<const trait::TraitSets&, access::DefaultEntityAccess,
                              const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
                &Manager::defaultEntityReference),
            py::arg("traitSets"), py::arg("defaultEntityReferenceAccess"),
            py::arg("context").none(false), py::arg("errorPolicyTag"),
@@ -161,22 +177,6 @@ void registerManager(const py::module& mod) {
            py::arg("traitSets"), py::arg("defaultEntityReferenceAccess"),
            py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"),
            py::call_guard<py::gil_scoped_release>{})
-      .def("defaultEntityReference",
-           py::overload_cast<const trait::TraitSet&, access::DefaultEntityAccess,
-                             const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Exception&>(
-               &Manager::defaultEntityReference),
-           py::arg("traitSet"), py::arg("defaultEntityReferenceAccess"),
-           py::arg("context").none(false), py::arg("errorPolicyTag"),
-           py::call_guard<py::gil_scoped_release>{})
-      .def("defaultEntityReference",
-           py::overload_cast<const trait::TraitSets&, access::DefaultEntityAccess,
-                             const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Exception&>(
-               &Manager::defaultEntityReference),
-           py::arg("traitSets"), py::arg("defaultEntityReferenceAccess"),
-           py::arg("context").none(false), py::arg("errorPolicyTag"),
-           py::call_guard<py::gil_scoped_release>{})
       .def(
           "entityExists",
           [](Manager& self, const EntityReference& entityReference,
@@ -187,13 +187,13 @@ void registerManager(const py::module& mod) {
           py::call_guard<py::gil_scoped_release>{})
       .def("entityExists",
            py::overload_cast<const EntityReference&, const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
                &Manager::entityExists),
            py::arg("entityReference"), py::arg("context").none(false), py::arg("errorPolicyTag"),
            py::call_guard<py::gil_scoped_release>{})
       .def("entityExists",
            py::overload_cast<const EntityReference&, const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
                &Manager::entityExists),
            py::arg("entityReference"), py::arg("context").none(false), py::arg("errorPolicyTag"),
            py::call_guard<py::gil_scoped_release>{})
@@ -205,6 +205,12 @@ void registerManager(const py::module& mod) {
           },
           py::arg("entityReferences"), py::arg("context").none(false),
           py::call_guard<py::gil_scoped_release>{})
+      .def("entityExists",
+           py::overload_cast<const EntityReferences&, const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::entityExists),
+           py::arg("entityReferences"), py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
       .def(
           "entityExists",
           [](Manager& self, const EntityReferences& entityReferences,
@@ -217,39 +223,10 @@ void registerManager(const py::module& mod) {
           py::call_guard<py::gil_scoped_release>{})
       .def("entityExists",
            py::overload_cast<const EntityReferences&, const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Variant&>(
-               &Manager::entityExists),
-           py::arg("entityReferences"), py::arg("context").none(false), py::arg("errorPolicyTag"),
-           py::call_guard<py::gil_scoped_release>{})
-      .def("entityExists",
-           py::overload_cast<const EntityReferences&, const ContextConstPtr&,
                              const Manager::ExistsSuccessCallback&,
                              const Manager::BatchElementErrorCallback&>(&Manager::entityExists),
            py::arg("entityReferences"), py::arg("context").none(false), py::arg("successCallback"),
            py::arg("errorCallback"), py::call_guard<py::gil_scoped_release>{})
-      .def("entityTraits",
-           py::overload_cast<const EntityReferences&, access::EntityTraitsAccess,
-                             const ContextConstPtr&, const Manager::EntityTraitsSuccessCallback&,
-                             const Manager::BatchElementErrorCallback&>(&Manager::entityTraits),
-           py::arg("entityReferences"), py::arg("entityTraitsAccess"),
-           py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"),
-           py::call_guard<py::gil_scoped_release>{})
-      .def("entityTraits",
-           py::overload_cast<const EntityReference&, access::EntityTraitsAccess,
-                             const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Exception&>(
-               &Manager::entityTraits),
-           py::arg("entityReference"), py::arg("entityTraitsAccess"),
-           py::arg("context").none(false), py::arg("errorPolicyTag"),
-           py::call_guard<py::gil_scoped_release>{})
-      .def("entityTraits",
-           py::overload_cast<const EntityReference&, access::EntityTraitsAccess,
-                             const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Variant&>(
-               &Manager::entityTraits),
-           py::arg("entityReference"), py::arg("entityTraitsAccess"),
-           py::arg("context").none(false), py::arg("errorPolicyTag"),
-           py::call_guard<py::gil_scoped_release>{})
       .def(
           "entityTraits",
           // Note: Technically we shouldn't need this overload, see
@@ -261,19 +238,19 @@ void registerManager(const py::module& mod) {
           py::arg("entityReference"), py::arg("entityTraitsAccess"),
           py::arg("context").none(false), py::call_guard<py::gil_scoped_release>{})
       .def("entityTraits",
-           py::overload_cast<const EntityReferences&, access::EntityTraitsAccess,
-                             const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Exception&>(
-               &Manager::entityTraits),
-           py::arg("entityReferences"), py::arg("entityTraitsAccess"),
-           py::arg("context").none(false), py::arg("errorPolicyTag"),
-           py::call_guard<py::gil_scoped_release>{})
-      .def("entityTraits",
-           py::overload_cast<const EntityReferences&, access::EntityTraitsAccess,
+           py::overload_cast<const EntityReference&, access::EntityTraitsAccess,
                              const ContextConstPtr&,
                              const Manager::BatchElementErrorPolicyTag::Variant&>(
                &Manager::entityTraits),
-           py::arg("entityReferences"), py::arg("entityTraitsAccess"),
+           py::arg("entityReference"), py::arg("entityTraitsAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("entityTraits",
+           py::overload_cast<const EntityReference&, access::EntityTraitsAccess,
+                             const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::entityTraits),
+           py::arg("entityReference"), py::arg("entityTraitsAccess"),
            py::arg("context").none(false), py::arg("errorPolicyTag"),
            py::call_guard<py::gil_scoped_release>{})
       .def(
@@ -286,33 +263,32 @@ void registerManager(const py::module& mod) {
           },
           py::arg("entityReferences"), py::arg("entityTraitsAccess"),
           py::arg("context").none(false), py::call_guard<py::gil_scoped_release>{})
+      .def("entityTraits",
+           py::overload_cast<const EntityReferences&, access::EntityTraitsAccess,
+                             const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::entityTraits),
+           py::arg("entityReferences"), py::arg("entityTraitsAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("entityTraits",
+           py::overload_cast<const EntityReferences&, access::EntityTraitsAccess,
+                             const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::entityTraits),
+           py::arg("entityReferences"), py::arg("entityTraitsAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("entityTraits",
+           py::overload_cast<const EntityReferences&, access::EntityTraitsAccess,
+                             const ContextConstPtr&, const Manager::EntityTraitsSuccessCallback&,
+                             const Manager::BatchElementErrorCallback&>(&Manager::entityTraits),
+           py::arg("entityReferences"), py::arg("entityTraitsAccess"),
+           py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"),
+           py::call_guard<py::gil_scoped_release>{})
       .def("hasCapability", &Manager::hasCapability, py::arg("capability"),
            py::call_guard<py::gil_scoped_release>{})
       .def("updateTerminology", &Manager::updateTerminology, py::arg("terms"),
-           py::call_guard<py::gil_scoped_release>{})
-      .def(
-          "resolve",
-          py::overload_cast<const EntityReferences&, const trait::TraitSet&, access::ResolveAccess,
-                            const ContextConstPtr&, const Manager::ResolveSuccessCallback&,
-                            const Manager::BatchElementErrorCallback&>(&Manager::resolve),
-          py::arg("entityReferences"), py::arg("traitSet"), py::arg("resolveAccess"),
-          py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"),
-          py::call_guard<py::gil_scoped_release>{})
-      .def("resolve",
-           py::overload_cast<const EntityReference&, const trait::TraitSet&, access::ResolveAccess,
-                             const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Exception&>(
-               &Manager::resolve),
-           py::arg("entityReference"), py::arg("traitSet"), py::arg("resolveAccess"),
-           py::arg("context").none(false), py::arg("errorPolicyTag"),
-           py::call_guard<py::gil_scoped_release>{})
-      .def("resolve",
-           py::overload_cast<const EntityReference&, const trait::TraitSet&, access::ResolveAccess,
-                             const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Variant&>(
-               &Manager::resolve),
-           py::arg("entityReference"), py::arg("traitSet"), py::arg("resolveAccess"),
-           py::arg("context").none(false), py::arg("errorPolicyTag"),
            py::call_guard<py::gil_scoped_release>{})
       .def(
           "resolve",
@@ -329,19 +305,19 @@ void registerManager(const py::module& mod) {
           py::arg("entityReference"), py::arg("traitSet"), py::arg("resolveAccess"),
           py::arg("context").none(false), py::call_guard<py::gil_scoped_release>{})
       .def("resolve",
-           py::overload_cast<const EntityReferences&, const trait::TraitSet&,
-                             access::ResolveAccess, const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+           py::overload_cast<const EntityReference&, const trait::TraitSet&, access::ResolveAccess,
+                             const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
                &Manager::resolve),
-           py::arg("entityReferences"), py::arg("traitSet"), py::arg("resolveAccess"),
+           py::arg("entityReference"), py::arg("traitSet"), py::arg("resolveAccess"),
            py::arg("context").none(false), py::arg("errorPolicyTag"),
            py::call_guard<py::gil_scoped_release>{})
       .def("resolve",
-           py::overload_cast<const EntityReferences&, const trait::TraitSet&,
-                             access::ResolveAccess, const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+           py::overload_cast<const EntityReference&, const trait::TraitSet&, access::ResolveAccess,
+                             const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
                &Manager::resolve),
-           py::arg("entityReferences"), py::arg("traitSet"), py::arg("resolveAccess"),
+           py::arg("entityReference"), py::arg("traitSet"), py::arg("resolveAccess"),
            py::arg("context").none(false), py::arg("errorPolicyTag"),
            py::call_guard<py::gil_scoped_release>{})
       .def(
@@ -355,16 +331,30 @@ void registerManager(const py::module& mod) {
           },
           py::arg("entityReferences"), py::arg("traitSet"), py::arg("resolveAccess"),
           py::arg("context").none(false), py::call_guard<py::gil_scoped_release>{})
-      .def("getWithRelationship",
-           py::overload_cast<const EntityReferences&, const trait::TraitsDataPtr&, std::size_t,
-                             access::RelationsAccess, const ContextConstPtr&,
-                             const Manager::RelationshipQuerySuccessCallback&,
-                             const Manager::BatchElementErrorCallback&, const trait::TraitSet&>(
-               &Manager::getWithRelationship),
-           py::arg("entityReferences"), py::arg("relationshipTraitsData").none(false),
-           py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
-           py::arg("successCallback"), py::arg("errorCallback"),
-           py::arg("resultTraitSet") = trait::TraitSet{}, py::call_guard<py::gil_scoped_release>{})
+      .def("resolve",
+           py::overload_cast<const EntityReferences&, const trait::TraitSet&,
+                             access::ResolveAccess, const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::resolve),
+           py::arg("entityReferences"), py::arg("traitSet"), py::arg("resolveAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("resolve",
+           py::overload_cast<const EntityReferences&, const trait::TraitSet&,
+                             access::ResolveAccess, const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::resolve),
+           py::arg("entityReferences"), py::arg("traitSet"), py::arg("resolveAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def(
+          "resolve",
+          py::overload_cast<const EntityReferences&, const trait::TraitSet&, access::ResolveAccess,
+                            const ContextConstPtr&, const Manager::ResolveSuccessCallback&,
+                            const Manager::BatchElementErrorCallback&>(&Manager::resolve),
+          py::arg("entityReferences"), py::arg("traitSet"), py::arg("resolveAccess"),
+          py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"),
+          py::call_guard<py::gil_scoped_release>{})
       .def(
           "getWithRelationship",
           // Note: Technically we shouldn't need this overload, see
@@ -379,6 +369,26 @@ void registerManager(const py::module& mod) {
           py::arg("entityReference"), py::arg("relationshipTraitsData").none(false),
           py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
           py::arg("resultTraitSet"), py::call_guard<py::gil_scoped_release>{})
+      .def("getWithRelationship",
+           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&, std::size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const trait::TraitSet&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::getWithRelationship),
+           py::arg("entityReference"), py::arg("relationshipTraitsData").none(false),
+           py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
+           py::arg("resultTraitSet"), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("getWithRelationship",
+           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&, std::size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const trait::TraitSet&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::getWithRelationship),
+           py::arg("entityReference"), py::arg("relationshipTraitsData").none(false),
+           py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
+           py::arg("resultTraitSet"), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
       .def(
           "getWithRelationship",
           [](Manager& self, const EntityReferences& entityReferences,
@@ -392,22 +402,12 @@ void registerManager(const py::module& mod) {
           py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
           py::arg("resultTraitSet"), py::call_guard<py::gil_scoped_release>{})
       .def("getWithRelationship",
-           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&, std::size_t,
-                             access::RelationsAccess, const ContextConstPtr&,
-                             const trait::TraitSet&,
-                             const Manager::BatchElementErrorPolicyTag::Exception&>(
-               &Manager::getWithRelationship),
-           py::arg("entityReference"), py::arg("relationshipTraitsData").none(false),
-           py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
-           py::arg("resultTraitSet"), py::arg("errorPolicyTag"),
-           py::call_guard<py::gil_scoped_release>{})
-      .def("getWithRelationship",
-           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&, std::size_t,
+           py::overload_cast<const EntityReferences&, const trait::TraitsDataPtr&, std::size_t,
                              access::RelationsAccess, const ContextConstPtr&,
                              const trait::TraitSet&,
                              const Manager::BatchElementErrorPolicyTag::Variant&>(
                &Manager::getWithRelationship),
-           py::arg("entityReference"), py::arg("relationshipTraitsData").none(false),
+           py::arg("entityReferences"), py::arg("relationshipTraitsData").none(false),
            py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
            py::arg("resultTraitSet"), py::arg("errorPolicyTag"),
            py::call_guard<py::gil_scoped_release>{})
@@ -424,30 +424,13 @@ void registerManager(const py::module& mod) {
       .def("getWithRelationship",
            py::overload_cast<const EntityReferences&, const trait::TraitsDataPtr&, std::size_t,
                              access::RelationsAccess, const ContextConstPtr&,
-                             const trait::TraitSet&,
-                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+                             const Manager::RelationshipQuerySuccessCallback&,
+                             const Manager::BatchElementErrorCallback&, const trait::TraitSet&>(
                &Manager::getWithRelationship),
            py::arg("entityReferences"), py::arg("relationshipTraitsData").none(false),
            py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
-           py::arg("resultTraitSet"), py::arg("errorPolicyTag"),
-           py::call_guard<py::gil_scoped_release>{})
-      .def(
-          "getWithRelationships",
-          [](Manager& self, const EntityReference& entityReference,
-             const trait::TraitsDatas& relationshipTraitsDatas, const std::size_t pageSize,
-             const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
-             const Manager::RelationshipQuerySuccessCallback& successCallback,
-             const Manager::BatchElementErrorCallback& errorCallback,
-             const trait::TraitSet& resultTraitSet) {
-            validateTraitsDatas(relationshipTraitsDatas);
-            self.getWithRelationships(entityReference, relationshipTraitsDatas, pageSize,
-                                      relationsAccess, context, successCallback, errorCallback,
-                                      resultTraitSet);
-          },
-          py::arg("entityReference"), py::arg("relationshipTraitsDatas"), py::arg("pageSize"),
-          py::arg("relationsAccess"), py::arg("context").none(false), py::arg("successCallback"),
-          py::arg("errorCallback"), py::arg("resultTraitSet") = trait::TraitSet{},
-          py::call_guard<py::gil_scoped_release>{})
+           py::arg("successCallback"), py::arg("errorCallback"),
+           py::arg("resultTraitSet") = trait::TraitSet{}, py::call_guard<py::gil_scoped_release>{})
       .def(
           "getWithRelationships",
           // Note: Technically we shouldn't need this overload, see
@@ -469,7 +452,7 @@ void registerManager(const py::module& mod) {
              const trait::TraitsDatas& relationshipTraitsDatas, const std::size_t pageSize,
              const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
              const trait::TraitSet& resultTraitSet,
-             const Manager::BatchElementErrorPolicyTag::Exception& errorPolicyTag) {
+             const Manager::BatchElementErrorPolicyTag::Variant& errorPolicyTag) {
             validateTraitsDatas(relationshipTraitsDatas);
             return self.getWithRelationships(entityReference, relationshipTraitsDatas, pageSize,
                                              relationsAccess, context, resultTraitSet,
@@ -484,7 +467,7 @@ void registerManager(const py::module& mod) {
              const trait::TraitsDatas& relationshipTraitsDatas, const std::size_t pageSize,
              const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
              const trait::TraitSet& resultTraitSet,
-             const Manager::BatchElementErrorPolicyTag::Variant& errorPolicyTag) {
+             const Manager::BatchElementErrorPolicyTag::Exception& errorPolicyTag) {
             validateTraitsDatas(relationshipTraitsDatas);
             return self.getWithRelationships(entityReference, relationshipTraitsDatas, pageSize,
                                              relationsAccess, context, resultTraitSet,
@@ -494,35 +477,22 @@ void registerManager(const py::module& mod) {
           py::arg("relationsAccess"), py::arg("context").none(false), py::arg("resultTraitSet"),
           py::arg("errorPolicyTag"), py::call_guard<py::gil_scoped_release>{})
       .def(
-          "preflight",
-          [](Manager& self, const EntityReferences& entityReferences,
-             const trait::TraitsDatas& traitsHints,
-             const access::PublishingAccess publishingAccess, const ContextConstPtr& context,
-             const Manager::PreflightSuccessCallback& successCallback,
-             const Manager::BatchElementErrorCallback& errorCallback) {
-            validateTraitsDatas(traitsHints);
-            self.preflight(entityReferences, traitsHints, publishingAccess, context,
-                           successCallback, errorCallback);
+          "getWithRelationships",
+          [](Manager& self, const EntityReference& entityReference,
+             const trait::TraitsDatas& relationshipTraitsDatas, const std::size_t pageSize,
+             const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+             const Manager::RelationshipQuerySuccessCallback& successCallback,
+             const Manager::BatchElementErrorCallback& errorCallback,
+             const trait::TraitSet& resultTraitSet) {
+            validateTraitsDatas(relationshipTraitsDatas);
+            self.getWithRelationships(entityReference, relationshipTraitsDatas, pageSize,
+                                      relationsAccess, context, successCallback, errorCallback,
+                                      resultTraitSet);
           },
-          py::arg("entityReferences"), py::arg("traitsHints"), py::arg("publishAccess"),
-          py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"),
+          py::arg("entityReference"), py::arg("relationshipTraitsDatas"), py::arg("pageSize"),
+          py::arg("relationsAccess"), py::arg("context").none(false), py::arg("successCallback"),
+          py::arg("errorCallback"), py::arg("resultTraitSet") = trait::TraitSet{},
           py::call_guard<py::gil_scoped_release>{})
-      .def("preflight",
-           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&,
-                             access::PublishingAccess, const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Exception&>(
-               &Manager::preflight),
-           py::arg("entityReference"), py::arg("traitsHint").none(false), py::arg("publishAccess"),
-           py::arg("context").none(false), py::arg("errorPolicyTag"),
-           py::call_guard<py::gil_scoped_release>{})
-      .def("preflight",
-           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&,
-                             access::PublishingAccess, const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Variant&>(
-               &Manager::preflight),
-           py::arg("entityReference"), py::arg("traitsHint").none(false), py::arg("publishAccess"),
-           py::arg("context").none(false), py::arg("errorPolicyTag"),
-           py::call_guard<py::gil_scoped_release>{})
       .def(
           "preflight",
           [](Manager& self, const EntityReference& entityReference,
@@ -532,6 +502,44 @@ void registerManager(const py::module& mod) {
           },
           py::arg("entityReference"), py::arg("traitsHint").none(false), py::arg("publishAccess"),
           py::arg("context").none(false), py::call_guard<py::gil_scoped_release>{})
+      .def("preflight",
+           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&,
+                             access::PublishingAccess, const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::preflight),
+           py::arg("entityReference"), py::arg("traitsHint").none(false), py::arg("publishAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("preflight",
+           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&,
+                             access::PublishingAccess, const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::preflight),
+           py::arg("entityReference"), py::arg("traitsHint").none(false), py::arg("publishAccess"),
+           py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def(
+          "preflight",
+          [](Manager& self, const EntityReferences& entityReferences,
+             const trait::TraitsDatas& traitsHints,
+             const access::PublishingAccess publishingAccess, const ContextConstPtr& context) {
+            validateTraitsDatas(traitsHints);
+            return self.preflight(entityReferences, traitsHints, publishingAccess, context);
+          },
+          py::arg("entityReferences"), py::arg("traitsHints"), py::arg("publishAccess"),
+          py::arg("context").none(false), py::call_guard<py::gil_scoped_release>{})
+      .def(
+          "preflight",
+          [](Manager& self, const EntityReferences& entityReferences,
+             const trait::TraitsDatas& traitsHints,
+             const access::PublishingAccess publishingAccess, const ContextConstPtr& context,
+             const Manager::BatchElementErrorPolicyTag::Variant& tag) {
+            validateTraitsDatas(traitsHints);
+            return self.preflight(entityReferences, traitsHints, publishingAccess, context, tag);
+          },
+          py::arg("entityReferences"), py::arg("traitsHints"), py::arg("publishAccess"),
+          py::arg("context").none(false), py::arg("errorPolicyTag"),
+          py::call_guard<py::gil_scoped_release>{})
       .def(
           "preflight",
           [](Manager& self, const EntityReferences& entityReferences,
@@ -549,54 +557,15 @@ void registerManager(const py::module& mod) {
           [](Manager& self, const EntityReferences& entityReferences,
              const trait::TraitsDatas& traitsHints,
              const access::PublishingAccess publishingAccess, const ContextConstPtr& context,
-             const Manager::BatchElementErrorPolicyTag::Variant& tag) {
-            validateTraitsDatas(traitsHints);
-            return self.preflight(entityReferences, traitsHints, publishingAccess, context, tag);
-          },
-          py::arg("entityReferences"), py::arg("traitsHints"), py::arg("publishAccess"),
-          py::arg("context").none(false), py::arg("errorPolicyTag"),
-          py::call_guard<py::gil_scoped_release>{})
-      .def(
-          "preflight",
-          [](Manager& self, const EntityReferences& entityReferences,
-             const trait::TraitsDatas& traitsHints,
-             const access::PublishingAccess publishingAccess, const ContextConstPtr& context) {
-            validateTraitsDatas(traitsHints);
-            return self.preflight(entityReferences, traitsHints, publishingAccess, context);
-          },
-          py::arg("entityReferences"), py::arg("traitsHints"), py::arg("publishAccess"),
-          py::arg("context").none(false), py::call_guard<py::gil_scoped_release>{})
-      .def(
-          "register",
-          [](Manager& self, const EntityReferences& entityReferences,
-             const trait::TraitsDatas& entityTraitsDatas,
-             const access::PublishingAccess publishingAccess, const ContextConstPtr& context,
-             const Manager::RegisterSuccessCallback& successCallback,
+             const Manager::PreflightSuccessCallback& successCallback,
              const Manager::BatchElementErrorCallback& errorCallback) {
-            validateTraitsDatas(entityTraitsDatas);
-            self.register_(entityReferences, entityTraitsDatas, publishingAccess, context,
+            validateTraitsDatas(traitsHints);
+            self.preflight(entityReferences, traitsHints, publishingAccess, context,
                            successCallback, errorCallback);
           },
-          py::arg("entityReferences"), py::arg("entityTraitsDatas"), py::arg("publishAccess"),
+          py::arg("entityReferences"), py::arg("traitsHints"), py::arg("publishAccess"),
           py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"),
           py::call_guard<py::gil_scoped_release>{})
-
-      .def("register",
-           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&,
-                             access::PublishingAccess, const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Exception&>(
-               &Manager::register_),
-           py::arg("entityReference"), py::arg("entityTraitsData").none(false),
-           py::arg("publishAccess"), py::arg("context").none(false), py::arg("errorPolicyTag"),
-           py::call_guard<py::gil_scoped_release>{})
-      .def("register",
-           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&,
-                             access::PublishingAccess, const ContextConstPtr&,
-                             const Manager::BatchElementErrorPolicyTag::Variant&>(
-               &Manager::register_),
-           py::arg("entityReference"), py::arg("entityTraitsData").none(false),
-           py::arg("publishAccess"), py::arg("context").none(false), py::arg("errorPolicyTag"),
-           py::call_guard<py::gil_scoped_release>{})
       .def(
           "register",
           [](Manager& self, const EntityReference& entityReference,
@@ -606,6 +575,45 @@ void registerManager(const py::module& mod) {
           },
           py::arg("entityReference"), py::arg("entityTraitsData").none(false),
           py::arg("publishAccess"), py::arg("context").none(false),
+          py::call_guard<py::gil_scoped_release>{})
+      .def("register",
+           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&,
+                             access::PublishingAccess, const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::register_),
+           py::arg("entityReference"), py::arg("entityTraitsData").none(false),
+           py::arg("publishAccess"), py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def("register",
+           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&,
+                             access::PublishingAccess, const ContextConstPtr&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::register_),
+           py::arg("entityReference"), py::arg("entityTraitsData").none(false),
+           py::arg("publishAccess"), py::arg("context").none(false), py::arg("errorPolicyTag"),
+           py::call_guard<py::gil_scoped_release>{})
+      .def(
+          "register",
+          [](Manager& self, const EntityReferences& entityReferences,
+             const trait::TraitsDatas& entityTraitsDatas,
+             const access::PublishingAccess publishingAccess, const ContextConstPtr& context) {
+            validateTraitsDatas(entityTraitsDatas);
+            return self.register_(entityReferences, entityTraitsDatas, publishingAccess, context);
+          },
+          py::arg("entityReferences"), py::arg("entityTraitsDatas"), py::arg("publishAccess"),
+          py::arg("context").none(false), py::call_guard<py::gil_scoped_release>{})
+      .def(
+          "register",
+          [](Manager& self, const EntityReferences& entityReferences,
+             const trait::TraitsDatas& entityTraitsDatas,
+             const access::PublishingAccess publishingAccess, const ContextConstPtr& context,
+             const Manager::BatchElementErrorPolicyTag::Variant& errorPolicyTag) {
+            validateTraitsDatas(entityTraitsDatas);
+            return self.register_(entityReferences, entityTraitsDatas, publishingAccess, context,
+                                  errorPolicyTag);
+          },
+          py::arg("entityReferences"), py::arg("entityTraitsDatas"), py::arg("publishAccess"),
+          py::arg("context").none(false), py::arg("errorPolicyTag"),
           py::call_guard<py::gil_scoped_release>{})
       .def(
           "register",
@@ -625,23 +633,13 @@ void registerManager(const py::module& mod) {
           [](Manager& self, const EntityReferences& entityReferences,
              const trait::TraitsDatas& entityTraitsDatas,
              const access::PublishingAccess publishingAccess, const ContextConstPtr& context,
-             const Manager::BatchElementErrorPolicyTag::Variant& errorPolicyTag) {
+             const Manager::RegisterSuccessCallback& successCallback,
+             const Manager::BatchElementErrorCallback& errorCallback) {
             validateTraitsDatas(entityTraitsDatas);
-            return self.register_(entityReferences, entityTraitsDatas, publishingAccess, context,
-                                  errorPolicyTag);
+            self.register_(entityReferences, entityTraitsDatas, publishingAccess, context,
+                           successCallback, errorCallback);
           },
           py::arg("entityReferences"), py::arg("entityTraitsDatas"), py::arg("publishAccess"),
-          py::arg("context").none(false), py::arg("errorPolicyTag"),
-          py::call_guard<py::gil_scoped_release>{})
-      .def(
-          "register",
-          [](Manager& self, const EntityReferences& entityReferences,
-             const trait::TraitsDatas& entityTraitsDatas,
-             const access::PublishingAccess publishingAccess, const ContextConstPtr& context) {
-            validateTraitsDatas(entityTraitsDatas);
-            return self.register_(entityReferences, entityTraitsDatas, publishingAccess, context);
-          },
-          py::arg("entityReference"), py::arg("entityTraitsData").none(false),
-          py::arg("publishAccess"), py::arg("context").none(false),
+          py::arg("context").none(false), py::arg("successCallback"), py::arg("errorCallback"),
           py::call_guard<py::gil_scoped_release>{});
 }  // NOLINT(readability/fn_size)


### PR DESCRIPTION
## Description

Reorders the existing pybind11 overload registrations for `hostApi.Manager` in the below order:

  1. Singular default
  2. Singular explicit variant/result
  3. Singular explicit exception
  4. Batch default
  5. Batch explicit variant/result
  6. Batch explicit exception
  7. Callback

  No public API, behaviour are changed.


Closes #1406 

- [ ] I have updated the release notes.
- [ ] I have updated all relevant user documentation.

 Release notes and user documentation were not updated because this is an internal binding registration.

## Reviewer Notes

pybind11 resolves overloads linearly in registration order. This PR changes `Manager` overload bindings only; it should make without changing API behaviour.


## Test Instructions

 Verify the diff is limited to reordering overload registrations in `src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp with no extra addition or deletion.
