### PR TITLE
[Core]  Throw descriptive error if identifier not found in config file

### DIFF
--- a/src/openassetio-core/include/openassetio/hostApi/ManagerFactory.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/ManagerFactory.hpp
@@ -219,7 +219,8 @@ class OPENASSETIO_CORE_EXPORT ManagerFactory final {
    *
    * @throws errors.ConfigurationException if there are errors occur
    * whilst loading the TOML file referenced by the @ref
-   * default_config_var env var.
+   * default_config_var env var, or if it is missing the
+   * `manager.identifier` field.
    */
   [[nodiscard]] static ManagerPtr defaultManagerForInterface(
       const HostInterfacePtr& hostInterface,
@@ -271,7 +272,8 @@ class OPENASSETIO_CORE_EXPORT ManagerFactory final {
    * config file does not exist at the path provided in @p configPath.
    *
    * @throws errors.ConfigurationException if there are errors occur
-   * whilst loading the TOML file.
+   * whilst loading the TOML file, or if it is missing the
+   * `manager.identifier` field.
    */
   [[nodiscard]] static ManagerPtr defaultManagerForInterface(
       std::string_view configPath, const HostInterfacePtr& hostInterface,

--- a/src/openassetio-python/tests/cmodule/gil/test_uidelegatefactory_gil.py
+++ b/src/openassetio-python/tests/cmodule/gil/test_uidelegatefactory_gil.py
@@ -151,7 +151,7 @@ class Test_UIDelegateFactory_gil:
     ):
         mock_ui_delegate_impl_factory.mock.instantiate.return_value = mock_ui_delegate_interface
         config_path = tmp_path / "ui_delegate.toml"
-        config_path.write_text('[ui_delegate]\nidentifier = "something"')
+        config_path.write_text('[manager]\nidentifier = "something"')
 
         # First overload
 

--- a/src/openassetio-python/tests/package/hostApi/resources/missing_identifier.toml
+++ b/src/openassetio-python/tests/package/hostApi/resources/missing_identifier.toml
@@ -1,0 +1,4 @@
+[manager]
+# missing identifier here
+[manager.settings]
+a_string = "Hello"

--- a/src/openassetio-python/tests/package/hostApi/test_managerfactory.py
+++ b/src/openassetio-python/tests/package/hostApi/test_managerfactory.py
@@ -17,7 +17,7 @@
 Tests that cover the openassetio.hostApi.ManagerFactory class.
 """
 
-# pylint: disable=invalid-name,redefined-outer-name
+# pylint: disable=bad-option-value,invalid-name,redefined-outer-name,too-many-arguments,too-many-positional-arguments,duplicate-code
 # pylint: disable=missing-class-docstring,missing-function-docstring
 import os
 import pathlib
@@ -221,6 +221,32 @@ class Test_ManagerFactory_defaultManagerForInterface:
             else:
                 ManagerFactory.defaultManagerForInterface(
                     invalid_manager_config,
+                    mock_host_interface,
+                    mock_manager_implementation_factory,
+                    mock_logger,
+                )
+
+    @pytest.mark.parametrize("use_env_var_for_config_file", [True, False])
+    def test_when_missing_identifier_then_ConfigurationException_raised(
+        self,
+        use_env_var_for_config_file,
+        config_with_missing_identifier,
+        mock_manager_implementation_factory,
+        mock_host_interface,
+        mock_logger,
+    ):
+        with pytest.raises(
+            errors.ConfigurationException,
+            match=r"Configuration file is missing 'identifier' field in its \[manager\] "
+            r"section at '.*'",
+        ):
+            if use_env_var_for_config_file:
+                ManagerFactory.defaultManagerForInterface(
+                    mock_host_interface, mock_manager_implementation_factory, mock_logger
+                )
+            else:
+                ManagerFactory.defaultManagerForInterface(
+                    config_with_missing_identifier,
                     mock_host_interface,
                     mock_manager_implementation_factory,
                     mock_logger,
@@ -586,6 +612,14 @@ def invalid_manager_config(monkeypatch, use_env_var_for_config_file):
 @pytest.fixture
 def config_with_invalid_property(resources_dir, monkeypatch, use_env_var_for_config_file):
     toml_path = os.path.join(resources_dir, "unsupported_value_type.toml")
+    if use_env_var_for_config_file:
+        monkeypatch.setenv("OPENASSETIO_DEFAULT_CONFIG", toml_path)
+    return toml_path
+
+
+@pytest.fixture
+def config_with_missing_identifier(resources_dir, monkeypatch, use_env_var_for_config_file):
+    toml_path = os.path.join(resources_dir, "missing_identifier.toml")
     if use_env_var_for_config_file:
         monkeypatch.setenv("OPENASSETIO_DEFAULT_CONFIG", toml_path)
     return toml_path

--- a/src/openassetio-python/tests/package/ui/hostApi/resources/missing_identifier.toml
+++ b/src/openassetio-python/tests/package/ui/hostApi/resources/missing_identifier.toml
@@ -1,0 +1,4 @@
+[manager]
+# missing identifier here
+[ui.settings]
+a_string = "Hello"

--- a/src/openassetio-python/tests/package/ui/hostApi/test_uidelegatefactory.py
+++ b/src/openassetio-python/tests/package/ui/hostApi/test_uidelegatefactory.py
@@ -20,7 +20,7 @@ Note that these tests are almost identical to the
 openassetio.hostApi.ManagerFactory tests.
 """
 
-# pylint: disable=invalid-name,redefined-outer-name
+# pylint: disable=bad-option-value,invalid-name,redefined-outer-name,too-many-arguments,too-many-positional-arguments,duplicate-code
 # pylint: disable=missing-class-docstring,missing-function-docstring
 import os
 import pathlib
@@ -234,6 +234,32 @@ class Test_UIDelegateFactory_defaultUIDelegateForInterface:
             else:
                 UIDelegateFactory.defaultUIDelegateForInterface(
                     invalid_ui_delegate_config,
+                    mock_host_interface,
+                    mock_ui_delegate_implementation_factory,
+                    mock_logger,
+                )
+
+    @pytest.mark.parametrize("use_env_var_for_config_file", [True, False])
+    def test_when_missing_identifier_then_ConfigurationException_raised(
+        self,
+        use_env_var_for_config_file,
+        config_with_missing_identifier,
+        mock_ui_delegate_implementation_factory,
+        mock_host_interface,
+        mock_logger,
+    ):
+        with pytest.raises(
+            errors.ConfigurationException,
+            match=r"Configuration file is missing 'identifier' field in its \[manager\] "
+            r"section at '.*'",
+        ):
+            if use_env_var_for_config_file:
+                UIDelegateFactory.defaultUIDelegateForInterface(
+                    mock_host_interface, mock_ui_delegate_implementation_factory, mock_logger
+                )
+            else:
+                UIDelegateFactory.defaultUIDelegateForInterface(
+                    config_with_missing_identifier,
                     mock_host_interface,
                     mock_ui_delegate_implementation_factory,
                     mock_logger,
@@ -618,6 +644,14 @@ def invalid_ui_delegate_config(monkeypatch, use_env_var_for_config_file):
 @pytest.fixture
 def config_with_invalid_property(resources_dir, monkeypatch, use_env_var_for_config_file):
     toml_path = os.path.join(resources_dir, "unsupported_value_type.toml")
+    if use_env_var_for_config_file:
+        monkeypatch.setenv("OPENASSETIO_DEFAULT_CONFIG", toml_path)
+    return toml_path
+
+
+@pytest.fixture
+def config_with_missing_identifier(resources_dir, monkeypatch, use_env_var_for_config_file):
+    toml_path = os.path.join(resources_dir, "missing_identifier.toml")
     if use_env_var_for_config_file:
         monkeypatch.setenv("OPENASSETIO_DEFAULT_CONFIG", toml_path)
     return toml_path

--- a/src/openassetio-ui/include/openassetio/ui/hostApi/UIDelegateFactory.hpp
+++ b/src/openassetio-ui/include/openassetio/ui/hostApi/UIDelegateFactory.hpp
@@ -235,7 +235,8 @@ class OPENASSETIO_UI_EXPORT UIDelegateFactory final {
    *
    * @throws errors.ConfigurationException if there are errors occur
    * whilst loading the TOML file referenced by the @ref
-   * default_config_var env var.
+   * default_config_var env var, or if it is missing the
+   * `manager.identifier` field.
    */
   [[nodiscard]] static UIDelegatePtr defaultUIDelegateForInterface(
       const HostInterfacePtr& hostInterface,
@@ -286,7 +287,8 @@ class OPENASSETIO_UI_EXPORT UIDelegateFactory final {
    * config file does not exist at the path provided in @p configPath.
    *
    * @throws errors.ConfigurationException if there are errors occur
-   * whilst loading the TOML file.
+   * whilst loading the TOML file, or if it is missing the
+   * `manager.identifier` field.
    */
   [[nodiscard]] static UIDelegatePtr defaultUIDelegateForInterface(
       std::string_view configPath, const HostInterfacePtr& hostInterface,

--- a/src/private/include/openassetio/private/hostApi/factory.hpp
+++ b/src/private/include/openassetio/private/hostApi/factory.hpp
@@ -115,7 +115,14 @@ inline std::pair<Identifier, InfoDictionary> identifierAndSettingsFromConfigFile
   } catch (const std::exception& exc) {
     throw errors::ConfigurationException{fmt::format("Error parsing config file. {}", exc.what())};
   }
-  const std::string_view identifier = config["manager"]["identifier"].value_or("");
+  const auto identifierNode = config["manager"]["identifier"];
+  if (!identifierNode) {
+    throw errors::ConfigurationException{
+        fmt::format("Configuration file is missing 'identifier' field in its "
+                    "[manager] section at '{}'",
+                    configPath.u8string())};
+  }
+  const std::string_view identifier = identifierNode.value_or(std::string_view{""});
 
   // Function to substitute ${config_dir} with the absolute,
   // canonicalised directory of the TOML config file.


### PR DESCRIPTION
Closes #1508
Description

Update `factory::identifierAndSettingsFromConfigFile` to explicitly check for the presence of the `manager.identifier` field in the TOML configuration file. If the field is missing, it now raises a `ConfigurationException` with a descriptive error message indicating the file path and the missing field. This avoids a confusing downstream exception where a missing identifier was silently parsed as an empty string.

- [ ] I have updated the release notes.
- [ ] I have updated all relevant user documentation.

Test Instructions

Python tests verify the new `ConfigurationException` is raised with the correct descriptive message when a config file lacking the `manager.identifier` field is loaded via `ManagerFactory` and `UIDelegateFactory`.