### PR TITLE
[CI] Suppress cppreference in markdown-link-check

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -11,6 +11,9 @@
     },
     {
       "pattern": "^https://www.blender.org"
+    },
+    {
+      "pattern": "^https://en.cppreference.com"
     }
   ]
 }


### PR DESCRIPTION
## Description

`en.cppreference.com` is consistently failing markdown-link-check. The links work locally, so it is likely that github runners are being blocked.

Closes # (issue)

- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have updated all relevant user documentation.~~
